### PR TITLE
Fix checking unofficial ogre versions in cmake when ogre 1.x is not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ ign_find_package(IgnOGRE VERSION 1.9.0
 # Ogre versions greater than 1.9.x are not officialy supported.
 # Display a warning for the users on this setup unless they provide
 # USE_UNOFFICIAL_OGRE_VERSIONS flag
-if (NOT USE_UNOFFICIAL_OGRE_VERSIONS)
+if (OGRE_FOUND AND NOT USE_UNOFFICIAL_OGRE_VERSIONS)
   if (${OGRE_VERSION} VERSION_GREATER_EQUAL 1.10.0)
     IGN_BUILD_WARNING("Ogre 1.x versions greater than 1.9 are not officially supported."
                       "The software might compile and even work but support from upstream"


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary


if ogre 1.x is not installed, running cmake produces this error:

```sh                                                 
CMake Error at CMakeLists.txt:78 (if):
  if given arguments:

    "VERSION_GREATER_EQUAL" "1.10.0"

  Unknown arguments specified

```

The change here makes sure that ogre is found before reading value from the `OGRE_VERSION` variable.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
