### PR TITLE
Backport 5 :arrow_right: 3 Disabling flaky depth and thermal camera tests on mac (#405)

### DIFF
--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -249,9 +249,10 @@ void DepthCameraTest::DepthCameraBoxes(
       unsigned int ma = *mrgba >> 0 & 0xFF;
       EXPECT_EQ(0u, mr);
       EXPECT_EQ(0u, mg);
-      // Note: If it fails here, it may be this problem again:
+#ifndef __APPLE__
       // https://github.com/ignitionrobotics/ign-rendering/issues/332
       EXPECT_GT(mb, 0u);
+#endif
 
       // Far left and right points should be red (background color)
       float lc = pointCloudData[pcLeft + 3];
@@ -450,10 +451,11 @@ void DepthCameraTest::DepthCameraBoxes(
           unsigned int a = *rgba >> 0 & 0xFF;
           EXPECT_EQ(0u, r);
           EXPECT_EQ(0u, g);
-          // Note: If it fails here, it may be this problem again:
+#ifndef __APPLE__
           // https://github.com/ignitionrobotics/ign-rendering/issues/332
           EXPECT_GT(b, 0u);
           EXPECT_EQ(255u, a);
+#endif
         }
       }
     }

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -200,7 +200,10 @@ void ThermalCameraTest::ThermalCameraBoxes(
       for (unsigned int j = 0; j < thermalCamera->ImageWidth(); ++j)
       {
         float temp = thermalData[step + j] * linearResolution;
+#ifndef __APPLE__
+        // https://github.com/ignitionrobotics/ign-rendering/issues/253
         EXPECT_NEAR(boxTemp, temp, boxTempRange);
+#endif
       }
     }
 


### PR DESCRIPTION
Backports #405 

Reference build (Thermal Camera and Depth Camera test regressions on Citadel): https://build.osrfoundation.org/job/ignition_rendering-ci-ign-rendering3-homebrew-amd64/74/

Signed-off-by: Cristóbal Arroyo <cristobal.arroyo@ekumenlabs.com>

# ➡️ Back port

Port `ign-rendering5` to `ign-rendering3`

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

FYI: @Blast545 