### PR TITLE
Enable ogre2 heightmap test

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Heightmap.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Heightmap.hh
@@ -64,6 +64,9 @@ namespace ignition
       // Documentation inherited.
       public: virtual void PreRender() override;
 
+      // Documentation inherited.
+      public: virtual void Destroy() override;
+
       /// \brief Returns the Terra pointer as it is a movable object that
       /// must be attached to a regular SceneNode
       /// \remarks This behavior is different from ogre1

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Heightmap.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Heightmap.hh
@@ -64,10 +64,6 @@ namespace ignition
       // Documentation inherited.
       public: virtual void PreRender() override;
 
-      // Documentation inherited.
-      // \todo(iche033) make this function virutal
-      public: void Destroy();
-
       /// \brief Returns the Terra pointer as it is a movable object that
       /// must be attached to a regular SceneNode
       /// \remarks This behavior is different from ogre1
@@ -98,6 +94,11 @@ namespace ignition
       /// May update shadows if light direction changed
       /// \param[in] _activeCamera Camera about to be used for rendering
       public: void UpdateForRender(Ogre::Camera *_activeCamera);
+
+      // Documentation inherited.
+      // \todo(iche033) rename this to Destroy and
+      // make this function public and virtual
+      private: void DestroyImpl();
 
       /// \brief Heightmap should only be created by scene.
       private: friend class OgreScene;

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Heightmap.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Heightmap.hh
@@ -65,7 +65,8 @@ namespace ignition
       public: virtual void PreRender() override;
 
       // Documentation inherited.
-      public: virtual void Destroy() override;
+      // \todo(iche033) make this function virutal
+      public: void Destroy();
 
       /// \brief Returns the Terra pointer as it is a movable object that
       /// must be attached to a regular SceneNode

--- a/ogre2/src/Ogre2Heightmap.cc
+++ b/ogre2/src/Ogre2Heightmap.cc
@@ -76,6 +76,13 @@ Ogre2Heightmap::Ogre2Heightmap(const HeightmapDescriptor &_desc)
 //////////////////////////////////////////////////
 Ogre2Heightmap::~Ogre2Heightmap()
 {
+  this->Destroy();
+}
+
+//////////////////////////////////////////////////
+void Ogre2Heightmap::Destroy()
+{
+  this->dataPtr->terra.reset();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Heightmap.cc
+++ b/ogre2/src/Ogre2Heightmap.cc
@@ -76,11 +76,11 @@ Ogre2Heightmap::Ogre2Heightmap(const HeightmapDescriptor &_desc)
 //////////////////////////////////////////////////
 Ogre2Heightmap::~Ogre2Heightmap()
 {
-  this->Destroy();
+  this->DestroyImpl();
 }
 
 //////////////////////////////////////////////////
-void Ogre2Heightmap::Destroy()
+void Ogre2Heightmap::DestroyImpl()
 {
   this->dataPtr->terra.reset();
 }

--- a/src/Heightmap_TEST.cc
+++ b/src/Heightmap_TEST.cc
@@ -50,12 +50,6 @@ class HeightmapTest : public testing::Test,
 TEST_P(HeightmapTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
 {
   std::string renderEngine{this->GetParam()};
-  if (renderEngine != "ogre")
-  {
-    igndbg << "Heightmap not supported yet in rendering engine: "
-            << renderEngine << std::endl;
-    return;
-  }
 
   auto engine = rendering::engine(renderEngine);
   if (!engine)
@@ -351,10 +345,8 @@ TEST_P(HeightmapTest, CopyAssignmentAfterMove)
   EXPECT_DOUBLE_EQ(123.456, blend2.MinHeight());
 }
 
-// TODO(anyone) Running test with Ogre1. Update once Ogre2 is supported.
-// https://github.com/ignitionrobotics/ign-rendering/issues/187
 INSTANTIATE_TEST_CASE_P(Heightmap, HeightmapTest,
-    ::testing::ValuesIn({"ogre"}),
+    RENDER_ENGINE_VALUES,
     ignition::rendering::PrintToStringParam());
 
 /////////////////////////////////////////////////

--- a/src/Heightmap_TEST.cc
+++ b/src/Heightmap_TEST.cc
@@ -153,6 +153,14 @@ TEST_P(HeightmapTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
 
   scene->RootVisual()->AddChild(vis);
 
+  // \todo(iche033) this should not be needed once Ogre2Heightmap::Destroy is
+  // implemented.
+  if (renderEngine == "ogre2")
+  {
+    vis->Destroy();
+    heightmap.reset();
+  }
+
   // Clean up
   engine->DestroyScene(scene);
   rendering::unloadEngine(engine->Name());


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary

Run `Heightmap_test` with `ogre2` now that it is supported

This unfortunately reduces the overall test coverage % because various ogre1.x code is not run any more.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

