### PR TITLE
Fix INTEGRATION_camera/shader_selection on macOS

### DIFF
--- a/test/integration/camera.cc
+++ b/test/integration/camera.cc
@@ -511,7 +511,7 @@ TEST_F(CameraTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Visibility))
 }
 
 /////////////////////////////////////////////////
-TEST_F(CameraTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ShaderSelection))
+TEST_F(CameraTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ShaderSelection))
 {
   CHECK_UNSUPPORTED_ENGINE("optix");
   // This test checks that custom shaders are being rendering correctly in
@@ -534,12 +534,27 @@ TEST_F(CameraTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ShaderSelection))
 
   std::string vertexShaderFile;
   std::string fragmentShaderFile;
-  if (this->engineToTest == "ogre2")
+
+  if (this->engine->Name() == "ogre2")
   {
-    vertexShaderFile = "simple_color_330_vs.glsl";
-    fragmentShaderFile = "simple_color_330_fs.glsl";
+    switch(this->engine->GraphicsAPI())
+    {
+      case GraphicsAPI::OPENGL:
+      case GraphicsAPI::VULKAN:
+        vertexShaderFile = "simple_color_330_vs.glsl";
+        fragmentShaderFile = "simple_color_330_fs.glsl";
+        break;
+      case GraphicsAPI::METAL:
+        vertexShaderFile = "simple_color_vs.metal";
+        fragmentShaderFile = "simple_color_fs.metal";
+        break;
+      case GraphicsAPI::DIRECT3D11:
+      default:
+        GTEST_FAIL() << "Unsupported graphics API for this test.";
+        break;
+    }
   }
-  else if (this->engineToTest == "ogre")
+  else if (this->engine->Name() == "ogre")
   {
     vertexShaderFile = "simple_color_vs.glsl";
     fragmentShaderFile = "simple_color_fs.glsl";
@@ -616,7 +631,7 @@ TEST_F(CameraTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ShaderSelection))
 
   // Currently, only ogre2 supports segmentation cameras
   SegmentationCameraPtr segmentationCamera;
-  if (this->engineToTest == "ogre2")
+  if (this->engine->Name() == "ogre2")
   {
     // Create segmentation camera
     // segmentation material switching may also affect shader materials

--- a/test/media/materials/programs/simple_color_fs.metal
+++ b/test/media/materials/programs/simple_color_fs.metal
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+
+fragment float4 main_metal
+(
+)
+{
+  return float4(1, 0, 0, 1);
+}

--- a/test/media/materials/programs/simple_color_vs.metal
+++ b/test/media/materials/programs/simple_color_vs.metal
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct VS_INPUT
+{
+  float4 position [[attribute(VES_POSITION)]];
+};
+
+struct PS_INPUT
+{
+  float4 gl_Position [[position]];
+};
+
+struct Params
+{
+  float4x4 worldviewproj_matrix;
+};
+
+vertex PS_INPUT main_metal
+(
+  VS_INPUT input [[stage_in]],
+  constant Params &p [[buffer(PARAMETER_SLOT)]]
+)
+{
+  PS_INPUT outVs;
+
+  outVs.gl_Position = ( p.worldviewproj_matrix * input.position ).xyzw;
+
+  return outVs;
+}


### PR DESCRIPTION
# 🦟 Bug fix

Partially addresses #695

## Summary

This was a test that was disabled on macOS after metal porting, but now it can be re-enabled.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
