### PR TITLE
Add codecov.yml config file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+    - "ogre"
+    - "optix"
+    - "ogre2/terrain/Terra"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 ignore:
     - "ogre"
     - "optix"
-    - "ogre2/terrain/Terra"
+    - "ogre2/src/terrain/Terra"


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Added codecov.yml config file to exclude files in `ogre`, `optix`, and `ogre2/src/terrain/Terra` from coverage. 

Related comment:  https://github.com/gazebosim/gz-rendering/pull/670#issuecomment-1192016802

## Summary

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
