### PR TITLE
Change aspect to AspectRatio()

### DIFF
--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -217,6 +217,7 @@ namespace ignition
       protected: double farClip = 1000.0;
 
       /// \brief Aspect ratio
+      /// Do not use this variable. Use ApsectRatio() instead.
       protected: double aspect = 1.3333333;
 
       /// \brief Horizontal camera field of view

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -286,7 +286,8 @@ namespace ignition
     void BaseCamera<T>::SetImageWidth(const unsigned int _width)
     {
       this->RenderTarget()->SetWidth(_width);
-      this->SetAspectRatio(1.0 * _width / this->ImageHeight());
+      this->SetAspectRatio(
+        static_cast<double>(_width) / static_cast<double>(this->ImageHeight()));
     }
 
     //////////////////////////////////////////////////
@@ -301,7 +302,8 @@ namespace ignition
     void BaseCamera<T>::SetImageHeight(const unsigned int _height)
     {
       this->RenderTarget()->SetHeight(_height);
-      this->SetAspectRatio(1.0 * this->ImageWidth() / _height);
+      this->SetAspectRatio(
+        static_cast<double>(this->ImageWidth()) / static_cast<double>(_height));
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -286,7 +286,7 @@ namespace ignition
     void BaseCamera<T>::SetImageWidth(const unsigned int _width)
     {
       this->RenderTarget()->SetWidth(_width);
-      this->aspect = this->AspectRatio();
+      this->SetAspectRatio(1.0 * _width / this->ImageHeight());
     }
 
     //////////////////////////////////////////////////
@@ -301,7 +301,7 @@ namespace ignition
     void BaseCamera<T>::SetImageHeight(const unsigned int _height)
     {
       this->RenderTarget()->SetHeight(_height);
-      this->aspect = this->AspectRatio();
+      this->SetAspectRatio(1.0 * this->ImageWidth() / _height);
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -217,7 +217,6 @@ namespace ignition
       protected: double farClip = 1000.0;
 
       /// \brief Aspect ratio
-      /// Do not use this variable. Use ApsectRatio() instead.
       protected: double aspect = 1.3333333;
 
       /// \brief Horizontal camera field of view

--- a/include/ignition/rendering/base/BaseCamera.hh
+++ b/include/ignition/rendering/base/BaseCamera.hh
@@ -286,6 +286,7 @@ namespace ignition
     void BaseCamera<T>::SetImageWidth(const unsigned int _width)
     {
       this->RenderTarget()->SetWidth(_width);
+      this->aspect = this->AspectRatio();
     }
 
     //////////////////////////////////////////////////
@@ -300,6 +301,7 @@ namespace ignition
     void BaseCamera<T>::SetImageHeight(const unsigned int _height)
     {
       this->RenderTarget()->SetHeight(_height);
+      this->aspect = this->AspectRatio();
     }
 
     //////////////////////////////////////////////////

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -73,8 +73,6 @@ void OgreCamera::SetHFOV(const math::Angle &_angle)
   double angle = _angle.Radian();
   double vfov = 2.0 * atan(tan(angle / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(vfov));
-  // keep aspect in BaseCamera the same as aspect in Ogre lib
-  this->aspect = this->AspectRatio();
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -73,6 +73,8 @@ void OgreCamera::SetHFOV(const math::Angle &_angle)
   double angle = _angle.Radian();
   double vfov = 2.0 * atan(tan(angle / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  // keep aspect in BaseCamera the same as aspect in Ogre lib
+  this->aspect = this->AspectRatio();
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -71,7 +71,7 @@ void OgreCamera::SetHFOV(const math::Angle &_angle)
 {
   BaseCamera::SetHFOV(_angle);
   double angle = _angle.Radian();
-  double vfov = 2.0 * atan(tan(angle / 2.0) / this->aspect);
+  double vfov = 2.0 * atan(tan(angle / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(vfov));
 }
 

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -76,7 +76,7 @@ void Ogre2Camera::SetHFOV(const math::Angle &_angle)
 {
   BaseCamera::SetHFOV(_angle);
   double angle = _angle.Radian();
-  double vfov = 2.0 * atan(tan(angle / 2.0) / this->aspect);
+  double vfov = 2.0 * atan(tan(angle / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(vfov));
 }
 

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -418,8 +418,7 @@ void Ogre2DepthCamera::CreateRenderTexture()
 void Ogre2DepthCamera::CreateDepthTexture()
 {
   // set aspect ratio and fov
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->aspect);
-  this->ogreCamera->setAspectRatio(this->aspect);
+  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(this->LimitFOV(vfov)));
 
   // Load depth material

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -418,7 +418,8 @@ void Ogre2DepthCamera::CreateRenderTexture()
 void Ogre2DepthCamera::CreateDepthTexture()
 {
   // set aspect ratio and fov
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
+  double vfov;
+  vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(this->LimitFOV(vfov)));
 
   // Load depth material

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -613,8 +613,7 @@ void Ogre2ThermalCamera::CreateRenderTexture()
 void Ogre2ThermalCamera::CreateThermalTexture()
 {
   // set aspect ratio and fov
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->aspect);
-  this->ogreCamera->setAspectRatio(this->aspect);
+  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(vfov));
 
   // Load thermal material

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -613,7 +613,8 @@ void Ogre2ThermalCamera::CreateRenderTexture()
 void Ogre2ThermalCamera::CreateThermalTexture()
 {
   // set aspect ratio and fov
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
+  double vfov;
+  vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
   this->ogreCamera->setFOVy(Ogre::Radian(vfov));
 
   // Load thermal material

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -171,28 +171,26 @@ void CameraTest::RenderTexture(const std::string &_renderEngine)
 
   // render texture parameters
   EXPECT_GT(camera->ImageWidth(), 0u);
-  camera->SetImageWidth(100u);
-  EXPECT_EQ(100u, camera->ImageWidth());
-
   EXPECT_GT(camera->ImageHeight(), 0u);
-  camera->SetImageHeight(80u);
-  EXPECT_EQ(80u, camera->ImageHeight());
 
-  double height = 80;
+  unsigned int height = 80;
   camera->SetImageHeight(height);
-  double aspectRatio = camera->ImageWidth() / height;
+  EXPECT_EQ(height, camera->ImageHeight());
+  double aspectRatio =
+    static_cast<double>(camera->ImageWidth()) / static_cast<double>(height);
   EXPECT_NEAR(aspectRatio, camera->AspectRatio(), 1e-6);
 
-  double width = 100;
+  unsigned int width = 100;
   camera->SetImageWidth(width);
-  aspectRatio = width / camera->ImageHeight();
+  EXPECT_EQ(width, camera->ImageWidth());
+  aspectRatio =
+    static_cast<double>(width) / static_cast<double>(camera->ImageHeight());
   EXPECT_NEAR(aspectRatio, camera->AspectRatio(), 1e-6);
-
 
   EXPECT_NE(PixelFormat::PF_UNKNOWN, camera->ImageFormat());
   camera->SetImageFormat(PixelFormat::PF_B8G8R8);
   EXPECT_EQ(PixelFormat::PF_B8G8R8, camera->ImageFormat());
-  EXPECT_EQ(100u*80u*3u, camera->ImageMemorySize());
+  EXPECT_EQ(width*height*3u, camera->ImageMemorySize());
 
 
   // verify render texture GL Id

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -178,6 +178,11 @@ void CameraTest::RenderTexture(const std::string &_renderEngine)
   camera->SetImageHeight(80u);
   EXPECT_EQ(80u, camera->ImageHeight());
 
+  double width = 100
+  camera.SetImageWidth(width)
+  double aspectRatio = width / camera.ImageHeight()
+  EXPECT_NEAR(aspectRatio, camera.AspectRatio(), 1e-6)
+
   EXPECT_NE(PixelFormat::PF_UNKNOWN, camera->ImageFormat());
   camera->SetImageFormat(PixelFormat::PF_B8G8R8);
   EXPECT_EQ(PixelFormat::PF_B8G8R8, camera->ImageFormat());

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -178,15 +178,16 @@ void CameraTest::RenderTexture(const std::string &_renderEngine)
   camera->SetImageHeight(80u);
   EXPECT_EQ(80u, camera->ImageHeight());
 
-  double width = 100;
-  camera->SetImageWidth(width);
-  double aspectRatio = width / camera->ImageHeight();
-  EXPECT_NEAR(aspectRatio, camera->AspectRatio(), 1e-6);
-
   double height = 80;
   camera->SetImageHeight(height);
-  aspectRatio = camera->ImageWidth() / height;
+  double aspectRatio = camera->ImageWidth() / height;
   EXPECT_NEAR(aspectRatio, camera->AspectRatio(), 1e-6);
+
+  double width = 100;
+  camera->SetImageWidth(width);
+  aspectRatio = width / camera->ImageHeight();
+  EXPECT_NEAR(aspectRatio, camera->AspectRatio(), 1e-6);
+
 
   EXPECT_NE(PixelFormat::PF_UNKNOWN, camera->ImageFormat());
   camera->SetImageFormat(PixelFormat::PF_B8G8R8);

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -178,10 +178,15 @@ void CameraTest::RenderTexture(const std::string &_renderEngine)
   camera->SetImageHeight(80u);
   EXPECT_EQ(80u, camera->ImageHeight());
 
-  double width = 100
-  camera.SetImageWidth(width)
-  double aspectRatio = width / camera.ImageHeight()
-  EXPECT_NEAR(aspectRatio, camera.AspectRatio(), 1e-6)
+  double width = 100;
+  camera->SetImageWidth(width);
+  double aspectRatio = width / camera->ImageHeight();
+  EXPECT_NEAR(aspectRatio, camera->AspectRatio(), 1e-6);
+
+  double height = 80;
+  camera->SetImageHeight(height);
+  aspectRatio = camera->ImageWidth() / height;
+  EXPECT_NEAR(aspectRatio, camera->AspectRatio(), 1e-6);
 
   EXPECT_NE(PixelFormat::PF_UNKNOWN, camera->ImageFormat());
   camera->SetImageFormat(PixelFormat::PF_B8G8R8);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes ignition crash bug introduced in [gz-sim#1499](https://github.com/gazebosim/gz-sim/pull/1499)

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
gz-sim#1499 adds a feature to change the FOV of the user camera at runtime. But if we scale the window after changing the FOV, Gazebo has a chance to crash. (Always crash on Ogre, sometimes crash on Ogre2)

Changing `aspect` to `AspectRatio()` in `OgreCamera::SetHFOV()` solves the bug. 

Also add comment to warn users not to use `aspect` in `BaseCamera` but to use `OrgeCamera::AspectRatio()` instead.

#### Why this bug happened: 
[Resizing the window](https://github.com/gazebosim/gz-gui/blob/5c096882eb2e7a3bd120983a627cf80da66064b6/src/plugins/minimal_scene/MinimalScene.cc#L292) needs the correct aspect ratio value. There are 2 aspect ratio values available: one in Ogre library (`AspectRatio()`), and the other is in `BaseCamera` (`this->aspect`). 

When we change the FOV and resize the window, the aspect ratio and fov value in the Ogre library will both change but `aspect` in the `BaseCamera` only update its fov value but not aspect ratio. However, in `Ogre2Camera::SetHFOV()`, it is still using the deprecated aspect ratio value from the `BaseCamera`. 

If you check with gdb, the value read by `AspectRatio()` (directly from Ogre) and `aspect` from `BaseCamera` no longer agree with each other after changing FOV and resizing the window. That is why there is a crash.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

