### PR TITLE
Increase TransformControl test converage

### DIFF
--- a/src/TransformController_TEST.cc
+++ b/src/TransformController_TEST.cc
@@ -128,6 +128,8 @@ void TransformControllerTest::TransformControl(const std::string &_renderEngine)
   EXPECT_EQ(math::Vector3d::UnitZ,
       transformControl.ToAxis(TransformAxis::TA_SCALE_Z));
 
+
+
   // Clean up
   engine->DestroyScene(scene);
   rendering::unloadEngine(engine->Name());
@@ -236,29 +238,65 @@ void TransformControllerTest::LocalSpace(const std::string &_renderEngine)
   transformControl.SetTransformSpace(TransformSpace::TS_LOCAL);
   transformControl.SetActiveAxis(math::Vector3d::UnitZ);
   transformControl.Translate(math::Vector3d(0, 0, 2));
-  EXPECT_EQ(visual->WorldPosition(), math::Vector3d(0, -2, 0));
-  EXPECT_EQ(visual->WorldRotation(), initialRot);
-  EXPECT_EQ(visual->WorldScale(), math::Vector3d::One);
+  transformControl.Update();
+  EXPECT_EQ(math::Vector3d(0, -2, 0), visual->WorldPosition());
+  EXPECT_EQ(initialRot, visual->WorldRotation());
+  EXPECT_EQ(math::Vector3d::One, visual->WorldScale());
+
+  // test translation when snapping is enabled
+  transformControl.SetActiveAxis(math::Vector3d::UnitY);
+  transformControl.SetTransformSpace(TransformSpace::TS_WORLD);
+  transformControl.Translate(math::Vector3d(0, 1, 0), true);
+  transformControl.Update();
+  EXPECT_EQ(math::Vector3d(0, -1, 0), visual->WorldPosition());
+  EXPECT_EQ(initialRot, visual->WorldRotation());
+  EXPECT_EQ(math::Vector3d::One, visual->WorldScale());
 
   // test rotation in local space
   transformControl.SetTransformMode(TransformMode::TM_ROTATION);
   transformControl.SetTransformSpace(TransformSpace::TS_LOCAL);
   transformControl.SetActiveAxis(math::Vector3d::UnitX);
   transformControl.Rotate(math::Quaterniond(IGN_PI, 0, 0));
-  EXPECT_EQ(visual->WorldPosition(), math::Vector3d(0, -2, 0));
-  EXPECT_EQ(visual->WorldRotation(),
-      math::Quaterniond(IGN_PI, 0, 0) * initialRot);
-  EXPECT_EQ(visual->WorldScale(), math::Vector3d::One);
+  transformControl.Update();
+  EXPECT_EQ(math::Vector3d(0, -1, 0), visual->WorldPosition());
+  EXPECT_EQ(math::Quaterniond(IGN_PI, 0, 0) * initialRot,
+      visual->WorldRotation());
+  EXPECT_EQ(math::Vector3d::One, visual->WorldScale());
+
+  // test rotation when snapping is enabled
+  transformControl.SetActiveAxis(math::Vector3d::UnitY);
+  transformControl.SetTransformSpace(TransformSpace::TS_WORLD);
+  transformControl.Rotate(math::Quaterniond(0, IGN_PI, 0), true);
+  transformControl.Update();
+  EXPECT_EQ( math::Vector3d(0, -1, 0), visual->WorldPosition());
+  EXPECT_EQ(math::Quaterniond(0, IGN_PI, 0) * math::Quaterniond(IGN_PI, 0, 0) *
+      initialRot, visual->WorldRotation());
+  EXPECT_EQ(math::Vector3d::One, visual->WorldScale());
 
   // test scaling in local space
   transformControl.SetTransformMode(TransformMode::TM_SCALE);
   transformControl.SetTransformSpace(TransformSpace::TS_LOCAL);
   transformControl.SetActiveAxis(math::Vector3d::UnitY);
   transformControl.Scale(math::Vector3d(1.0, 0.3, 1.0));
-  EXPECT_EQ(visual->WorldPosition(), math::Vector3d(0, -2, 0));
-  EXPECT_EQ(visual->WorldRotation(),
-      math::Quaterniond(IGN_PI, 0, 0) * initialRot);
-  EXPECT_EQ(visual->WorldScale(), math::Vector3d(1.0, 0.3, 1.0));
+  transformControl.Update();
+  EXPECT_EQ(math::Vector3d(0, -1, 0), visual->WorldPosition());
+  EXPECT_EQ(math::Quaterniond(0, IGN_PI, 0) * math::Quaterniond(IGN_PI, 0, 0) *
+      initialRot, visual->WorldRotation());
+
+  auto expectedScale = math::Vector3d(1.0, 0.3, 1.0);
+  EXPECT_EQ(expectedScale, visual->WorldScale());
+
+  // test scaling when snapping is enabled
+  auto newScale = math::Vector3d(2.0, 6.0, 1.2);
+  transformControl.Scale(newScale, true);
+  transformControl.Update();
+  EXPECT_EQ(math::Vector3d(0, -1, 0), visual->WorldPosition());
+  EXPECT_EQ(math::Quaterniond(0, IGN_PI, 0) * math::Quaterniond(IGN_PI, 0, 0) *
+      initialRot, visual->WorldRotation());
+  math::Vector3d snappedScale(std::round(newScale.X() * expectedScale.X()),
+                              std::round(newScale.Y() * expectedScale.Y()),
+                              std::round(newScale.Z() * expectedScale.Z()));
+  EXPECT_EQ(snappedScale, visual->WorldScale());
 
   // Clean up
   engine->DestroyScene(scene);
@@ -288,15 +326,29 @@ void TransformControllerTest::Control2d(const std::string &_renderEngine)
 
   TransformController transformControl;
 
-  // test setting camera
-  transformControl.SetCamera(camera);
-  EXPECT_EQ(camera, transformControl.Camera());
+  // test translation and scale without a node
+  math::Vector2d start0(0.5, 0.5);
+  math::Vector2d end0(0.5, 0.8);
+  EXPECT_EQ(math::Vector3d::Zero,
+      transformControl.TranslationFrom2d(math::Vector3d::UnitZ, start0, end0));
+  EXPECT_EQ(math::Vector3d::Zero,
+      transformControl.ScaleFrom2d(math::Vector3d::UnitY, start0, end0));
 
   // create a dummy node visual node and attach to the controller
   VisualPtr visual = scene->CreateVisual();
   ASSERT_NE(nullptr, visual);
   transformControl.Attach(visual);
   EXPECT_EQ(visual, transformControl.Node());
+
+  // test translation and scale without a camera
+  EXPECT_EQ(math::Vector3d::Zero,
+      transformControl.TranslationFrom2d(math::Vector3d::UnitZ, start0, end0));
+  EXPECT_EQ(math::Vector3d::Zero,
+      transformControl.ScaleFrom2d(math::Vector3d::UnitY, start0, end0));
+
+  // test setting camera
+  transformControl.SetCamera(camera);
+  EXPECT_EQ(camera, transformControl.Camera());
 
   // test translation from 2d
   transformControl.SetTransformMode(TransformMode::TM_TRANSLATION);
@@ -305,12 +357,25 @@ void TransformControllerTest::Control2d(const std::string &_renderEngine)
   transformControl.Start();
   math::Vector2d start(0.5, 0.5);
   math::Vector2d end(0.5, 0.8);
+  // translation in z
   math::Vector3d translation =
       transformControl.TranslationFrom2d(math::Vector3d::UnitZ, start, end);
   transformControl.Stop();
   EXPECT_DOUBLE_EQ(translation.X(), 0);
   EXPECT_DOUBLE_EQ(translation.Y(), 0);
   EXPECT_GT(translation.Z(), 0);
+
+  // translation in y
+  transformControl.SetActiveAxis(math::Vector3d::UnitY);
+  transformControl.Start();
+  math::Vector2d starty(0.5, 0.5);
+  math::Vector2d endy(0.2, 0.5);
+  translation =
+      transformControl.TranslationFrom2d(math::Vector3d::UnitY, starty, endy);
+  transformControl.Stop();
+  EXPECT_DOUBLE_EQ(translation.X(), 0);
+  EXPECT_GT(translation.Y(), 0);
+  EXPECT_DOUBLE_EQ(translation.Z(), 0);
 
   // test rotation from 2d
   transformControl.SetTransformMode(TransformMode::TM_ROTATION);

--- a/src/TransformController_TEST.cc
+++ b/src/TransformController_TEST.cc
@@ -128,8 +128,6 @@ void TransformControllerTest::TransformControl(const std::string &_renderEngine)
   EXPECT_EQ(math::Vector3d::UnitZ,
       transformControl.ToAxis(TransformAxis::TA_SCALE_Z));
 
-
-
   // Clean up
   engine->DestroyScene(scene);
   rendering::unloadEngine(engine->Name());
@@ -218,6 +216,15 @@ void TransformControllerTest::LocalSpace(const std::string &_renderEngine)
   camera->SetImageHeight(240);
 
   TransformController transformControl;
+
+  // test invalid callas and make sure no exceptions are thrown
+  EXPECT_NO_THROW(transformControl.SetCamera(nullptr));
+  EXPECT_NO_THROW(transformControl.Attach(nullptr));
+  EXPECT_NO_THROW(transformControl.Start());
+  EXPECT_NO_THROW(transformControl.Translate(math::Vector3d::Zero));
+  EXPECT_NO_THROW(transformControl.Rotate(math::Quaterniond::Identity));
+  EXPECT_NO_THROW(transformControl.Translate(math::Vector3d::One));
+  EXPECT_EQ(math::Vector3d::Zero, transformControl.AxisById(0u));
 
   // test setting camera
   transformControl.SetCamera(camera);
@@ -403,6 +410,12 @@ void TransformControllerTest::Control2d(const std::string &_renderEngine)
   EXPECT_DOUBLE_EQ(scale.X(), 1);
   EXPECT_GT(scale.Y(), 0);
   EXPECT_DOUBLE_EQ(scale.Z(), 1);
+
+  // test snapping with invalid args
+  EXPECT_EQ(math::Vector3d::Zero,
+      transformControl.SnapPoint(math::Vector3d::One, -1));
+  EXPECT_EQ(math::Vector3d::Zero,
+      transformControl.SnapPoint(math::Vector3d::One, 1, -1));
 
   // Clean up
   engine->DestroyScene(scene);


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Increase test coverage to ~90%

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

