### PR TITLE
Cleanup depth camera resources on destroy

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -327,6 +327,13 @@ void Ogre2DepthCamera::Destroy()
   {
     Ogre::MaterialManager::getSingleton().remove(
         this->dataPtr->depthMaterial->getName());
+    this->dataPtr->depthMaterial.setNull();
+  }
+  if (this->dataPtr->depthFinalMaterial)
+  {
+    Ogre::MaterialManager::getSingleton().remove(
+        this->dataPtr->depthFinalMaterial->getName());
+    this->dataPtr->depthFinalMaterial.setNull();
   }
 
   if (!this->dataPtr->ogreCompositorWorkspaceDef.empty())
@@ -337,6 +344,12 @@ void Ogre2DepthCamera::Destroy()
         this->dataPtr->ogreCompositorBaseNodeDef);
     ogreCompMgr->removeNodeDefinition(
         this->dataPtr->ogreCompositorFinalNodeDef);
+  }
+
+  if (this->dataPtr->particleNoiseListener)
+  {
+    this->ogreCamera->removeListener(this->dataPtr->particleNoiseListener.get());
+    this->dataPtr->particleNoiseListener.reset();
   }
 
   Ogre::SceneManager *ogreSceneManager;

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -348,7 +348,8 @@ void Ogre2DepthCamera::Destroy()
 
   if (this->dataPtr->particleNoiseListener)
   {
-    this->ogreCamera->removeListener(this->dataPtr->particleNoiseListener.get());
+    this->ogreCamera->removeListener(
+        this->dataPtr->particleNoiseListener.get());
     this->dataPtr->particleNoiseListener.reset();
   }
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

A follow up to https://github.com/gazebosim/gz-rendering/pull/617 - now that we are actually destroying sensors properly, I noticed a crash when running the  depth camera integration test in ign-sensors. This should fix the crash (fix is similar to the changes done in #617)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

