### PR TITLE
Provide a Virtual Method Anchor for Classes in Headers 

### DIFF
--- a/include/gz/rendering/ArrowVisual.hh
+++ b/include/gz/rendering/ArrowVisual.hh
@@ -32,7 +32,7 @@ namespace gz
       public virtual CompositeVisual
     {
       /// \brief Destructor
-      public: virtual ~ArrowVisual() { }
+      public: virtual ~ArrowVisual();
 
       /// \brief Get arrow-head visual
       /// \return The arrow-head visual

--- a/include/gz/rendering/AxisVisual.hh
+++ b/include/gz/rendering/AxisVisual.hh
@@ -32,7 +32,7 @@ namespace gz
       public virtual CompositeVisual
     {
       /// \brief Destructor
-      public: virtual ~AxisVisual() { }
+      public: virtual ~AxisVisual();
 
       /// \brief set true to show the axis heads, false otherwise
       /// \param[in] _b true to show the axis heads, false otherwise

--- a/include/gz/rendering/BoundingBoxCamera.hh
+++ b/include/gz/rendering/BoundingBoxCamera.hh
@@ -55,7 +55,7 @@ namespace gz
       public virtual Camera
     {
       /// \brief Destructor
-      public: virtual ~BoundingBoxCamera() { }
+      public: virtual ~BoundingBoxCamera();
 
       /// \brief Get the BoundingBox data
       /// \return Buffer of bounding boxes info (label, minX, minY, maxX, maxY).

--- a/include/gz/rendering/COMVisual.hh
+++ b/include/gz/rendering/COMVisual.hh
@@ -37,7 +37,7 @@ namespace gz
       public virtual Visual
     {
       /// \brief Destructor
-      public: virtual ~COMVisual() {}
+      public: virtual ~COMVisual();
 
       /// \brief Set the inertial component of the visual
       /// \param[in] _inertial Inertial component of the visual

--- a/include/gz/rendering/Camera.hh
+++ b/include/gz/rendering/Camera.hh
@@ -54,7 +54,7 @@ namespace gz
           unsigned int, unsigned int, const std::string&)> NewFrameListener;
 
       /// \brief Destructor
-      public: virtual ~Camera() { }
+      public: virtual ~Camera();
 
       /// \brief Get the image width in pixels
       /// \return The image width in pixels

--- a/include/gz/rendering/Capsule.hh
+++ b/include/gz/rendering/Capsule.hh
@@ -19,6 +19,7 @@
 #define GZ_RENDERING_CAPSULE_HH_
 
 #include "gz/rendering/config.hh"
+#include "gz/rendering/Export.hh"
 #include "gz/rendering/Geometry.hh"
 #include "gz/rendering/Object.hh"
 
@@ -33,7 +34,7 @@ namespace gz
       public virtual Geometry
     {
       /// \brief Destructor
-      public: virtual ~Capsule() { }
+      public: virtual ~Capsule();
 
       /// \brief Set the radius of the capsule
       public: virtual void SetRadius(double _radius) = 0;

--- a/include/gz/rendering/CompositeVisual.hh
+++ b/include/gz/rendering/CompositeVisual.hh
@@ -33,7 +33,7 @@ namespace gz
       public virtual Visual
     {
       /// \brief Destructor
-      public: virtual ~CompositeVisual() { }
+      public: virtual ~CompositeVisual();
     };
     }
   }

--- a/include/gz/rendering/DepthCamera.hh
+++ b/include/gz/rendering/DepthCamera.hh
@@ -39,7 +39,7 @@ namespace gz
           unsigned int, unsigned int, const std::string&)> NewFrameListener;
 
       /// \brief Destructor
-      public: virtual ~DepthCamera() { }
+      public: virtual ~DepthCamera();
 
       /// \brief Create a texture which will hold the depth data
       public: virtual void CreateDepthTexture() = 0;

--- a/include/gz/rendering/Geometry.hh
+++ b/include/gz/rendering/Geometry.hh
@@ -36,7 +36,7 @@ namespace gz
       public virtual Object
     {
       /// \brief Destructor
-      public: virtual ~Geometry() { }
+      public: virtual ~Geometry();
 
       /// \brief Determine if this Geometry is attached to a Visual
       /// \return True if this Geometry has a parent Visual

--- a/include/gz/rendering/GizmoVisual.hh
+++ b/include/gz/rendering/GizmoVisual.hh
@@ -35,7 +35,7 @@ namespace gz
       public virtual CompositeVisual
     {
       /// \brief Destructor
-      public: virtual ~GizmoVisual() { }
+      public: virtual ~GizmoVisual();
 
       /// \brief Set the transform mode of the gizmo. This controls the visual
       /// appearance of the gizmo. Only the visuals in the specified mode will

--- a/include/gz/rendering/GpuRays.hh
+++ b/include/gz/rendering/GpuRays.hh
@@ -42,7 +42,7 @@ namespace gz
           unsigned int, unsigned int, const std::string&)> NewFrameListener;
 
       /// \brief Destructor
-      public: virtual ~GpuRays() { }
+      public: virtual ~GpuRays();
 
       /// \brief All things needed to get back z buffer for gpu rays data.
       /// \return Array of gpu rays data.

--- a/include/gz/rendering/Grid.hh
+++ b/include/gz/rendering/Grid.hh
@@ -35,7 +35,7 @@ namespace gz
       public virtual Geometry
     {
       /// \brief Destructor
-      public: virtual ~Grid() = 0;
+      public: virtual ~Grid();
 
       /// \brief Set the number of cells on a planar grid
       /// \param[in] _count The number of cells

--- a/include/gz/rendering/Grid.hh
+++ b/include/gz/rendering/Grid.hh
@@ -35,7 +35,7 @@ namespace gz
       public virtual Geometry
     {
       /// \brief Destructor
-      public: virtual ~Grid() { }
+      public: virtual ~Grid() = 0;
 
       /// \brief Set the number of cells on a planar grid
       /// \param[in] _count The number of cells

--- a/include/gz/rendering/InertiaVisual.hh
+++ b/include/gz/rendering/InertiaVisual.hh
@@ -36,7 +36,7 @@ namespace gz
       public virtual Visual
     {
       /// \brief Destructor
-      public: virtual ~InertiaVisual() {}
+      public: virtual ~InertiaVisual();
 
       /// \brief Set the inertial component of the visual
       /// \param[in] _inertial Inertial component of the visual

--- a/include/gz/rendering/JointVisual.hh
+++ b/include/gz/rendering/JointVisual.hh
@@ -70,7 +70,7 @@ namespace gz
       public virtual Visual
     {
       /// \brief Destructor
-      public: virtual ~JointVisual() {}
+      public: virtual ~JointVisual();
 
       /// \brief Create an axis and attach it to the joint visual.
       /// \param[in] _axis Axis vector.

--- a/include/gz/rendering/Light.hh
+++ b/include/gz/rendering/Light.hh
@@ -33,7 +33,7 @@ namespace gz
       public virtual Node
     {
       /// \brief Destructor
-      public: virtual ~Light() { }
+      public: virtual ~Light();
 
       /// \brief Get the diffuse color
       /// \return The diffuse color
@@ -122,7 +122,7 @@ namespace gz
       public virtual Light
     {
       /// \brief Destructor
-      public: virtual ~DirectionalLight() { }
+      public: virtual ~DirectionalLight();
 
       /// \brief Get the direction of the light
       /// \return The direction of the light
@@ -145,7 +145,7 @@ namespace gz
       public virtual Light
     {
       /// \brief Destructor
-      public: virtual ~PointLight() { }
+      public: virtual ~PointLight();
     };
 
     /// \class SpotLight Light.hh gz/rendering/Light.hh
@@ -154,7 +154,7 @@ namespace gz
       public virtual Light
     {
       /// \brief Destructor
-      public: virtual ~SpotLight() { }
+      public: virtual ~SpotLight();
 
       /// \brief Get direction of the light
       /// \return The direction of the light

--- a/include/gz/rendering/LightVisual.hh
+++ b/include/gz/rendering/LightVisual.hh
@@ -50,7 +50,7 @@ namespace gz
       public virtual Visual
     {
       /// \brief Descructor
-      public: virtual ~LightVisual() {}
+      public: virtual ~LightVisual();
 
       /// \brief set type of the light
       /// \param[in] _type type of the light

--- a/include/gz/rendering/Material.hh
+++ b/include/gz/rendering/Material.hh
@@ -49,7 +49,7 @@ namespace gz
       public virtual Object
     {
       /// \brief Destructor
-      public: virtual ~Material() { }
+      public: virtual ~Material();
 
       /// \brief Determine if lighting affects this material
       /// \return True if lighting affects this material

--- a/include/gz/rendering/Mesh.hh
+++ b/include/gz/rendering/Mesh.hh
@@ -38,7 +38,7 @@ namespace gz
       public virtual Geometry
     {
       /// \brief Destructor
-      public: virtual ~Mesh() { }
+      public: virtual ~Mesh();
 
       /// \brief Check whether the mesh has skeleton
       /// \return True if the mesh has skeleton
@@ -136,7 +136,7 @@ namespace gz
       public virtual Object
     {
       /// \brief Destructor
-      public: virtual ~SubMesh() { }
+      public: virtual ~SubMesh();
 
       /// \brief Get the currently assigned material
       /// \return The currently assigned material

--- a/include/gz/rendering/Node.hh
+++ b/include/gz/rendering/Node.hh
@@ -52,7 +52,7 @@ namespace gz
       public virtual Object
     {
       /// \brief Destructor
-      public: virtual ~Node() { }
+      public: virtual ~Node();
 
       /// \brief Determine if this Node is attached to another Node.
       /// \return True if this Node has a parent Node

--- a/include/gz/rendering/Object.hh
+++ b/include/gz/rendering/Object.hh
@@ -34,7 +34,7 @@ namespace gz
     class GZ_RENDERING_VISIBLE Object
     {
       /// \brief Destructor
-      public: virtual ~Object() { }
+      public: virtual ~Object();
 
       /// \brief Get the object ID. This ID will be unique across all objects
       /// inside a given scene, but necessarily true for objects across

--- a/include/gz/rendering/ParticleEmitter.hh
+++ b/include/gz/rendering/ParticleEmitter.hh
@@ -59,7 +59,7 @@ namespace gz
       public virtual Visual
     {
       /// \brief Destructor
-      public: virtual ~ParticleEmitter() {}
+      public: virtual ~ParticleEmitter();
 
       /// \brief \brief Get the emitter type.
       /// \return Emitter type.

--- a/include/gz/rendering/RayQuery.hh
+++ b/include/gz/rendering/RayQuery.hh
@@ -64,7 +64,7 @@ namespace gz
         : public virtual Object
     {
       /// \brief Destructor
-      public: virtual ~RayQuery() { }
+      public: virtual ~RayQuery();
 
       /// \brief Set ray origin
       /// \param[in] _origin Ray origin

--- a/include/gz/rendering/RenderEngine.hh
+++ b/include/gz/rendering/RenderEngine.hh
@@ -37,7 +37,7 @@ namespace gz
     class GZ_RENDERING_VISIBLE RenderEngine
     {
       /// \brief Destructor
-      public: virtual ~RenderEngine() { }
+      public: virtual ~RenderEngine();
 
       /// \brief Load any necessary resources to set up render-engine. This
       /// should called before any other function.

--- a/include/gz/rendering/RenderPass.hh
+++ b/include/gz/rendering/RenderPass.hh
@@ -35,7 +35,7 @@ namespace gz
       : public virtual Object
     {
       /// \brief Destructor
-      public: virtual ~RenderPass() { }
+      public: virtual ~RenderPass();
 
       /// \brief Set to enable or disable the render pass
       /// \param[in] _enabled True to enable the render pass, false to disable.

--- a/include/gz/rendering/RenderTarget.hh
+++ b/include/gz/rendering/RenderTarget.hh
@@ -38,7 +38,7 @@ namespace gz
       public virtual Object
     {
       /// \brief Destructor
-      public: virtual ~RenderTarget() { }
+      public: virtual ~RenderTarget();
 
       /// \brief Get render target width in pixels
       /// \return The render target width in pixels
@@ -104,7 +104,7 @@ namespace gz
       public virtual RenderTarget
     {
       /// \brief Destructor
-      public: virtual ~RenderTexture() { }
+      public: virtual ~RenderTexture();
 
       /// \brief Returns the OpenGL texture Id. A valid Id is returned only
       // if this is an OpenGL render texture
@@ -127,7 +127,7 @@ namespace gz
       public virtual RenderTarget
     {
       /// \brief Destructor
-      public: virtual ~RenderWindow() { }
+      public: virtual ~RenderWindow();
 
       /// \brief Get the window handle that the render window is attached to.
       /// \return Window handle

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -48,7 +48,7 @@ namespace gz
     class GZ_RENDERING_VISIBLE Scene
     {
       /// \brief Destructor
-      public: virtual ~Scene() { }
+      public: virtual ~Scene();
 
       /// \brief Load scene-specific resources
       public: virtual void Load() = 0;

--- a/include/gz/rendering/SegmentationCamera.hh
+++ b/include/gz/rendering/SegmentationCamera.hh
@@ -52,7 +52,7 @@ namespace gz
       public virtual Camera
     {
       /// \brief Destructor
-      public: virtual ~SegmentationCamera() { }
+      public: virtual ~SegmentationCamera();
 
       /// \brief Create a texture which will hold the segmentation data
       public: virtual void CreateSegmentationTexture() = 0;

--- a/include/gz/rendering/Sensor.hh
+++ b/include/gz/rendering/Sensor.hh
@@ -33,7 +33,7 @@ namespace gz
       public virtual Node
     {
       /// \brief Sensor
-      public: virtual ~Sensor() { }
+      public: virtual ~Sensor();
 
       /// \brief Set visibility mask
       /// \param[in] _mask Visibility mask

--- a/include/gz/rendering/Storage.hh
+++ b/include/gz/rendering/Storage.hh
@@ -57,7 +57,7 @@ namespace gz
       typedef std::shared_ptr<const T> ConstTPtr;
 
       /// \brief Destructor
-      public: virtual ~Map() { }
+      public: virtual ~Map() = default;
 
       /// \brief Get the number of elements in this map
       /// \return The number of elements in this map
@@ -122,7 +122,7 @@ namespace gz
       typedef std::shared_ptr<const T> ConstTPtr;
 
       /// \brief Destructor
-      public: virtual ~Store() { }
+      public: virtual ~Store() = default;
 
       /// \brief Get number of elements in this store
       /// \return The number of elements in this store
@@ -244,7 +244,7 @@ namespace gz
       typedef std::shared_ptr<const TStore> ConstTStorePtr;
 
       /// \brief Destructor
-      public: virtual ~CompositeStore() { }
+      public: virtual ~CompositeStore() = default;
 
       /// \brief Get number of Stores
       /// \return The number of Stores
@@ -291,7 +291,7 @@ namespace gz
     class GZ_RENDERING_VISIBLE StoreWrapper :
       public Store<T>
     {
-      public: virtual ~StoreWrapper() { }
+      public: virtual ~StoreWrapper() = default;
     };
 
 // armhf failed to build with this code. It can not be removed for the rest

--- a/include/gz/rendering/Text.hh
+++ b/include/gz/rendering/Text.hh
@@ -66,7 +66,7 @@ namespace gz
       public: Text() = default;
 
       /// \brief Destructor
-      public: virtual ~Text() = default;
+      public: virtual ~Text();
 
       /// \brief Set the font.
       /// \param[in] _font Name of the font

--- a/include/gz/rendering/ThermalCamera.hh
+++ b/include/gz/rendering/ThermalCamera.hh
@@ -41,7 +41,7 @@ namespace gz
       public virtual Camera
     {
       /// \brief Destructor
-      public: virtual ~ThermalCamera() { }
+      public: virtual ~ThermalCamera();
 
       /// \brief Set the ambient temperature of the environment
       /// \param[in] _ambient Ambient temperature in kelvin

--- a/include/gz/rendering/ViewController.hh
+++ b/include/gz/rendering/ViewController.hh
@@ -35,7 +35,7 @@ namespace gz
     class GZ_RENDERING_VISIBLE ViewController
     {
       /// \brief Destructor
-      public: virtual ~ViewController() { }
+      public: virtual ~ViewController();
 
       /// \brief Set the camera that will be controlled by this view controller.
       /// \param[in] _camera Camera to control

--- a/include/gz/rendering/Visual.hh
+++ b/include/gz/rendering/Visual.hh
@@ -34,7 +34,7 @@ namespace gz
       public virtual Node
     {
       /// \brief Destructor
-      public: virtual ~Visual() { }
+      public: virtual ~Visual();
 
       /// \brief Get the number of geometries attached to this visual
       /// \return The number of geometries attached to this visual

--- a/include/gz/rendering/WideAngleCamera.hh
+++ b/include/gz/rendering/WideAngleCamera.hh
@@ -38,7 +38,7 @@ namespace gz
       public virtual Camera
     {
       /// \brief Destructor
-      public: virtual ~WideAngleCamera() { }
+      public: virtual ~WideAngleCamera();
 
       /// \brief Set the camera lens to use for this wide angle camera
       /// \param[in] _lens Camera lens to set

--- a/src/ArrowVisual.cc
+++ b/src/ArrowVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/ArrowVisual.hh"
+
+namespace gz::rendering
+{
+
+ArrowVisual::~ArrowVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/AxisVisual.cc
+++ b/src/AxisVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/AxisVisual.hh"
+
+namespace gz::rendering
+{
+
+AxisVisual::~AxisVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/BoundingBox.cc
+++ b/src/BoundingBox.cc
@@ -91,9 +91,7 @@ BoundingBox::BoundingBox() :
 }
 
 /////////////////////////////////////////////////
-BoundingBox::~BoundingBox()
-{
-}
+BoundingBox::~BoundingBox() = default;
 
 //////////////////////////////////////////////////
 BoundingBox::BoundingBox(const BoundingBox &_box)

--- a/src/BoundingBoxCamera.cc
+++ b/src/BoundingBoxCamera.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/BoundingBoxCamera.hh"
+
+namespace gz::rendering
+{
+
+BoundingBoxCamera::~BoundingBoxCamera() = default;
+
+}  // namespace gz::rendering

--- a/src/COMVisual.cc
+++ b/src/COMVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/COMVisual.hh"
+
+namespace gz::rendering
+{
+
+COMVisual::~COMVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/Camera.cc
+++ b/src/Camera.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Camera.hh"
+
+namespace gz::rendering
+{
+
+Camera::~Camera() = default;
+
+}  // namespace gz::rendering

--- a/src/CameraLens.cc
+++ b/src/CameraLens.cc
@@ -156,9 +156,7 @@ CameraLens::CameraLens(const CameraLens &_other)
 }
 
 //////////////////////////////////////////////////
-CameraLens::~CameraLens()
-{
-}
+CameraLens::~CameraLens() = default;
 
 //////////////////////////////////////////////////
 CameraLens &CameraLens::operator=(const CameraLens &_other)

--- a/src/Capsule.cc
+++ b/src/Capsule.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Capsule.hh"
+
+namespace gz::rendering
+{
+
+Capsule::~Capsule() = default;
+
+}  // namespace gz::rendering

--- a/src/CompositeVisual.cc
+++ b/src/CompositeVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/CompositeVisual.hh"
+
+namespace gz::rendering
+{
+
+CompositeVisual::~CompositeVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/DepthCamera.cc
+++ b/src/DepthCamera.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/DepthCamera.hh"
+
+namespace gz::rendering
+{
+
+DepthCamera::~DepthCamera() = default;
+
+}  // namespace gz::rendering

--- a/src/DistortionPass.cc
+++ b/src/DistortionPass.cc
@@ -21,11 +21,7 @@ using namespace gz;
 using namespace rendering;
 
 //////////////////////////////////////////////////
-DistortionPass::DistortionPass()
-{
-}
+DistortionPass::DistortionPass() = default;
 
 //////////////////////////////////////////////////
-DistortionPass::~DistortionPass()
-{
-}
+DistortionPass::~DistortionPass() = default;

--- a/src/GaussianNoisePass.cc
+++ b/src/GaussianNoisePass.cc
@@ -22,11 +22,7 @@ using namespace gz;
 using namespace rendering;
 
 //////////////////////////////////////////////////
-GaussianNoisePass::GaussianNoisePass()
-{
-}
+GaussianNoisePass::GaussianNoisePass() = default;
 
 //////////////////////////////////////////////////
-GaussianNoisePass::~GaussianNoisePass()
-{
-}
+GaussianNoisePass::~GaussianNoisePass() = default;

--- a/src/Geometry.cc
+++ b/src/Geometry.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Geometry.hh"
+
+namespace gz::rendering
+{
+
+Geometry::~Geometry() = default;
+
+}  // namespace gz::rendering

--- a/src/GizmoVisual.cc
+++ b/src/GizmoVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/GizmoVisual.hh"
+
+namespace gz::rendering
+{
+
+GizmoVisual::~GizmoVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/GpuRays.cc
+++ b/src/GpuRays.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/GpuRays.hh"
+
+namespace gz::rendering
+{
+
+GpuRays::~GpuRays() = default;
+
+}  // namespace gz::rendering

--- a/src/Grid.cc
+++ b/src/Grid.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Grid.hh"
+
+namespace gz::rendering
+{
+
+Grid::~Grid() = default;
+
+}  // namespace gz::rendering

--- a/src/HeightmapDescriptor.cc
+++ b/src/HeightmapDescriptor.cc
@@ -80,9 +80,7 @@ HeightmapTexture::HeightmapTexture() :
 }
 
 /////////////////////////////////////////////////
-HeightmapTexture::~HeightmapTexture()
-{
-}
+HeightmapTexture::~HeightmapTexture() = default;
 
 //////////////////////////////////////////////////
 HeightmapTexture::HeightmapTexture(const HeightmapTexture &_texture)
@@ -154,9 +152,7 @@ HeightmapBlend::HeightmapBlend() :
 
 
 /////////////////////////////////////////////////
-HeightmapBlend::~HeightmapBlend()
-{
-}
+HeightmapBlend::~HeightmapBlend() = default;
 
 //////////////////////////////////////////////////
 HeightmapBlend::HeightmapBlend(const HeightmapBlend &_blend)

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -41,9 +41,7 @@ Image::Image(unsigned int _width, unsigned int _height,
 }
 
 //////////////////////////////////////////////////
-Image::~Image()
-{
-}
+Image::~Image() = default;
 
 //////////////////////////////////////////////////
 unsigned int Image::Width() const

--- a/src/InertiaVisual.cc
+++ b/src/InertiaVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/InertiaVisual.hh"
+
+namespace gz::rendering
+{
+
+InertiaVisual::~InertiaVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/JointVisual.cc
+++ b/src/JointVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/JointVisual.hh"
+
+namespace gz::rendering
+{
+
+JointVisual::~JointVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/LidarVisual.cc
+++ b/src/LidarVisual.cc
@@ -22,11 +22,7 @@ using namespace gz;
 using namespace rendering;
 
 //////////////////////////////////////////////////
-LidarVisual::LidarVisual()
-{
-}
+LidarVisual::LidarVisual() = default;
 
 //////////////////////////////////////////////////
-LidarVisual::~LidarVisual()
-{
-}
+LidarVisual::~LidarVisual() = default;

--- a/src/Light.cc
+++ b/src/Light.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Light.hh"
+
+namespace gz::rendering
+{
+
+Light::~Light() = default;
+
+DirectionalLight::~DirectionalLight() = default;
+
+PointLight::~PointLight() = default;
+
+SpotLight::~SpotLight() = default;
+
+}  // namespace gz::rendering

--- a/src/LightVisual.cc
+++ b/src/LightVisual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/LightVisual.hh"
+
+namespace gz::rendering
+{
+
+LightVisual::~LightVisual() = default;
+
+}  // namespace gz::rendering

--- a/src/Marker.cc
+++ b/src/Marker.cc
@@ -22,11 +22,7 @@ using namespace gz;
 using namespace rendering;
 
 //////////////////////////////////////////////////
-Marker::Marker()
-{
-}
+Marker::Marker() = default;
 
 //////////////////////////////////////////////////
-Marker::~Marker()
-{
-}
+Marker::~Marker() = default;

--- a/src/Material.cc
+++ b/src/Material.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Material.hh"
+
+namespace gz::rendering
+{
+
+Material::~Material() = default;
+
+}  // namespace gz::rendering

--- a/src/Mesh.cc
+++ b/src/Mesh.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Mesh.hh"
+
+namespace gz::rendering
+{
+
+Mesh::~Mesh() = default;
+
+SubMesh::~SubMesh() = default;
+
+}  // namespace gz::rendering
+

--- a/src/MeshDescriptor.cc
+++ b/src/MeshDescriptor.cc
@@ -25,9 +25,7 @@ using namespace gz;
 using namespace rendering;
 
 //////////////////////////////////////////////////
-MeshDescriptor::MeshDescriptor()
-{
-}
+MeshDescriptor::MeshDescriptor() = default;
 
 //////////////////////////////////////////////////
 MeshDescriptor::MeshDescriptor(const std::string &_meshName) :

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Node.hh"
+
+namespace gz::rendering
+{
+
+Node::~Node() = default;
+
+}  // namespace gz::rendering

--- a/src/Object.cc
+++ b/src/Object.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Object.hh"
+
+namespace gz::rendering
+{
+
+Object::~Object() = default;
+
+}  // namespace gz::rendering

--- a/src/OrbitViewController.cc
+++ b/src/OrbitViewController.cc
@@ -60,9 +60,7 @@ OrbitViewController::OrbitViewController(const CameraPtr &_camera)
 }
 
 //////////////////////////////////////////////////
-OrbitViewController::~OrbitViewController()
-{
-}
+OrbitViewController::~OrbitViewController() = default;
 
 //////////////////////////////////////////////////
 void OrbitViewController::SetCamera(const CameraPtr &_camera)

--- a/src/OrthoViewController.cc
+++ b/src/OrthoViewController.cc
@@ -67,9 +67,7 @@ OrthoViewController::OrthoViewController(const CameraPtr &_camera)
 }
 
 //////////////////////////////////////////////////
-OrthoViewController::~OrthoViewController()
-{
-}
+OrthoViewController::~OrthoViewController() = default;
 
 //////////////////////////////////////////////////
 void OrthoViewController::SetCamera(const CameraPtr &_camera)

--- a/src/ParticleEmitter.cc
+++ b/src/ParticleEmitter.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/ParticleEmitter.hh"
+
+namespace gz::rendering
+{
+
+ParticleEmitter::~ParticleEmitter() = default;
+
+}  // namespace gz::rendering

--- a/src/RayQuery.cc
+++ b/src/RayQuery.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/RayQuery.hh"
+
+namespace gz::rendering
+{
+
+RayQuery::~RayQuery() = default;
+
+}  // namespace gz::rendering

--- a/src/RenderEngine.cc
+++ b/src/RenderEngine.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/RenderEngine.hh"
+
+namespace gz::rendering
+{
+
+RenderEngine::~RenderEngine() = default;
+
+}  // namespace gz::rendering

--- a/src/RenderPass.cc
+++ b/src/RenderPass.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/RenderPass.hh"
+
+namespace gz::rendering
+{
+
+RenderPass::~RenderPass() = default;
+
+}  // namespace gz::rendering

--- a/src/RenderPassSystem.cc
+++ b/src/RenderPassSystem.cc
@@ -38,9 +38,7 @@ RenderPassSystem::RenderPassSystem() :
 }
 
 //////////////////////////////////////////////////
-RenderPassSystem::~RenderPassSystem()
-{
-}
+RenderPassSystem::~RenderPassSystem() = default;
 
 //////////////////////////////////////////////////
 RenderPassPtr RenderPassSystem::CreateImpl(const std::string &_type)

--- a/src/RenderTarget.cc
+++ b/src/RenderTarget.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/RenderTarget.hh"
+
+namespace gz::rendering
+{
+
+RenderTarget::~RenderTarget() = default;
+
+RenderTexture::~RenderTexture() = default;
+
+RenderWindow::~RenderWindow() = default;
+
+}  // namespace gz::rendering

--- a/src/Scene.cc
+++ b/src/Scene.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Scene.hh"
+
+namespace gz::rendering
+{
+
+Scene::~Scene() = default;
+
+}  // namespace gz::rendering

--- a/src/SegmentationCamera.cc
+++ b/src/SegmentationCamera.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/SegmentationCamera.hh"
+
+namespace gz::rendering
+{
+
+SegmentationCamera::~SegmentationCamera() = default;
+
+}  // namespace gz::rendering

--- a/src/Sensor.cc
+++ b/src/Sensor.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Sensor.hh"
+
+namespace gz::rendering
+{
+
+Sensor::~Sensor() = default;
+
+}  // namespace gz::rendering

--- a/src/Text.cc
+++ b/src/Text.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Text.hh"
+
+namespace gz::rendering
+{
+
+Text::~Text() = default;
+
+}  // namespace gz::rendering

--- a/src/ThermalCamera.cc
+++ b/src/ThermalCamera.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/ThermalCamera.hh"
+
+namespace gz::rendering
+{
+
+ThermalCamera::~ThermalCamera() = default;
+
+}  // namespace gz::rendering

--- a/src/ViewController.cc
+++ b/src/ViewController.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/ViewController.hh"
+
+namespace gz::rendering
+{
+
+ViewController::~ViewController() = default;
+
+}  // namespace gz::rendering

--- a/src/Visual.cc
+++ b/src/Visual.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/Visual.hh"
+
+namespace gz::rendering
+{
+
+Visual::~Visual() = default;
+
+}  // namespace gz::rendering

--- a/src/WideAngleCamera.cc
+++ b/src/WideAngleCamera.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/WideAngleCamera.hh"
+
+namespace gz::rendering
+{
+
+WideAngleCamera::~WideAngleCamera() = default;
+
+}  // namespace gz::rendering


### PR DESCRIPTION
# 🦟 Bug fix

Based on https://github.com/gazebosim/gz-rendering/issues/702#issuecomment-1217673602

## Summary

We have some classes defined in headers that need to have at least one virtual method implemented in a `cc` file.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.