### PR TITLE
Add tests for ShaderType, GraphicsAPI, and DistortionPass

### DIFF
--- a/src/GraphicsAPI_TEST.cc
+++ b/src/GraphicsAPI_TEST.cc
@@ -58,9 +58,3 @@ TEST(GraphicsAPITest, GraphicsAPI)
   str = GraphicsAPIUtils::Str(static_cast<GraphicsAPI>(99));
   EXPECT_TRUE(str.empty());
 }
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/GraphicsAPI_TEST.cc
+++ b/src/GraphicsAPI_TEST.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Console.hh>
+
+#include "test_config.h"  // NOLINT(build/include)
+#include "ignition/rendering/GraphicsAPI.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+/////////////////////////////////////////////////
+TEST(GraphicsAPITest, GraphicsAPI)
+{
+  GraphicsAPI api = GraphicsAPIUtils::Set("UNKNOWN");
+  EXPECT_EQ(GraphicsAPI::UNKNOWN, api);
+
+  api = GraphicsAPIUtils::Set("DIRECT3D11");
+  EXPECT_EQ(GraphicsAPI::DIRECT3D11, api);
+
+  api = GraphicsAPIUtils::Set("VULKAN");
+  EXPECT_EQ(GraphicsAPI::VULKAN, api);
+
+  api = GraphicsAPIUtils::Set("METAL");
+  EXPECT_EQ(GraphicsAPI::METAL, api);
+
+  api = GraphicsAPIUtils::Set("invalid");
+  EXPECT_EQ(GraphicsAPI::UNKNOWN, api);
+
+  std::string str = GraphicsAPIUtils::Str(GraphicsAPI::UNKNOWN);
+  EXPECT_EQ("UNKNOWN", str);
+
+  str = GraphicsAPIUtils::Str(GraphicsAPI::DIRECT3D11);
+  EXPECT_EQ("DIRECT3D11", str);
+
+  str = GraphicsAPIUtils::Str(GraphicsAPI::VULKAN);
+  EXPECT_EQ("VULKAN", str);
+
+  str = GraphicsAPIUtils::Str(GraphicsAPI::METAL);
+  EXPECT_EQ("METAL", str);
+
+  str = GraphicsAPIUtils::Str(static_cast<GraphicsAPI>(99));
+  EXPECT_TRUE(str.empty());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/RenderPassSystem_TEST.cc
+++ b/src/RenderPassSystem_TEST.cc
@@ -20,6 +20,7 @@
 #include <ignition/common/Console.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
+#include "ignition/rendering/DistortionPass.hh"
 #include "ignition/rendering/GaussianNoisePass.hh"
 #include "ignition/rendering/RenderEngine.hh"
 #include "ignition/rendering/RenderingIface.hh"
@@ -70,6 +71,16 @@ void RenderPassSystemTest::RenderPassSystem(const std::string &_renderEngine)
   GaussianNoisePassPtr noisePass =
       std::dynamic_pointer_cast<GaussianNoisePass>(pass);
   EXPECT_NE(nullptr, noisePass);
+
+  // create distortion pass
+  RenderPassPtr dpass = rpSystem->Create<DistortionPass>();
+  if (_renderEngine == "ogre")
+  {
+    EXPECT_NE(nullptr, dpass);
+    DistortionPassPtr distortionPass =
+        std::dynamic_pointer_cast<DistortionPass>(dpass);
+    EXPECT_NE(nullptr, distortionPass);
+  }
 }
 
 /////////////////////////////////////////////////

--- a/src/ShaderType_TEST.cc
+++ b/src/ShaderType_TEST.cc
@@ -1,0 +1,57 @@
+/* * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "ignition/rendering/ShaderType.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+/////////////////////////////////////////////////
+TEST(ShaderType, ShaderUtil)
+{
+  EXPECT_TRUE(ShaderUtil::IsValid(ShaderType::ST_PIXEL));
+  EXPECT_TRUE(ShaderUtil::IsValid(ShaderType::ST_VERTEX));
+  EXPECT_TRUE(ShaderUtil::IsValid(ShaderType::ST_NORM_OBJ));
+  EXPECT_TRUE(ShaderUtil::IsValid(ShaderType::ST_NORM_TAN));
+  EXPECT_FALSE(ShaderUtil::IsValid(ShaderType::ST_UNKNOWN));
+
+  EXPECT_EQ(ShaderType::ST_PIXEL,
+      ShaderUtil::Sanitize(ShaderType::ST_PIXEL));
+  EXPECT_EQ(ShaderType::ST_UNKNOWN,
+      ShaderUtil::Sanitize(static_cast<ShaderType>(99)));
+
+  EXPECT_EQ("pixel", ShaderUtil::Name(ShaderType::ST_PIXEL));
+  EXPECT_EQ("vertex", ShaderUtil::Name(ShaderType::ST_VERTEX));
+  EXPECT_EQ("normal_map_object_space", ShaderUtil::Name(ShaderType::ST_NORM_OBJ));
+  EXPECT_EQ("normal_map_tangent_space", ShaderUtil::Name(ShaderType::ST_NORM_TAN));
+  EXPECT_EQ("UNKNOWN", ShaderUtil::Name(ShaderType::ST_UNKNOWN));
+
+  EXPECT_EQ(ST_PIXEL, ShaderUtil::Enum("pixel"));
+  EXPECT_EQ(ST_VERTEX, ShaderUtil::Enum("vertex"));
+  EXPECT_EQ(ST_NORM_OBJ, ShaderUtil::Enum("normal_map_object_space"));
+  EXPECT_EQ(ST_NORM_TAN, ShaderUtil::Enum("normal_map_tangent_space"));
+  EXPECT_EQ(ST_UNKNOWN, ShaderUtil::Enum("UNKNOWN"));
+  EXPECT_EQ(ST_UNKNOWN, ShaderUtil::Enum("invalid"));
+}
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ShaderType_TEST.cc
+++ b/src/ShaderType_TEST.cc
@@ -50,10 +50,3 @@ TEST(ShaderType, ShaderUtil)
   EXPECT_EQ(ST_UNKNOWN, ShaderUtil::Enum("UNKNOWN"));
   EXPECT_EQ(ST_UNKNOWN, ShaderUtil::Enum("invalid"));
 }
-
-//////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/ShaderType_TEST.cc
+++ b/src/ShaderType_TEST.cc
@@ -37,8 +37,10 @@ TEST(ShaderType, ShaderUtil)
 
   EXPECT_EQ("pixel", ShaderUtil::Name(ShaderType::ST_PIXEL));
   EXPECT_EQ("vertex", ShaderUtil::Name(ShaderType::ST_VERTEX));
-  EXPECT_EQ("normal_map_object_space", ShaderUtil::Name(ShaderType::ST_NORM_OBJ));
-  EXPECT_EQ("normal_map_tangent_space", ShaderUtil::Name(ShaderType::ST_NORM_TAN));
+  EXPECT_EQ("normal_map_object_space",
+      ShaderUtil::Name(ShaderType::ST_NORM_OBJ));
+  EXPECT_EQ("normal_map_tangent_space",
+      ShaderUtil::Name(ShaderType::ST_NORM_TAN));
   EXPECT_EQ("UNKNOWN", ShaderUtil::Name(ShaderType::ST_UNKNOWN));
 
   EXPECT_EQ(ST_PIXEL, ShaderUtil::Enum("pixel"));


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Added unit tests for ShaderType, GraphicsAPI, and DistortionPass, which currently have zero or very low test coverage.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
