### PR TITLE
Fix selection buffer material script

### DIFF
--- a/ogre2/src/media/materials/scripts/selection_buffer.material
+++ b/ogre2/src/media/materials/scripts/selection_buffer.material
@@ -44,7 +44,7 @@ material SelectionBuffer
     pass
     {
       // Make this pass use the vertex shader defined above
-      vertex_program_ref selection_buffer_fs { }
+      vertex_program_ref selection_buffer_vs { }
 
       // Make this pass use the pixel shader defined above
       fragment_program_ref selection_buffer_fs { }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

on some machines, ogre would not find the definition of the vertex shader program referred to by the selection_buffer.material script. The vertex program definition was actually specified in a different file. This causes a compiler error to be printed in the ogre2.log:

```
18:54:23: Compiler error: reference to a non existing object in selection_buffer.material(37)
```

The fix is to just define a new one in the same file. 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

