### PR TITLE
Fix double to float conversion beyond float max

### DIFF
--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -69,6 +69,12 @@ if (USE_GLX)
 endif()
 
 # Build the unit tests
-ign_build_tests(TYPE UNIT SOURCES ${gtest_sources} LIB_DEPS ${ogre2_target})
+ign_build_tests(TYPE UNIT
+    SOURCES
+      ${gtest_sources}
+    LIB_DEPS
+      ${ogre2_target}
+      IgnOGRE2::IgnOGRE2
+)
 
 install(DIRECTORY "media"  DESTINATION ${IGN_RENDERING_RESOURCE_PATH}/ogre2)

--- a/ogre2/src/Ogre2Conversions.cc
+++ b/ogre2/src/Ogre2Conversions.cc
@@ -27,6 +27,21 @@
 using namespace ignition;
 using namespace rendering;
 
+/// \brief Converts an infinite float value to a max / min value.
+/// The narrowing conversion from double to float may result in infs for values
+/// above max, which eventually causes issues within Ogre.
+/// \param[in, out] _f Float value to fix.
+void infToMax(float &_f)
+{
+  if (!std::isinf(_f))
+    return;
+
+  if (_f > 0)
+    _f = std::numeric_limits<float>::max();
+  else
+    _f = -std::numeric_limits<float>::max();
+}
+
 //////////////////////////////////////////////////
 const Ogre::PixelFormatGpu Ogre2Conversions::ogrePixelFormats[PF_COUNT] =
     {
@@ -73,7 +88,13 @@ math::Color Ogre2Conversions::Convert(const Ogre::ColourValue &_color)
 //////////////////////////////////////////////////
 Ogre::Vector3 Ogre2Conversions::Convert(const math::Vector3d &_vector)
 {
-  return Ogre::Vector3(_vector.X(), _vector.Y(), _vector.Z());
+  auto ogreVec = Ogre::Vector3(_vector.X(), _vector.Y(), _vector.Z());
+
+  infToMax(ogreVec.x);
+  infToMax(ogreVec.y);
+  infToMax(ogreVec.z);
+
+  return ogreVec;
 }
 
 //////////////////////////////////////////////////
@@ -85,7 +106,14 @@ math::Vector3d Ogre2Conversions::Convert(const Ogre::Vector3 &_vector)
 //////////////////////////////////////////////////
 Ogre::Quaternion Ogre2Conversions::Convert(const math::Quaterniond &_quat)
 {
-  return Ogre::Quaternion(_quat.W(), _quat.X(), _quat.Y(), _quat.Z());
+  auto ogreQuat = Ogre::Quaternion(_quat.W(), _quat.X(), _quat.Y(), _quat.Z());
+
+  infToMax(ogreQuat.w);
+  infToMax(ogreQuat.x);
+  infToMax(ogreQuat.y);
+  infToMax(ogreQuat.z);
+
+  return ogreQuat;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Conversions_TEST.cc
+++ b/ogre2/src/Ogre2Conversions_TEST.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "test_config.h"  // NOLINT(build/include)
+#include "ignition/rendering/ogre2/Ogre2Conversions.hh"
+
+using namespace ignition;
+using namespace rendering;
+
+/////////////////////////////////////////////////
+TEST(Ogre2ConversionsTest, Vector3)
+{
+  math::Vector3d gzVec(0.1, 0.2, 0.3);
+  auto ogreVec = Ogre2Conversions::Convert(gzVec);
+  auto gzVec2 = Ogre2Conversions::Convert(ogreVec);
+  EXPECT_EQ(gzVec2, gzVec);
+}
+
+/////////////////////////////////////////////////
+TEST(Ogre2ConversionsTest, Vector3Inf)
+{
+  math::Vector3d gzVec(
+      std::numeric_limits<float>::infinity(),
+      -std::numeric_limits<double>::infinity(),
+      std::numeric_limits<float>::max() + 1);
+
+  auto ogreVec = Ogre2Conversions::Convert(gzVec);
+
+  EXPECT_DOUBLE_EQ(std::numeric_limits<float>::max(), ogreVec.x);
+  EXPECT_DOUBLE_EQ(-std::numeric_limits<float>::max(), ogreVec.y);
+  EXPECT_DOUBLE_EQ(std::numeric_limits<float>::max(), ogreVec.z);
+}
+
+/////////////////////////////////////////////////
+TEST(Ogre2ConversionsTest, Quaternion)
+{
+  math::Quaterniond gzQuat(0.1, 0.2, 0.3);
+  auto ogreQuat = Ogre2Conversions::Convert(gzQuat);
+  auto gzQuat2 = Ogre2Conversions::Convert(ogreQuat);
+  EXPECT_EQ(gzQuat2, gzQuat);
+}
+
+/////////////////////////////////////////////////
+TEST(Ogre2ConversionsTest, QuaternionInf)
+{
+  math::Quaterniond gzQuat(
+      std::numeric_limits<float>::infinity(),
+      -std::numeric_limits<double>::infinity(),
+      std::numeric_limits<float>::max() + 1,
+      -std::numeric_limits<float>::max() - 1);
+
+  auto ogreQuat = Ogre2Conversions::Convert(gzQuat);
+
+  EXPECT_DOUBLE_EQ(std::numeric_limits<float>::max(), ogreQuat.w);
+  EXPECT_DOUBLE_EQ(-std::numeric_limits<float>::max(), ogreQuat.x);
+  EXPECT_DOUBLE_EQ(std::numeric_limits<float>::max(), ogreQuat.y);
+  EXPECT_DOUBLE_EQ(-std::numeric_limits<float>::max(), ogreQuat.z);
+}

--- a/ogre2/src/Ogre2Node.cc
+++ b/ogre2/src/Ogre2Node.cc
@@ -109,6 +109,13 @@ void Ogre2Node::SetRawLocalPosition(const math::Vector3d &_position)
   if (nullptr == this->ogreNode)
     return;
 
+  if (!_position.IsFinite())
+  {
+    ignerr << "Unable to set non-finite position [" << _position
+           << "] to node [" << this->Name() << "]" << std::endl;
+    return;
+  }
+
   this->ogreNode->setPosition(Ogre2Conversions::Convert(_position));
 }
 
@@ -126,6 +133,13 @@ void Ogre2Node::SetRawLocalRotation(const math::Quaterniond &_rotation)
 {
   if (nullptr == this->ogreNode)
     return;
+
+  if (!_rotation.IsFinite())
+  {
+    ignerr << "Unable to set non-finite rotation [" << _rotation
+           << "] to node [" << this->Name() << "]" << std::endl;
+    return;
+  }
 
   this->ogreNode->setOrientation(Ogre2Conversions::Convert(_rotation));
 }
@@ -266,6 +280,13 @@ void Ogre2Node::SetLocalScaleImpl(const math::Vector3d &_scale)
 {
   if (nullptr == this->ogreNode)
     return;
+
+  if (!_scale.IsFinite())
+  {
+    ignerr << "Unable to set non-finite scale [" << _scale
+           << "] to node [" << this->Name() << "]" << std::endl;
+    return;
+  }
 
   this->ogreNode->setScale(Ogre2Conversions::Convert(_scale));
 }


### PR DESCRIPTION
* Follow up to https://github.com/gazebosim/gz-rendering/pull/655
* Related to
    * https://github.com/gazebosim/gz-sim/pull/1499#pullrequestreview-1009122496
    * https://github.com/gazebosim/gz-sim/issues/1072

---

Gazebo is using double precision, while Ogre is using floats. When we go beyond the limits of what a `float` can hold, some compilers will generate `inf`s when converting those `double`s to `float`s. But internally, Ogre doesn't handle inf values well, which results in crashes and exceptions (like https://github.com/gazebosim/gz-sim/issues/1072).

The solution I found was to guard some of our Gazebo ➡️ Ogre conversions against infs, but I'm open to other ideas.

This solved the issue in https://github.com/gazebosim/gz-sim/pull/1499#pullrequestreview-1009122496 for me, but since that's tricky to reproduce, I'd appreciate confirmation from @jennuine or @AzulRadio that it works for them too.

---

Opening for visibility so others can try it out. If the idea is accepted, I'll open a separate PR to Citadel and we can forward-port that one.

Do not merge.