### PR TITLE
Hotfix typo in ogre2 include statement

### DIFF
--- a/ogre2/include/ignition/rendering/ogre2/Ogre2BoundingBoxCamera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2BoundingBoxCamera.hh
@@ -15,5 +15,5 @@
  *
  */
 
-#include <gz/rendering/ogre2/Ogre2BoundinBoxCamera.hh>
+#include <gz/rendering/ogre2/Ogre2BoundingBoxCamera.hh>
 #include <ignition/rendering/config.hh>


### PR DESCRIPTION
Signed-off-by: methylDragon <methylDragon@gmail.com>

# 🦟 Bug fix

**Boundin** :no_mouth: 