### PR TITLE
Add regression test for multiple engine reloads

### DIFF
--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -44,6 +44,12 @@ void OgreCamera::Destroy()
   if (!this->ogreCamera)
     return;
 
+  if (this->renderTexture)
+  {
+    this->renderTexture->Destroy();
+    this->renderTexture = nullptr;
+  }
+
   Ogre::SceneManager *ogreSceneManager;
   ogreSceneManager = this->scene->OgreSceneManager();
   if (ogreSceneManager == nullptr)

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -109,12 +109,14 @@ void OgreDepthCamera::Destroy()
 
   if (this->dataPtr->pcdTexture)
   {
-    this->dataPtr->pcdTexture->RenderTarget()->removeAllViewports();
+    this->dataPtr->pcdTexture->Destroy();
+    this->dataPtr->pcdTexture.reset();
   }
 
   if (this->dataPtr->colorTexture)
   {
-    this->dataPtr->colorTexture->RenderTarget()->removeAllViewports();
+    this->dataPtr->colorTexture->Destroy();
+    this->dataPtr->colorTexture.reset();
   }
 
   if (!this->ogreCamera || !this->scene->IsInitialized())

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -39,9 +39,6 @@ class gz::rendering::OgreDepthCameraPrivate
   /// \brief Point cloud xyz data buffer
   public: float *pcdBuffer = nullptr;
 
-  /// \brief Point cloud view port
-  public: Ogre::Viewport *pcdViewport = nullptr;
-
   /// \brief Point cloud material
   public: MaterialPtr pcdMaterial = nullptr;
 
@@ -108,6 +105,16 @@ void OgreDepthCamera::Destroy()
   {
     delete [] this->dataPtr->colorBuffer;
     this->dataPtr->colorBuffer = nullptr;
+  }
+
+  if (this->dataPtr->pcdTexture)
+  {
+    this->dataPtr->pcdTexture->RenderTarget()->removeAllViewports();
+  }
+
+  if (this->dataPtr->colorTexture)
+  {
+    this->dataPtr->colorTexture->RenderTarget()->removeAllViewports();
   }
 
   if (!this->ogreCamera || !this->scene->IsInitialized())

--- a/ogre/src/OgreGpuRays.cc
+++ b/ogre/src/OgreGpuRays.cc
@@ -16,7 +16,6 @@
 */
 
 #include <gz/common/Mesh.hh>
-#include <gz/common/MeshManager.hh>
 #include <gz/common/SubMesh.hh>
 
 #include <gz/math/Color.hh>
@@ -201,6 +200,12 @@ void OgreGpuRays::Destroy()
   {
     this->scene->OgreSceneManager()->destroyCamera(this->dataPtr->orthoCam);
     this->dataPtr->orthoCam = nullptr;
+  }
+
+  if (this->dataPtr->undistMesh)
+  {
+    delete this->dataPtr->undistMesh;
+    this->dataPtr->undistMesh = nullptr;
   }
 
   this->dataPtr->visual.reset();
@@ -886,8 +891,6 @@ void OgreGpuRays::CreateMesh()
   mesh->AddSubMesh(*submesh);
 
   this->dataPtr->undistMesh = mesh;
-
-  common::MeshManager::Instance()->AddMesh(this->dataPtr->undistMesh);
 }
 
 /////////////////////////////////////////////////

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -61,10 +61,7 @@ OgreRenderTarget::OgreRenderTarget()
 //////////////////////////////////////////////////
 OgreRenderTarget::~OgreRenderTarget()
 {
-  // TODO(anyone): clean up check null
-
-  OgreRTShaderSystem::Instance()->DetachViewport(this->ogreViewport,
-      this->scene);
+  GZ_ASSERT(this->ogreViewport == nullptr, "Destroy() not called!");
 }
 
 //////////////////////////////////////////////////
@@ -339,6 +336,8 @@ void OgreRenderTexture::DestroyTarget()
   if (nullptr == this->ogreTexture)
     return;
 
+  this->materialApplicator.reset();
+
   OgreRTShaderSystem::Instance()->DetachViewport(this->ogreViewport,
       this->scene);
 
@@ -351,6 +350,7 @@ void OgreRenderTexture::DestroyTarget()
   auto engine = OgreRenderEngine::Instance();
   engine->OgreRoot()->getRenderSystem()->_cleanupDepthBuffers(false);
 
+  this->ogreViewport = nullptr;
   this->ogreTexture = nullptr;
 }
 

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -104,9 +104,6 @@ class gz::rendering::OgreThermalCameraPrivate
   /// \brief Dummy texture
   public: OgreRenderTexturePtr thermalTexture;
 
-  /// \brief Point cloud texture
-  public: OgreRenderTexturePtr colorTexture;
-
   /// \brief Lens distortion compositor
   public: Ogre::CompositorInstance *thermalInstance = nullptr;
 

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -291,6 +291,12 @@ void OgreThermalCamera::Destroy()
     this->dataPtr->thermalImage = nullptr;
   }
 
+  if (this->dataPtr->thermalTexture)
+  {
+    this->dataPtr->thermalTexture->Destroy();
+    this->dataPtr->thermalTexture = nullptr;
+  }
+
   if (!this->ogreCamera || !this->scene->IsInitialized())
     return;
 

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -156,6 +156,12 @@ void OgreWideAngleCamera::Destroy()
     this->dataPtr->wideAngleImage = nullptr;
   }
 
+  if (this->dataPtr->wideAngleTexture)
+  {
+    this->dataPtr->wideAngleTexture->Destroy();
+    this->dataPtr->wideAngleTexture = nullptr;
+  }
+
   for (unsigned int i = 0u; i < this->dataPtr->kEnvCameraCount; ++i)
   {
     if (this->dataPtr->envRenderTargets[i])

--- a/test/common_test/Material_TEST.cc
+++ b/test/common_test/Material_TEST.cc
@@ -27,6 +27,8 @@
 #include "gz/rendering/ShaderType.hh"
 #include "gz/rendering/Scene.hh"
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 using namespace gz;
 using namespace rendering;
 
@@ -332,7 +334,7 @@ TEST_F(MaterialTest, MaterialProperties)
 }
 
 /////////////////////////////////////////////////
-TEST_F(MaterialTest, Copy)
+TEST_F(MaterialTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Copy))
 {
   ScenePtr scene = engine->CreateScene("copy_scene");
   ASSERT_NE(nullptr, scene);

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -1,8 +1,11 @@
 set(TEST_TYPE "REGRESSION")
 
-set(tests
+gz_rendering_test(
+  TYPE ${TEST_TYPE}
+  SOURCE reload_engine
+  LIB_DEPS
+    gz-plugin${GZ_PLUGIN_VER}::loader
+    gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+    ${PROJECT_LIBRARY_TARGET_NAME}
 )
 
-link_directories(${PROJECT_BINARY_DIR}/test)
-
-gz_build_tests(TYPE REGRESSION SOURCES ${tests})

--- a/test/regression/reload_engine.cc
+++ b/test/regression/reload_engine.cc
@@ -210,7 +210,7 @@ TEST_F(ReloadEngineTest, ThermalCamera)
 /////////////////////////////////////////////////
 TEST_F(ReloadEngineTest, WideAngleCamera)
 {
-  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
+  CHECK_SUPPORTED_ENGINE("ogre");
 
   this->Run([](auto engine){
     auto scene = engine->CreateScene("scene");

--- a/test/regression/reload_engine.cc
+++ b/test/regression/reload_engine.cc
@@ -29,10 +29,16 @@
 #include <gz/rendering/ThermalCamera.hh>
 #include <gz/rendering/WideAngleCamera.hh>
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 constexpr auto kNumRetries = 3;
 
+/// \brief Test fixture for reloading engines.
+/// Since the CommonRenderingTest loads an engine by default,
+/// we are doing a custom implementation here.
 class ReloadEngineTest: public ::testing::Test
 {
+  /// \brief Set up the test fixture
   public: void SetUp() override
   {
     gz::common::Console::SetVerbosity(4);
@@ -43,23 +49,28 @@ class ReloadEngineTest: public ::testing::Test
     }
 
     this->engineToTest = envEngine;
-    this->params = GetEngineParams(envEngine, envBackend, envHeadless);
+    this->engineParams = GetEngineParams(envEngine, envBackend, envHeadless);
   }
 
+  /// \brief Load the configured engine and run a series of rendering commands
+  /// \param[in] _exec Function to execute on loaded engine
   public: void Run(std::function<void(gz::rendering::RenderEngine*)> _exec)
   {
     for (size_t ii = 0; ii < kNumRetries; ++ii)
     {
-      auto engine = gz::rendering::engine(this->engineToTest, this->params);
-      _exec(engine);
+      auto engine = gz::rendering::engine(this->engineToTest,
+                                          this->engineParams);
       ASSERT_NE(nullptr, engine);
+      _exec(engine);
       ASSERT_TRUE(gz::rendering::unloadEngine(this->engineToTest));
     }
   }
 
+  /// \brief Engine under test
   protected: std::string engineToTest;
 
-  protected: std::map<std::string, std::string> params;
+  /// \brief Parameters for spawning rendering engine
+  protected: std::map<std::string, std::string> engineParams;
 };
 
 /////////////////////////////////////////////////
@@ -102,7 +113,7 @@ TEST_F(ReloadEngineTest, BoundingBoxCamera)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ReloadEngineTest, Camera)
+TEST_F(ReloadEngineTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Camera))
 {
   this->Run([](auto engine){
     auto scene = engine->CreateScene("scene");
@@ -122,7 +133,7 @@ TEST_F(ReloadEngineTest, Camera)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ReloadEngineTest, DepthCamera)
+TEST_F(ReloadEngineTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(DepthCamera))
 {
   this->Run([](auto engine){
     auto scene = engine->CreateScene("scene");
@@ -142,7 +153,7 @@ TEST_F(ReloadEngineTest, DepthCamera)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ReloadEngineTest, GpuRays)
+TEST_F(ReloadEngineTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(GpuRays))
 {
   this->Run([](auto engine){
     auto scene = engine->CreateScene("scene");
@@ -186,7 +197,7 @@ TEST_F(ReloadEngineTest, SegmentationCamera)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ReloadEngineTest, ThermalCamera)
+TEST_F(ReloadEngineTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ThermalCamera))
 {
   CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
@@ -208,7 +219,7 @@ TEST_F(ReloadEngineTest, ThermalCamera)
 }
 
 /////////////////////////////////////////////////
-TEST_F(ReloadEngineTest, WideAngleCamera)
+TEST_F(ReloadEngineTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(WideAngleCamera))
 {
   CHECK_SUPPORTED_ENGINE("ogre");
 
@@ -228,4 +239,3 @@ TEST_F(ReloadEngineTest, WideAngleCamera)
     engine->DestroyScene(scene);
   });
 }
-

--- a/test/regression/reload_engine.cc
+++ b/test/regression/reload_engine.cc
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2017 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "CommonRenderingTest.hh"
+
+#include <gz/rendering/Scene.hh>
+#include <gz/rendering/Visual.hh>
+#include <gz/rendering/BoundingBoxCamera.hh>
+#include <gz/rendering/Camera.hh>
+#include <gz/rendering/DepthCamera.hh>
+#include <gz/rendering/GpuRays.hh>
+#include <gz/rendering/SegmentationCamera.hh>
+#include <gz/rendering/ThermalCamera.hh>
+#include <gz/rendering/WideAngleCamera.hh>
+
+constexpr auto kNumRetries = 3;
+
+class ReloadEngineTest: public ::testing::Test
+{
+  public: void SetUp() override
+  {
+    gz::common::Console::SetVerbosity(4);
+    auto [envEngine, envBackend, envHeadless] = GetTestParams();
+    if (envEngine.empty())
+    {
+      GTEST_SKIP() << kEngineToTestEnv << " environment not set";
+    }
+
+    this->engineToTest = envEngine;
+    this->params = GetEngineParams(envEngine, envBackend, envHeadless);
+  }
+
+  public: void Run(std::function<void(gz::rendering::RenderEngine*)> _exec)
+  {
+    for (size_t ii = 0; ii < kNumRetries; ++ii)
+    {
+      auto engine = gz::rendering::engine(this->engineToTest, this->params);
+      _exec(engine);
+      ASSERT_NE(nullptr, engine);
+      ASSERT_TRUE(gz::rendering::unloadEngine(this->engineToTest));
+    }
+  }
+
+  protected: std::string engineToTest;
+
+  protected: std::map<std::string, std::string> params;
+};
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, Empty)
+{
+  // Noop test
+  this->Run([](auto){});
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, Scene)
+{
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    engine->DestroyScene(scene);
+  });
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, BoundingBoxCamera)
+{
+  CHECK_SUPPORTED_ENGINE("ogre2");
+
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    auto root = scene->RootVisual();
+    ASSERT_NE(nullptr, root);
+
+    auto camera = scene->CreateBoundingBoxCamera("camera");
+    ASSERT_NE(nullptr, camera);
+    camera->SetImageWidth(500);
+    camera->SetImageHeight(500);
+    root->AddChild(camera);
+
+    camera->Update();
+    engine->DestroyScene(scene);
+  });
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, Camera)
+{
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    auto root = scene->RootVisual();
+    ASSERT_NE(nullptr, root);
+
+    auto camera = scene->CreateCamera("camera");
+    ASSERT_NE(nullptr, camera);
+    camera->SetImageWidth(500);
+    camera->SetImageHeight(500);
+    root->AddChild(camera);
+
+    camera->Update();
+    engine->DestroyScene(scene);
+  });
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, DepthCamera)
+{
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    auto root = scene->RootVisual();
+    ASSERT_NE(nullptr, root);
+
+    auto camera = scene->CreateDepthCamera("camera");
+    ASSERT_NE(nullptr, camera);
+    camera->SetImageWidth(500);
+    camera->SetImageHeight(500);
+    root->AddChild(camera);
+
+    camera->Update();
+    engine->DestroyScene(scene);
+  });
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, GpuRays)
+{
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    auto root = scene->RootVisual();
+    ASSERT_NE(nullptr, root);
+
+    auto gpuRays = scene->CreateGpuRays("gpu_rays");
+    ASSERT_NE(nullptr, gpuRays);
+    gpuRays->SetAngleMin(-1.0);
+    gpuRays->SetAngleMax(1.0);
+    gpuRays->SetRayCount(1000);
+    gpuRays->SetVerticalRayCount(1);
+    root->AddChild(gpuRays);
+
+    gpuRays->Update();
+    engine->DestroyScene(scene);
+  });
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, SegmentationCamera)
+{
+  CHECK_SUPPORTED_ENGINE("ogre2");
+
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    auto root = scene->RootVisual();
+    ASSERT_NE(nullptr, root);
+
+    auto camera = scene->CreateSegmentationCamera("camera");
+    ASSERT_NE(nullptr, camera);
+    camera->SetImageWidth(500);
+    camera->SetImageHeight(500);
+    root->AddChild(camera);
+
+    camera->Update();
+    engine->DestroyScene(scene);
+  });
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, ThermalCamera)
+{
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
+
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    auto root = scene->RootVisual();
+    ASSERT_NE(nullptr, root);
+
+    auto camera = scene->CreateThermalCamera("camera");
+    ASSERT_NE(nullptr, camera);
+    camera->SetImageWidth(500);
+    camera->SetImageHeight(500);
+    root->AddChild(camera);
+
+    camera->Update();
+    engine->DestroyScene(scene);
+  });
+}
+
+/////////////////////////////////////////////////
+TEST_F(ReloadEngineTest, WideAngleCamera)
+{
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
+
+  this->Run([](auto engine){
+    auto scene = engine->CreateScene("scene");
+    ASSERT_NE(nullptr, scene);
+    auto root = scene->RootVisual();
+    ASSERT_NE(nullptr, root);
+
+    auto camera = scene->CreateWideAngleCamera("camera");
+    ASSERT_NE(nullptr, camera);
+    camera->SetImageWidth(500);
+    camera->SetImageHeight(500);
+    root->AddChild(camera);
+
+    camera->Update();
+    engine->DestroyScene(scene);
+  });
+}
+


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Similar to previous crashes we have had, we weren't appropriately cleaning up resources in our rendering objects.

I uncovered this while testing `gz-sensors7`, as it wasn't revealed by tests here.

As a result, I have added a regression test that will attempt to load and unload a rendering engine multiple times while also instantiating sensors.  If everything is cleaned up correctly, this test runs without any segfaults.

A have also included fixes for the DepthCamera and GpuRays sensor that were detected via this test.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
