### PR TITLE
Add necessary headers for Vulkan QML GUI backend

### DIFF
--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,2 +1,3 @@
 libogre-next-dev
 libogre-next-2.3-dev
+libvulkan-dev

--- a/include/gz/rendering/Camera.hh
+++ b/include/gz/rendering/Camera.hh
@@ -79,7 +79,9 @@ namespace gz
 
       /// \brief Set the image pixel format
       /// \param[in] _format New image pixel format
-      public: virtual void SetImageFormat(PixelFormat _format) = 0;
+      /// \param[in] _reinterpretable See RenderTarget::SetFormat
+      public: virtual void SetImageFormat(PixelFormat _format,
+                                          bool _reinterpretable = false) = 0;
 
       /// \brief Get the total image memory size in bytes
       /// \return The image memory size in bytes

--- a/include/gz/rendering/Camera.hh
+++ b/include/gz/rendering/Camera.hh
@@ -332,6 +332,12 @@ namespace gz
       /// \param[out] _textureIdPtr the address of a void* pointer.
       public: virtual void RenderTextureMetalId(void *_textureIdPtr) const = 0;
 
+      /// \brief Right now this is Vulkan-only. This function needs to be
+      /// called after rendering, and before handling the texture pointer
+      /// (i.e. by calling RenderTextureMetalId()) so that external APIs
+      /// (e.g. Qt) can sample the texture.
+      public: virtual void PrepareForExternalSampling() = 0;
+
       /// \brief Add a render pass to the camera
       /// \param[in] _pass New render pass to add
       public: virtual void AddRenderPass(const RenderPassPtr &_pass) = 0;

--- a/include/gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh
+++ b/include/gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_RENDERING_RENDERENGINE_VULKANEXTERNALDEVICESTRUCTS_HH_
+#define GZ_RENDERING_RENDERENGINE_VULKANEXTERNALDEVICESTRUCTS_HH_
+
+#ifndef __APPLE__
+
+#  include <vector>
+#  include "gz/rendering/Export.hh"
+#  include "gz/rendering/config.hh"
+
+#  include "vulkan/vulkan_core.h"
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    /// \brief Structure to encapsulate data needed by OgreNext to init Vulkan
+    /// from Qt.
+    /// Mirrors Ogre::VulkanExternalInstance without depending on OgreNext
+    /// directly.
+    struct GZ_RENDERING_VISIBLE GzVulkanExternalInstance
+    {
+      VkInstance instance;
+      std::vector<VkLayerProperties> instanceLayers;
+      std::vector<VkExtensionProperties> instanceExtensions;
+    };
+
+    /// \brief Structure to encapsulate data needed by OgreNext to init Vulkan
+    /// from Qt.
+    /// Mirrors Ogre::VulkanExternalDevice without depending on OgreNext
+    /// directly.
+    struct GZ_RENDERING_VISIBLE GzVulkanExternalDevice
+    {
+      VkPhysicalDevice physicalDevice;
+      VkDevice device;
+      std::vector<VkExtensionProperties> deviceExtensions;
+      VkQueue graphicsQueue;
+      VkQueue presentQueue;
+    };
+  }
+  }
+}
+
+#endif
+#endif

--- a/include/gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh
+++ b/include/gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh
@@ -19,11 +19,11 @@
 
 #ifndef __APPLE__
 
-#  include <vector>
-#  include "gz/rendering/Export.hh"
-#  include "gz/rendering/config.hh"
+#include <vector>
+#include "gz/rendering/Export.hh"
+#include "gz/rendering/config.hh"
 
-#  include "vulkan/vulkan_core.h"
+#include "vulkan/vulkan_core.h"
 
 namespace gz
 {

--- a/include/gz/rendering/RenderTarget.hh
+++ b/include/gz/rendering/RenderTarget.hh
@@ -62,7 +62,15 @@ namespace gz
 
       /// \brief Set the render target image format
       /// \param[in] _format New target format
-      public: virtual void SetFormat(PixelFormat _format) = 0;
+      /// \param[in] _reinterpretable whether the RenderTarget will be
+      /// reinterpreted to another format (e.g.
+      /// from RGBA8_UNORM to/from RGBA8_UNORM_SRGB)
+      public: virtual void SetFormat(PixelFormat _format,
+                                     bool _reinterpretable = false) = 0;
+
+      /// \brief See SetFormat()
+      /// \return True if format is reinterpretable
+      public: virtual bool Reinterpretable() const = 0;
 
       /// \brief Write rendered image to given Image. The RenderTarget will
       /// convert the underlying image to the specified format listed in the

--- a/include/gz/rendering/base/BaseCamera.hh
+++ b/include/gz/rendering/base/BaseCamera.hh
@@ -187,6 +187,9 @@ namespace gz
           const override;
 
       // Documentation inherited.
+      public: virtual void PrepareForExternalSampling() override;
+
+      // Documentation inherited.
       public: virtual void AddRenderPass(const RenderPassPtr &_pass) override;
 
       // Documentation inherited.
@@ -840,6 +843,14 @@ namespace gz
     void BaseCamera<T>::RenderTextureMetalId(void *) const
     {
       gzerr << "RenderTextureMetalId is not supported by current render"
+          << " engine" << std::endl;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseCamera<T>::PrepareForExternalSampling()
+    {
+      gzerr << "PrepareForExternalSampling is not supported by current render"
           << " engine" << std::endl;
     }
 

--- a/include/gz/rendering/base/BaseCamera.hh
+++ b/include/gz/rendering/base/BaseCamera.hh
@@ -61,7 +61,9 @@ namespace gz
 
       public: virtual unsigned int ImageMemorySize() const override;
 
-      public: virtual void SetImageFormat(PixelFormat _format) override;
+      public: virtual void SetImageFormat(PixelFormat _format,
+                                          bool _reinterpretable = false)
+          override;
 
       public: virtual math::Angle HFOV() const override;
 
@@ -335,9 +337,10 @@ namespace gz
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseCamera<T>::SetImageFormat(PixelFormat _format)
+    void BaseCamera<T>::SetImageFormat(PixelFormat _format,
+                                       bool _reinterpretable)
     {
-      this->RenderTarget()->SetFormat(_format);
+      this->RenderTarget()->SetFormat(_format, _reinterpretable);
     }
 
     //////////////////////////////////////////////////

--- a/include/gz/rendering/base/BaseRenderTarget.hh
+++ b/include/gz/rendering/base/BaseRenderTarget.hh
@@ -56,7 +56,11 @@ namespace gz
 
       public: virtual PixelFormat Format() const override;
 
-      public: virtual void SetFormat(PixelFormat _format) override;
+      public: virtual void SetFormat(PixelFormat _format,
+                                     bool _reinterpretable = false) override;
+
+      // Documentation inherited
+      public: virtual bool Reinterpretable() const override;
 
       // Documentation inherited
       public: virtual math::Color BackgroundColor() const override;
@@ -80,6 +84,8 @@ namespace gz
       protected: virtual void RebuildImpl() = 0;
 
       protected: PixelFormat format = PF_UNKNOWN;
+
+      protected: bool reinterpretable = false;
 
       protected: bool targetDirty = true;
 
@@ -218,10 +224,19 @@ namespace gz
 
     //////////////////////////////////////////////////
     template <class T>
-    void BaseRenderTarget<T>::SetFormat(PixelFormat _format)
+    void BaseRenderTarget<T>::SetFormat(PixelFormat _format,
+                                        bool _reinterpretable)
     {
       this->format = PixelUtil::Sanitize(_format);
+      this->reinterpretable = _reinterpretable;
       this->targetDirty = true;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    bool BaseRenderTarget<T>::Reinterpretable() const
+    {
+      return this->reinterpretable;
     }
 
     //////////////////////////////////////////////////

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
@@ -127,6 +127,9 @@ namespace gz
           const override;
 
       // Documentation inherited.
+      public: virtual void PrepareForExternalSampling() override;
+
+      // Documentation inherited.
       public: void SetShadowsDirty() override;
 
       // Documentation inherited.

--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderTarget.hh
@@ -139,6 +139,9 @@ namespace gz
       // Documentation inherited
       public: void MetalIdImpl(void *_textureIdPtr) const;
 
+      /// \brief See Camera::PrepareForExternalSampling
+      public: void PrepareForExternalSampling();
+
       /// \brief Destroy the render texture
       protected: void DestroyTargetImpl();
 

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -231,6 +231,14 @@ void Ogre2Camera::RenderTextureMetalId(void *_textureIdPtr) const
 }
 
 //////////////////////////////////////////////////
+void Ogre2Camera::PrepareForExternalSampling()
+{
+  if (!this->renderTexture)
+    return;
+  this->renderTexture->PrepareForExternalSampling();
+}
+
+//////////////////////////////////////////////////
 void Ogre2Camera::SetShadowsDirty()
 {
   this->SetShadowsNodeDefDirty();

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -48,7 +48,7 @@
 #  endif
 // Needed headers to receive an external Vulkan device from Qt
 // and inject it into OgreNext
-#  include "OGRE/RenderSystems/Vulkan/OgreVulkanDevice.h"
+#  include "RenderSystems/Vulkan/OgreVulkanDevice.h"
 #  include "gz/rendering/RenderEngineVulkanExternalDeviceStructs.hh"
 #endif
 #include "Ogre2GzHlmsSphericalClipMinDistance.hh"

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -39,6 +39,7 @@
 #include "Ogre2GzHlmsUnlitPrivate.hh"
 
 #ifdef OGRE_BUILD_RENDERSYSTEM_VULKAN
+#  include "vulkan/vulkan_core.h"
 // Deal with old vulkan headers causing build errors
 #  ifndef VK_NV_device_generated_commands
 #    define VK_ACCESS_COMMAND_PREPROCESS_READ_BIT_NV 0x00020000

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -518,13 +518,20 @@ void Ogre2RenderTarget::BuildTargetImpl()
   Ogre::TextureGpuManager *textureMgr =
       ogreRoot->getRenderSystem()->getTextureGpuManager();
 
+  uint32_t textureFlags = Ogre::TextureFlags::RenderToTexture;
+
+  if (this->reinterpretable)
+  {
+    textureFlags |= Ogre::TextureFlags::Reinterpretable;
+  }
+
   for (size_t i = 0u; i < 2u; ++i)
   {
     this->dataPtr->ogreTexture[i] =
         textureMgr->createTexture(
           this->name + std::to_string(i),
           Ogre::GpuPageOutStrategy::Discard,
-          Ogre::TextureFlags::RenderToTexture,
+          textureFlags,
           Ogre::TextureTypes::Type2D);
 
     this->dataPtr->ogreTexture[i]->setResolution(this->width, this->height);


### PR DESCRIPTION
# 🎉 New feature

No ticket is associated with this feature.

## Order in which PRs must be merged

1. This PR.
2. gazebosim/gz-gui#357
    - or optionally, merge this one as part of the next one aka PR 467, which includes it
3. gazebosim/gz-gui#467
4. gazebosim/gz-sim#1735

## Summary

The GUI component needs to send the Vulkan device to Rendering component, which in turns sends it to OgreNext. There were various possible solutions:

1. gz-gui gets linked against OgreNext
2. gz-rendering gets linked against Qt
3. The solution in this PR, where a few structs are added to get passed around and perform Qt -> OgreNext conversions while both components are reasonably isolated from each other.

This PR adds the following structs:

 - `GzVulkanExternalInstance` (mirrors `Ogre::VulkanExternalInstance` without depending on OgreNext)
 - `GzVulkanExternalDevice` (mirrors `Ogre::VulkanExternalDevice` without depending on OgreNext)

These structs are filled by gz-gui and passed to gz-rendering via "external_instance" and "external_device".

The new code is guarded using `#ifdef OGRE_BUILD_RENDERSYSTEM_VULKAN` because if OgreNext wasn't built with Vulkan support, then it is extremely likely the Vulkan SDK isn't present (i.e. Apple systems) which means including RenderEngineVulkanExternalDeviceStructs.hh will cause errors.

## Test it

To test this code we need gazebosim/gz-gui#467 however we could add test coverage by creating a Vulkan Device in a test and testing this interface.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
