### PR TITLE
Protect against non-finite inputs on Node and OrbitViewController

### DIFF
--- a/include/ignition/rendering/base/BaseNode.hh
+++ b/include/ignition/rendering/base/BaseNode.hh
@@ -336,15 +336,15 @@ namespace ignition
     template <class T>
     void BaseNode<T>::SetLocalPose(const math::Pose3d &_pose)
     {
-      math::Pose3d pose = _pose;
-      pose.Pos() = pose.Pos() - pose.Rot() * this->origin;
-
-      if (!pose.IsFinite())
+      if (!_pose.IsFinite())
       {
-        ignerr << "Unable to set pose of a node: "
-               << "non-finite (nan, inf) values detected." << std::endl;
+        ignerr << "Unable to set non-finite pose [" << _pose
+               << "] to node [" << this->Name() << "]" << std::endl;
         return;
       }
+
+      math::Pose3d pose = _pose;
+      pose.Pos() = pose.Pos() - pose.Rot() * this->origin;
 
       if (!initialLocalPoseSet)
       {
@@ -380,6 +380,13 @@ namespace ignition
     template <class T>
     void BaseNode<T>::SetLocalPosition(const math::Vector3d &_position)
     {
+      if (!_position.IsFinite())
+      {
+        ignerr << "Unable to set non-finite position [" << _position
+               << "] to node [" << this->Name() << "]" << std::endl;
+        return;
+      }
+
       math::Pose3d pose = this->LocalPose();
       pose.Pos() = _position;
       this->SetLocalPose(pose);
@@ -411,6 +418,13 @@ namespace ignition
     template <class T>
     void BaseNode<T>::SetLocalRotation(const math::Quaterniond &_rotation)
     {
+      if (!_rotation.IsFinite())
+      {
+        ignerr << "Unable to set non-finite rotation [" << _rotation
+               << "] to node [" << this->Name() << "]" << std::endl;
+        return;
+      }
+
       math::Pose3d pose = this->LocalPose();
       pose.Rot() = _rotation;
       this->SetLocalPose(pose);
@@ -525,6 +539,12 @@ namespace ignition
     template <class T>
     void BaseNode<T>::SetOrigin(const math::Vector3d &_origin)
     {
+      if (!_origin.IsFinite())
+      {
+        ignerr << "Unable to set non-finite origin [" << _origin
+               << "] to node [" << this->Name() << "]" << std::endl;
+        return;
+      }
       this->origin = _origin;
     }
 

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -79,8 +79,27 @@ void Ogre2RayQuery::SetFromCamera(const CameraPtr &_camera,
   Ogre::Ray ray =
       camera->ogreCamera->getCameraToViewportRay(screenPos.X(), screenPos.Y());
 
-  this->origin = Ogre2Conversions::Convert(ray.getOrigin());
-  this->direction = Ogre2Conversions::Convert(ray.getDirection());
+  auto originMath = Ogre2Conversions::Convert(ray.getOrigin());
+  if (originMath.IsFinite())
+  {
+    this->origin = originMath;
+  }
+  else
+  {
+    ignwarn << "Attempted to set non-finite origin from camera ["
+            << camera->Name() << "]" << std::endl;
+  }
+
+  auto directionMath = Ogre2Conversions::Convert(ray.getDirection());
+  if (directionMath.IsFinite())
+  {
+    this->direction = directionMath;
+  }
+  else
+  {
+    ignwarn << "Attempted to set non-finite direction from camera ["
+            << camera->Name() << "]" << std::endl;
+  }
 
   this->dataPtr->camera = camera;
 

--- a/src/OrbitViewController.cc
+++ b/src/OrbitViewController.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <cmath>
+
 #include <ignition/common/Console.hh>
 
 #include "ignition/rendering/OrbitViewController.hh"
@@ -92,6 +94,13 @@ const math::Vector3d &OrbitViewController::Target() const
 //////////////////////////////////////////////////
 void OrbitViewController::Zoom(const double _value)
 {
+  if (!std::isfinite(_value))
+  {
+    ignerr << "Failed to zoom by non-finite value [" << _value << "]"
+           << std::endl;
+    return;
+  }
+
   if (!this->dataPtr->camera)
   {
     ignerr << "Camera is NULL" << std::endl;
@@ -113,9 +122,23 @@ void OrbitViewController::Zoom(const double _value)
 //////////////////////////////////////////////////
 void OrbitViewController::Pan(const math::Vector2d &_value)
 {
+  if (!_value.IsFinite())
+  {
+    ignerr << "Failed to pan by non-finite value [" << _value << "]"
+           << std::endl;
+    return;
+  }
+
   if (!this->dataPtr->camera)
   {
     ignerr << "Camera is NULL" << std::endl;
+    return;
+  }
+
+  if (!this->dataPtr->camera->WorldPosition().IsFinite())
+  {
+    ignerr << "Camera world position isn't finite ["
+           << this->dataPtr->camera->WorldPosition() << "]" << std::endl;
     return;
   }
 
@@ -148,6 +171,13 @@ void OrbitViewController::Pan(const math::Vector2d &_value)
 //////////////////////////////////////////////////
 void OrbitViewController::Orbit(const math::Vector2d &_value)
 {
+  if (!_value.IsFinite())
+  {
+    ignerr << "Failed to orbit by non-finite value [" << _value << "]"
+           << std::endl;
+    return;
+  }
+
   if (!this->dataPtr->camera)
   {
     ignerr << "Camera is NULL" << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While debugging https://github.com/gazebosim/gz-sim/pull/1499#pullrequestreview-1009122496, I noticed that GUI and Sim are often providing non-finite values to Rendering, which often results in crashes. This PR adds some guards for situations that I ran into. 

I'm going to keep investigating why downstream libraries are setting NaNs, but having the guards in place helps in any case.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
