### PR TITLE
ogre: Do not assume that ogre plugins have lib prefix on macOS

### DIFF
--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -421,20 +421,17 @@ void OgreRenderEngine::LoadPlugins()
     std::vector<std::string>::iterator piter;
 
 #ifdef __APPLE__
-    std::string prefix = "lib";
     std::string extension = ".dylib";
 #elif _WIN32
-    std::string prefix = "";
     std::string extension = ".dll";
 #else
-    std::string prefix = "";
     std::string extension = ".so";
 #endif
 
-    plugins.push_back(path+"/"+prefix+"RenderSystem_GL");
-    plugins.push_back(path+"/"+prefix+"Plugin_ParticleFX");
-    plugins.push_back(path+"/"+prefix+"Plugin_BSPSceneManager");
-    plugins.push_back(path+"/"+prefix+"Plugin_OctreeSceneManager");
+    plugins.push_back(path+"/RenderSystem_GL");
+    plugins.push_back(path+"/Plugin_ParticleFX");
+    plugins.push_back(path+"/Plugin_BSPSceneManager");
+    plugins.push_back(path+"/Plugin_OctreeSceneManager");
 
 #ifdef HAVE_OCULUS
     plugins.push_back(path+"/Plugin_CgProgramManager");


### PR DESCRIPTION
# 🦟 Bug fix

Fix most of the test suite when running against ogre with conda-forge-provided dependencies on macOS. 

## Summary

By default, ogre plugins (the one that are installed under `lib\OGRE\<..>` and that are loaded at runtime) are not built with the `lib` prefix on any platform. However, for legacy reasons (see comment in https://github.com/osrf/homebrew-simulation/blame/f27e070d08600f77933f5608df8d413bc99b2206/Formula/ogre1.9.rb#L105) the `ogre1.9` contained both the deprecated `lib\OGRE\libRenderSystem_GL.dylib` and the recommended to use `lib\OGRE\RenderSystem_GL.dylib`. Furthermore, the ignition-rendering ogre plugin only looked for the library starting with `lib` on macOS, creating runtime problems on macOS distributions  in which ogre did not had the plugin that started with `lib`, such as conda-forge, but I imagine that on vcpkg on macOS you could get a similar problem. 

This PR switches also igniton-rendering to only look for ogre plugins without the `lib` prefix. It is basically the backport of the gazebo commit https://github.com/osrf/gazebo/commit/2dd748d36599d5b709cb3f995f96c1f2f58d3520#diff-ed2a31885765b0b34495723b06e6ce939e978bb42f5c082a9b93b9fec20257a2 from gazebo8/2017 that was never forward ported to ignition-rendering. 

As the homebrew bottles provide ogre plugins without the `lib` prefix since at least 5 years (see comment https://github.com/osrf/homebrew-simulation/blame/f27e070d08600f77933f5608df8d413bc99b2206/Formula/ogre1.9.rb#L105) I think there is a low risk of creating problems (even because if anyone has a system in which gazebo classic works fine, then also ignition-rendering will work fine  after this PR).

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
