### PR TITLE
Backport from 6 :arrow_right: 3 - Disable C4275 warnings on Windows from OgreUTFString (#621)

### DIFF
--- a/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
@@ -22,6 +22,8 @@
   #pragma GCC system_header
 #else
   #pragma warning(push, 0)
+  #pragma warning(disable:4275)
+  #pragma warning(disable:4005)
 #endif
 
 // This prevents some deprecation #warning messages on OSX 10.9

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -20,6 +20,8 @@
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 #else
 # pragma warning(push, 0)
+# pragma warning(disable: 4005)
+# pragma warning(disable: 4275)
 #endif
 // leave this out of OgreIncludes as it conflicts with other files requiring
 // gl.h

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -123,7 +123,7 @@ void Ogre2RenderEngine::Destroy()
   delete this->ogreLogManager;
   this->ogreLogManager = nullptr;
 
-#if not (__APPLE__ || _WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   if (this->dummyDisplay)
   {
     Display *x11Display = static_cast<Display*>(this->dummyDisplay);
@@ -328,7 +328,7 @@ void Ogre2RenderEngine::CreateLogger()
 //////////////////////////////////////////////////
 void Ogre2RenderEngine::CreateContext()
 {
-#if not (__APPLE__ || _WIN32)
+#if !defined(__APPLE__) && !defined(_WIN32)
   // create X11 display
   this->dummyDisplay = XOpenDisplay(0);
   Display *x11Display = static_cast<Display*>(this->dummyDisplay);

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -764,9 +764,16 @@ void Ogre2RenderTarget::RebuildMaterial()
 //////////////////////////////////////////////////
 // Ogre2RenderTexture
 //////////////////////////////////////////////////
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 Ogre2RenderTexture::Ogre2RenderTexture()
 {
 }
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
 
 //////////////////////////////////////////////////
 Ogre2RenderTexture::~Ogre2RenderTexture()


### PR DESCRIPTION
Backports #617 

Reference issue: https://github.com/gazebosim/gz-rendering/issues/621

Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# ➡️ Backport

Port 6 to 3

Branch comparison: https://github.com/gazebosim/gz-rendering/compare/ign-rendering3...Crola1702:Crola1702/6_to_3-2022_08_16

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
