### PR TITLE
Fix setting emissive map

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -673,11 +673,11 @@ void Ogre2Material::SetEmissiveMap(const std::string &_name,
   this->dataPtr->emissiveMapData = _img;
   if (_img == nullptr)
   {
-    this->SetTextureMapImpl(this->metalnessMapName, Ogre::PBSM_EMISSIVE);
+    this->SetTextureMapImpl(this->emissiveMapName, Ogre::PBSM_EMISSIVE);
   }
   else
   {
-    this->SetTextureMapDataImpl(this->metalnessMapName,
+    this->SetTextureMapDataImpl(this->emissiveMapName,
                                 _img, Ogre::PBSM_EMISSIVE);
   }
 }


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

It was incorrectly setting the emissive map with the metalness map texture.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

