### PR TITLE
ign -> gz Environment Variable Migration : gz-rendering

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -15,8 +15,8 @@ release will remove the deprecated code.
 2. The `ignition` namespace is deprecated and will be removed in future versions.  Use `gz` instead.
 3. Header files under `ignition/...` are deprecated and will be removed in future versions.
    Use `gz/...` instead.
-* The environment variable `IGN_RENDERING_PLUGIN_PATH` is deprecated. Use `GZ_RENDERING_PLUGIN_PATH` instead.
-
+4. The environment variable `IGN_RENDERING_PLUGIN_PATH` is deprecated. Use `GZ_RENDERING_PLUGIN_PATH` instead.
+5. The environment variable `IGN_RENDERING_RESOURCE_PATH` is deprecated. Use `GZ_RENDERING_RESOURCE_PATH` instead.
 ## Gazebo Rendering 6.2.1 to 6.X
 
 ### Modifications

--- a/examples/hello_world_plugin/README.md
+++ b/examples/hello_world_plugin/README.md
@@ -22,11 +22,11 @@ and `HelloWorldPlugin.dll` on Windows.
 
 ## Run
 
-Be sure to have the `IGN_GAZEBO_RENDER_ENGINE_PATH` environment variable set to the path
+Be sure to have the `GZ_SIM_RENDER_ENGINE_PATH` environment variable set to the path
 where your plugin is located.  From within the `build` directory of this example, you can run
 
 ~~~
-export IGN_GAZEBO_RENDER_ENGINE_PATH=$PWD
+export GZ_SIM_RENDER_ENGINE_PATH=$PWD
 ~~~
 
 to set the environment variable accordingly.

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -206,7 +206,20 @@ void OgreDepthCamera::CreatePointCloudTexture()
   this->dataPtr->pcdMaterial = this->scene->CreateMaterial();
 
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
 

--- a/ogre/src/OgreMaterial.cc
+++ b/ogre/src/OgreMaterial.cc
@@ -661,7 +661,20 @@ void OgreMaterial::SetDepthMaterial(const double _far,
   // TODO(anyone): convert depth configuration into a ShaderType
   // Get shader parameters path
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
 

--- a/ogre/src/OgreRTShaderSystem.cc
+++ b/ogre/src/OgreRTShaderSystem.cc
@@ -486,7 +486,20 @@ bool OgreRTShaderSystem::Paths(std::string &coreLibsPath,
     std::string &cachePath)
 {
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
 

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -567,7 +567,20 @@ void OgreRenderEngine::CreateResources()
   // TODO(anyone) support loading resources from user specified paths
   std::list<std::string> paths;
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
   // install path

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -672,7 +672,20 @@ void Ogre2RenderEngine::CreateRenderSystem()
 void Ogre2RenderEngine::RegisterHlms()
 {
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
   // install path
@@ -866,7 +879,20 @@ void Ogre2RenderEngine::RegisterHlms()
 void Ogre2RenderEngine::CreateResources()
 {
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
   // install path

--- a/optix/src/OptixRenderEngine.cc
+++ b/optix/src/OptixRenderEngine.cc
@@ -81,7 +81,20 @@ std::string OptixRenderEngine::PtxFile(const std::string& _fileBase) const
   std::vector<std::string> folders;
 
   const char *env= std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
   resourcePath = common::joinPaths(resourcePath, "optix");

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1548,7 +1548,20 @@ void BaseScene::CreateMaterials()
   material->SetLightingEnabled(true);
 
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
-  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+  // TODO(CH3): Deprecated. Remove on tock.
+  if (!env)
+  {
+    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
+
+    if (env)
+    {
+      gzwarn << "Using deprecated environment variable "
+             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
+             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
+    }
+  }
+
   std::string resourcePath = (env) ? std::string(env) :
       GZ_RENDERING_RESOURCE_PATH;
 

--- a/tutorials/03_rendering_plugins.md
+++ b/tutorials/03_rendering_plugins.md
@@ -24,7 +24,7 @@ Finally, for your custom rendering engine to actually have any functionality and
 
 Once you have your own rendering plugin written, you can build it similarly to how the example is built.  It may be helpful to look at the [`CMakeLists.txt`](https://github.com/gazebosim/gz-rendering/tree/main/examples/hello_world_plugin) from the example as it contains the boilerplate code needed to get a custom rendering engine plugin built.
 
-After you have your plugin built, you will need to set the `IGN_GAZEBO_RENDER_ENGINE_PATH` environment variable to the path in which your built shared library resides.  Note that you will need to do this for every command line instance unless you add the line to your startup shell script (`.bashrc`, `.zshrc`, etc.).
+After you have your plugin built, you will need to set the `GZ_SIM_RENDER_ENGINE_PATH` environment variable to the path in which your built shared library resides.  Note that you will need to do this for every command line instance unless you add the line to your startup shell script (`.bashrc`, `.zshrc`, etc.).
 
 From here, you should be able to reference your rendering plugin within Gazebo by the name of the generated shared library file (without the `lib` prefix or the file extension, i.e., libHelloWorldPlugin.so -> HelloWorldPlugin).
 


### PR DESCRIPTION
See: https://github.com/gazebo-tooling/release-tools/issues/734

Actually no environment variables need to be migrated (though how it's been implemented means there isn't really a way to emit warnings...)

They were implemented like so in the namespace migration:
```
  const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
  env = (env) ? env : std::getenv("IGN_RENDERING_RESOURCE_PATH");
```