### PR TITLE
Camera::HFOV override for Ogre and Ogre2

### DIFF
--- a/ogre/include/ignition/rendering/ogre/OgreCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreCamera.hh
@@ -46,6 +46,9 @@ namespace ignition
       public: virtual ~OgreCamera();
 
       // Documentation inherited.
+      public: virtual math::Angle HFOV() const override;
+
+      // Documentation inherited.
       public: virtual void SetHFOV(const math::Angle &_hfov) override;
 
       // Documentation inherited.

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -70,8 +70,7 @@ void OgreCamera::Destroy()
 math::Angle OgreCamera::HFOV() const
 {
   double vfov = this->ogreCamera->getFOVy().valueRadians();
-  double hFOV;
-  hFOV = 2.0 * atan(tan(vfov / 2.0) * this->ImageWidth() / this->ImageHeight());
+  double hFOV = 2.0 * atan(tan(vfov / 2.0) * this->AspectRatio());
   return math::Angle(hFOV);
 }
 

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -67,6 +67,15 @@ void OgreCamera::Destroy()
 }
 
 //////////////////////////////////////////////////
+math::Angle OgreCamera::HFOV() const
+{
+  double vfov = this->ogreCamera->getFOVy().valueRadians();
+  double hFOV;
+  hFOV = 2.0 * atan(tan(vfov / 2.0) * this->ImageWidth() / this->ImageHeight());
+  return math::Angle(hFOV);
+}
+
+//////////////////////////////////////////////////
 void OgreCamera::SetHFOV(const math::Angle &_angle)
 {
   BaseCamera::SetHFOV(_angle);

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
@@ -50,6 +50,9 @@ namespace ignition
       public: virtual ~Ogre2Camera();
 
       // Documentation inherited.
+      public: virtual math::Angle HFOV() const override;
+
+      // Documentation inherited.
       public: virtual void SetHFOV(const math::Angle &_hfov) override;
 
       // Documentation inherited.

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -72,6 +72,15 @@ void Ogre2Camera::Destroy()
 }
 
 //////////////////////////////////////////////////
+math::Angle Ogre2Camera::HFOV() const
+{
+  double vfov = this->ogreCamera->getFOVy().valueRadians();
+  double hFOV;
+  hFOV = 2.0 * atan(tan(vfov / 2.0) * this->ImageWidth() / this->ImageHeight());
+  return math::Angle(hFOV);
+}
+
+//////////////////////////////////////////////////
 void Ogre2Camera::SetHFOV(const math::Angle &_angle)
 {
   BaseCamera::SetHFOV(_angle);

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -75,8 +75,7 @@ void Ogre2Camera::Destroy()
 math::Angle Ogre2Camera::HFOV() const
 {
   double vfov = this->ogreCamera->getFOVy().valueRadians();
-  double hFOV;
-  hFOV = 2.0 * atan(tan(vfov / 2.0) * this->ImageWidth() / this->ImageHeight());
+  double hFOV = 2.0 * atan(tan(vfov / 2.0) * this->AspectRatio());
   return math::Angle(hFOV);
 }
 

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -72,7 +72,7 @@ void CameraTest::ViewProjectionMatrix(const std::string &_renderEngine)
   EXPECT_GT(camera->HFOV(), 0);
   math::Angle hfov(1.57);
   camera->SetHFOV(hfov);
-  EXPECT_DOUBLE_EQ(hfov.Radian(), camera->HFOV().Radian());
+  EXPECT_NEAR(hfov.Radian(), camera->HFOV().Radian(), 1e-6);
 
   EXPECT_GT(camera->AspectRatio(), 0);
   camera->SetAspectRatio(1.7777);


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Original Issue: #500

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

`Camera::HFOV()` only returned a fixed value previously. Now it should change as we resize the window and change FOV at runtime. 

![demo_fov](https://user-images.githubusercontent.com/50132891/170728349-fe9dc9c9-6c05-486f-9654-0746ea6c848f.gif)


My VM can only run Ogre so I need someone to help me test this on Ogre2.

Draft because it fails too many tests

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
