### PR TITLE
Disable thermal camera tests on MacOS

### DIFF
--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/Console.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
 
@@ -835,7 +836,9 @@ TEST_P(CameraTest, VisualAt)
 }
 
 /////////////////////////////////////////////////
-TEST_P(CameraTest, ShaderSelection)
+// See: https://github.com/gazebosim/gz-rendering/issues/654
+TEST_P(CameraTest,
+       IGN_UTILS_TEST_DISABLED_ON_MAC(ShaderSelection))
 {
   ShaderSelection(GetParam());
 }

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>
 #include <ignition/common/Event.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include <ignition/math/Color.hh>
 
@@ -628,7 +629,9 @@ void ThermalCameraTest::ThermalCameraParticles(
   ignition::rendering::unloadEngine(engine->Name());
 }
 
-TEST_P(ThermalCameraTest, ThermalCameraBoxesUniformTemp)
+// See: https://github.com/gazebosim/gz-rendering/issues/654
+TEST_P(ThermalCameraTest,
+       IGN_UTILS_TEST_DISABLED_ON_MAC(ThermalCameraBoxesUniformTemp))
 {
   ThermalCameraBoxes(GetParam(), false);
 }


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

Temporary remedy for #654

## Summary
Tests known to fail on MacOS will not be run to help getting CI to a known state.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests -> temprarily disabling tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸