### PR TITLE
Use pose multiplication instead of subtraction

### DIFF
--- a/include/gz/rendering/base/BaseNode.hh
+++ b/include/gz/rendering/base/BaseNode.hh
@@ -504,7 +504,7 @@ namespace gz
         return _pose;
       }
 
-      return _pose - parent->WorldPose();
+      return parent->WorldPose().Inverse() * _pose;
     }
 
     //////////////////////////////////////////////////


### PR DESCRIPTION
# 🎉 New feature

Part of [gz-math#60](https://github.com/gazebosim/gz-math/issues/60).

## Summary

As noted in [gz-math#60](https://github.com/gazebosim/gz-math/issues/60), there are concerns about the pose subtraction operator. Given that it is equivalent to multiplying by an inverse (albeit with reversed order), the subtraction operator will be deprecated. This PR replaces usage of the soon-to-be-deprecated operator with the equivalent multiplication by inverse.

## Test it

Build against https://github.com/gazebosim/gz-math/pull/438 and confirm that tests still pass and that there are no deprecation warnings.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
