### PR TITLE
[Ogre2] Fix invalid anti-aliasing level warning

### DIFF
--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -560,10 +560,20 @@ uint8_t Ogre2RenderTarget::TargetFSAA() const
   {
     // output warning but only do it once
     static bool ogre2FSAAWarn = false;
-    if (ogre2FSAAWarn)
+    if (!ogre2FSAAWarn)
     {
+      std::ostringstream os;
+      os << "[ ";
+      for (auto &&level : fsaaLevels)
+      {
+        os << level << " ";
+      }
+      os << "]";
+
       ignwarn << "Anti-aliasing level of '" << this->antiAliasing << "' "
-              << "is not supported. Setting to 0" << std::endl;
+              << "is not supported; valid FSAA levels are: " << os.str()
+              << ". Setting to 0" << std::endl;
+      targetFSAA = 0u;
       ogre2FSAAWarn = true;
     }
   }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes issue discussed in https://github.com/ignitionrobotics/ign-rendering/pull/463#issuecomment-942641429

## Summary

This PR fixes a bug where the invalid anti-aliasing level warning in `Ogre2RenderTarget::TargetFSAA()` was not being output and the FSAA level was not being set to a default value of 0. This can cause the scene to fail to render. 

The code will now output a warning, provide a list of valid options and set the anti-aliasing level to 0. 

The code can be tested by changing the camera anti-aliasing level in the `simple_demo` example:

Modify:

https://github.com/ignitionrobotics/ign-rendering/blob/1c77a8ac05cce3ed5a5b99e56030db833ad67b0a/examples/simple_demo/Main.cc#L179

to

```
// create camera
camera->SetAntiAliasing(3);
```

The console output is:

```bash
[Wrn] [Ogre2RenderTarget.cc:573] Anti-aliasing level of '3' is not supported; valid FSAA levels are: [ 1 2 4 8 ]. Setting to 0
``` 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**