### PR TITLE
Fix build in case no suitable OGRE is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ gz_find_package(GzOGRE VERSION 1.9.0
 # Display a warning for the users on this setup unless they provide
 # USE_UNOFFICIAL_OGRE_VERSIONS flag
 if (NOT USE_UNOFFICIAL_OGRE_VERSIONS)
-  if (${OGRE_VERSION} VERSION_GREATER_EQUAL 1.10.0)
+  if (OGRE_VERSION VERSION_GREATER_EQUAL 1.10.0)
     GZ_BUILD_WARNING("Ogre 1.x versions greater than 1.9 are not officially supported."
                       "The software might compile and even work but support from upstream"
                       "could be reduced to accepting patches for newer versions")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Trying to build Garden on Windows via conda results in a state where ogre is not found (conda provides 1.13, but gz-rendering wants 1.9). Due to the badly written `if()`, if ogre is not found, the whole build fails with:

```
--- stderr: gz-rendering7
CMake Warning at D:/programovani/ign5-ws/install/share/cmake/gz-cmake3/cmake3/FindGzOGRE.cmake:173 (find_package):
  Could not find a configuration file for package "OGRE" that is compatible
  with requested version "1.9".

  The following configuration files were considered but not accepted:

    D:/Programy/Conda/envs/ign5-ws/Library/CMake/OGREConfig.cmake, version: 13.4.4

Call Stack (most recent call first):
  D:/programovani/ign5-ws/install/share/cmake/gz-cmake3/cmake3/GzUtils.cmake:231 (find_package)
  CMakeLists.txt:78 (gz_find_package)


CMake Error at CMakeLists.txt:87 (if):
  if given arguments:

    "VERSION_GREATER_EQUAL" "1.10.0"

  Unknown arguments specified


---
Failed   <<< gz-rendering7 [4.59s, exited with code 1]
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.