### PR TITLE
Use gz-utils test macros

### DIFF
--- a/src/Heightmap_TEST.cc
+++ b/src/Heightmap_TEST.cc
@@ -19,7 +19,7 @@
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/ImageHeightmap.hh>
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
 #include "ignition/rendering/RenderEngine.hh"


### PR DESCRIPTION
* Part of https://github.com/gazebosim/gz-cmake/issues/171

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The utilities from `gz-cmake` are deprecated.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] ~~Updated documentation (as needed)~~
- [x] ~~Updated migration guide (as needed)~~
- [x] ~~Consider updating Python bindings (if the library has them)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
