### PR TITLE
Fix Windows warnings

### DIFF
--- a/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
@@ -22,6 +22,8 @@
   #pragma GCC system_header
 #else
   #pragma warning(push, 0)
+  #pragma warning(disable:4275)
+  #pragma warning(disable:4005)
 #endif
 
 // This prevents some deprecation #warning messages on OSX 10.9

--- a/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
@@ -44,7 +44,6 @@ namespace ignition
 #ifdef _MSC_VER
   #pragma warning(push)
   #pragma warning(disable:4275)
-  asdf
 #endif
       public Ogre::MaterialManager::Listener,
 #ifdef _MSC_VER

--- a/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreMaterialSwitcher.hh
@@ -44,6 +44,7 @@ namespace ignition
 #ifdef _MSC_VER
   #pragma warning(push)
   #pragma warning(disable:4275)
+  asdf
 #endif
       public Ogre::MaterialManager::Listener,
 #ifdef _MSC_VER

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -21,6 +21,7 @@
 #else
 # pragma warning(push, 0)
 # pragma warning(disable: 4005)
+# pragma warning(disable: 4275)
 #endif
 // leave this out of OgreIncludes as it conflicts with other files requiring
 // gl.h

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -20,6 +20,7 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 #else
 # pragma warning(push, 0)
+# pragma warning(disable: 4005)
 #endif
 // leave this out of OgreIncludes as it conflicts with other files requiring
 // gl.h

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -282,7 +282,7 @@ void Ogre2LaserRetroMaterialSwitcher::cameraPreRenderScene(
           {
             try
             {
-              retroValue = std::get<int>(tempLaserRetro);
+              retroValue = static_cast<float>(std::get<int>(tempLaserRetro));
             }
             catch(std::bad_variant_access &e)
             {
@@ -621,19 +621,19 @@ math::Vector2d Ogre2GpuRays::SampleCubemap(const math::Vector3d &_v,
   math::Vector2d uv;
   if (vAbs.Z() >= vAbs.X() && vAbs.Z() >= vAbs.Y())
   {
-    _faceIndex = _v.Z() < 0.0 ? 5.0 : 4.0;
+    _faceIndex = _v.Z() < 0 ? 5 : 4;
     ma = 0.5 / vAbs.Z();
     uv = math::Vector2d(_v.Z() < 0.0 ? -_v.X() : _v.X(), -_v.Y());
   }
   else if (vAbs.Y() >= vAbs.X())
   {
-    _faceIndex = _v.Y() < 0.0 ? 3.0 : 2.0;
+    _faceIndex = _v.Y() < 0 ? 3 : 2;
     ma = 0.5 / vAbs.Y();
     uv = math::Vector2d(_v.X(), _v.Y() < 0.0 ? -_v.Z() : _v.Z());
   }
   else
   {
-    _faceIndex = _v.X() < 0.0 ? 1.0 : 0.0;
+    _faceIndex = _v.X() < 0 ? 1 : 0;
     ma = 0.5 / vAbs.X();
     uv = math::Vector2d(_v.X() < 0.0 ? _v.Z() : -_v.Z(), -_v.Y());
   }
@@ -723,7 +723,7 @@ void Ogre2GpuRays::CreateSampleTexture()
       // v
       pDest[index++] = uv.Y();
       // face
-      pDest[index++] = faceIdx;
+      pDest[index++] = static_cast<float>(faceIdx);
       // unused
       pDest[index++] = 1.0;
       h += hStep;

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -159,7 +159,7 @@ void Ogre2RenderEngine::Destroy()
   delete this->ogreLogManager;
   this->ogreLogManager = nullptr;
 
-#if not (__APPLE__ || _WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   if (this->dummyDisplay)
   {
     Display *x11Display = static_cast<Display*>(this->dummyDisplay);
@@ -382,7 +382,7 @@ void Ogre2RenderEngine::CreateLogger()
 //////////////////////////////////////////////////
 void Ogre2RenderEngine::CreateContext()
 {
-#if not (__APPLE__ || _WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   if (this->Headless())
   {
     // Nothing to do

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -852,12 +852,16 @@ void Ogre2RenderTarget::RebuildMaterial()
 //////////////////////////////////////////////////
 // Ogre2RenderTexture
 //////////////////////////////////////////////////
+#ifndef _WIN32
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 Ogre2RenderTexture::Ogre2RenderTexture()
 {
 }
+#ifndef _WIN32
 #pragma GCC diagnostic pop
+#endif
 
 //////////////////////////////////////////////////
 Ogre2RenderTexture::~Ogre2RenderTexture()

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -651,7 +651,7 @@ void Ogre2Scene::UpdateShadowNode()
   // directional lights
   unsigned int atlasId = 0u;
   unsigned int texSize = 2048u;
-  unsigned int halfTexSize = texSize * 0.5;
+  unsigned int halfTexSize = static_cast<unsigned int>(texSize * 0.5);
   for (unsigned int i = 0; i < dirLightCount; ++i)
   {
     shadowParam.technique = Ogre::SHADOWMAP_PSSM;
@@ -866,12 +866,16 @@ void Ogre2Scene::CreateShadowNodeWithSettings(
     for (size_t j = 0; j < numSplits; ++j)
     {
       Ogre::Vector2 uvOffset(
-          shadowParam.atlasStart[j].x, shadowParam.atlasStart[j].y);
+          static_cast<Ogre::Real>(shadowParam.atlasStart[j].x),
+          static_cast<Ogre::Real>(shadowParam.atlasStart[j].y));
       Ogre::Vector2 uvLength(
-          shadowParam.resolution[j].x, shadowParam.resolution[j].y);
+          static_cast<Ogre::Real>(shadowParam.resolution[j].x),
+          static_cast<Ogre::Real>(shadowParam.resolution[j].y));
 
-      uvOffset /= Ogre::Vector2(texResolution.x, texResolution.y);
-      uvLength /= Ogre::Vector2(texResolution.x, texResolution.y);
+      uvOffset /= Ogre::Vector2(static_cast<Ogre::Real>(texResolution.x),
+          static_cast<Ogre::Real>(texResolution.y));
+      uvLength /= Ogre::Vector2(static_cast<Ogre::Real>(texResolution.x),
+          static_cast<Ogre::Real>(texResolution.y));
 
       const Ogre::String texName =
           "atlas" + Ogre::StringConverter::toString(shadowParam.atlasId);

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -87,8 +87,8 @@ bool Ogre2SegmentationMaterialSwitcher::IsTakenColor(const math::Color &_color)
 {
   // Get the int value of the 24 bit color
   // Multiply by 255 as color values are normalized
-  int64_t colorId = (_color.R() * 255) * 256 * 256 +
-    (_color.G() * 255) * 256 + (_color.B() * 255);
+  int64_t colorId = static_cast<int64_t>((_color.R() * 255) * 256 * 256 +
+    (_color.G() * 255) * 256 + (_color.B() * 255));
 
   if (this->takenColors.count(colorId))
   {
@@ -117,7 +117,10 @@ math::Color Ogre2SegmentationMaterialSwitcher::LabelToColor(int64_t _label,
   int g = distribution(this->generator);
   int b = distribution(this->generator);
 
-  math::Color color(r, g, b);
+  math::Color color(
+    static_cast<float>(r),
+    static_cast<float>(g),
+    static_cast<float>(b));
 
   // if the label is colored before return the color
   // don't check for taken colors in that case, all items

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -288,7 +288,7 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
           {
             try
             {
-              temp = std::get<int>(tempAny);
+              temp = static_cast<float>(std::get<int>(tempAny));
             }
             catch(std::bad_variant_access &e)
             {


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Fixes windows build warnings, #621

For the ogre1.x windows warnings, the pragma: `#pragma warning(push, 0)`  does not seem to suppress the warnings any more so I added more pragmas that explicitly disables the specific warnings

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
