### PR TITLE
Add 64 bit signed and unsigned integer type support to UserData

### DIFF
--- a/include/ignition/rendering/Node.hh
+++ b/include/ignition/rendering/Node.hh
@@ -44,7 +44,7 @@ namespace ignition
     /// "empty variant" should be returned for keys that don't exist)
     using Variant =
       std::variant<std::monostate, int, float, double, std::string, bool,
-        unsigned int>;
+        unsigned int, int64_t, uint64_t>;
 
     /// \class Node Node.hh ignition/rendering/Node.hh
     /// \brief Represents a single posable node in the scene graph

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -379,6 +379,24 @@ void VisualTest::UserData(const std::string &_renderEngine)
   value = visual->UserData(unsignedIntKey);
   EXPECT_EQ(unsignedIntValue, std::get<unsigned int>(value));
 
+  // int64_t
+  std::string int64Key = "int64_t";
+  int64_t int64Value = -math::MAX_I64;
+  EXPECT_FALSE(visual->HasUserData(int64Key));
+  visual->SetUserData(int64Key, int64Value);
+  EXPECT_TRUE(visual->HasUserData(int64Key));
+  value = visual->UserData(int64Key);
+  EXPECT_EQ(int64Value, std::get<int64_t>(value));
+
+  // uint64_t
+  std::string uint64Key = "uint64_t";
+  uint64_t uint64Value = math::MAX_UI64;
+  EXPECT_FALSE(visual->HasUserData(uint64Key));
+  visual->SetUserData(uint64Key, uint64Value);
+  EXPECT_TRUE(visual->HasUserData(uint64Key));
+  value = visual->UserData(uint64Key);
+  EXPECT_EQ(uint64Value, std::get<uint64_t>(value));
+
   // test a key that does not exist (should return no data)
   value = visual->UserData("invalidKey");
   EXPECT_FALSE(std::holds_alternative<int>(value));


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

adds support for `uint64_t` and `int64_t` types.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

