### PR TITLE
Destroy GpuRay camera on exit

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -665,12 +665,7 @@ void Ogre2GpuRays::Destroy()
   if (this->scene)
   {
     Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
-    if (ogreSceneManager == nullptr)
-    {
-      ignerr << "Scene manager not available. "
-             << "Unable to remove cameras and listeners" << std::endl;
-    }
-    else
+    if (ogreSceneManager)
     {
       ogreSceneManager->destroyCamera(this->dataPtr->ogreCamera);
       this->dataPtr->ogreCamera = nullptr;

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -661,7 +661,22 @@ void Ogre2GpuRays::Destroy()
     ogreCompMgr->removeWorkspace(this->dataPtr->ogreCompositorWorkspace2nd);
     this->dataPtr->ogreCompositorWorkspace2nd = nullptr;
   }
+
+  if (this->scene)
+  {
+    Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
+    if (ogreSceneManager == nullptr)
+    {
+      ignerr << "Scene manager not available. "
+             << "Unable to remove cameras and listeners" << std::endl;
+    }
+    else
+    {
+      ogreSceneManager->destroyCamera(this->dataPtr->ogreCamera);
+      this->dataPtr->ogreCamera = nullptr;
+    }
   }
+}
 
 /////////////////////////////////////////////////
 void Ogre2GpuRays::CreateRenderTexture()


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

## Summary
Destroy camera on exit in Ogre2GpuRay class, which is also done in gz-rendering6 [here](https://github.com/gazebosim/gz-rendering/blob/ign-rendering6/ogre2/src/Ogre2GpuRays.cc#L498). This also ensures the `Destroy` function can be called multiple times.

This should fix the gpu lidar test in gz-sensors.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

