### PR TITLE
[macOS] modify definition of bufferFetch1 to work when GL_ARB_texture_buffer_range is not available

### DIFF
--- a/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -113,7 +113,7 @@
 
 #define OGRE_Load3D( tex, iuv, lod ) texelFetch( tex, ivec3( iuv ), lod )
 
-#define bufferFetch1( buffer, idx ) texelFetch( buffer, idx ).x
+#define bufferFetch1( buffer, idx ) bufferFetch( buffer, idx ).x
 
 #define OGRE_SAMPLER_ARG_DECL( samplerName )
 #define OGRE_SAMPLER_ARG( samplerName )


### PR DESCRIPTION
This PR modifies the shader piece `CrossPlatformSettings_piece_all.glsl` to work when the OpenGL extension  `GL_ARB_texture_buffer_range` is not available.

The definition of `bufferFetch1` was failing for OpenGL < 4.2 resulting in compile errors for lighting shaders

# 🦟 Bug fix

Partial fix of #422

## Summary

This is a single line change to the cross platform settings shader piece. It changes the definition of `bufferFetch1` to use the `bufferFetch` definition which has compatibility settings rather than use `texelFetch` directly.

Before this change the shaders would fail to compile using the ogre2 render engine on macOS. After this change the shaders will compile.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

Not all tests pass on macOS. The failures are listed below, but are not connected to the changes in this PR.

```bash
The following tests FAILED:
	  7 - UNIT_COMVisual_TEST (Subprocess aborted)
	 19 - UNIT_Heightmap_TEST (SEGFAULT)
	 59 - UNIT_RenderingIface_TEST (SEGFAULT)
	 83 - INTEGRATION_depth_camera (Failed)
```

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
