### PR TITLE
Remove unused point cloud color uniform variable

### DIFF
--- a/ogre2/src/media/materials/programs/GLSL/point_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/point_fs.glsl
@@ -17,10 +17,6 @@
 
 #version ogre_glsl_ver_330
 
-vulkan( layout( ogre_P0 ) uniform Params { )
-  uniform vec4 color;
-vulkan( }; )
-
 vulkan_layout( location = 0 )
 in block
 {

--- a/ogre2/src/media/materials/scripts/point_cloud_point.material
+++ b/ogre2/src/media/materials/scripts/point_cloud_point.material
@@ -68,11 +68,6 @@ fragment_program PointCloudFS unified
   delegate PointCloudFS_GLSL
   delegate PointCloudFS_Metal
   delegate PointCloudFS_VK
-
-  default_params
-  {
-    param_named color float4 1.0 1.0 1.0 1.0
-  }
 }
 
 material PointCloudPoint


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/719

We're not longer using the `color` uniform in the shaders so removing it to prevent a warning from popping up in the ogre2.log on macOS

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
