### PR TITLE
Fixed rotate gizmo in debs

### DIFF
--- a/src/TransformController.cc
+++ b/src/TransformController.cc
@@ -29,7 +29,7 @@ class gz::rendering::TransformControllerPrivate
 {
   /// \brief Gizmo visual that provides translation, rotation, and scale
   /// tandles for transformation
-  public: GizmoVisualPtr gizmoVisual;
+  public: GizmoVisualPtr gizmoVisual{nullptr};
 
   /// \brief Node to be transformed
   public: NodePtr node;


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

Related to this issue https://github.com/gazebosim/gz-sim/issues/1725

## Summary

I got the following error, which means that `CreateGizmoVisual()` is not called. 

```bash
[GUI] [Err] [MeshDescriptor.cc:54] Mesh manager can't find mesh named [gizmo_rotate]
[GUI] [Err] [Ogre2MeshFactory.cc:566] Cannot load null mesh [gizmo_rotate]
[GUI] [Err] [Ogre2MeshFactory.cc:125] Failed to get Ogre item for [gizmo_rotate]
[GUI] [Err] [Ogre2Visual.cc:134] Cannot attach null geometry.
[GUI] [Err] [MeshDescriptor.cc:54] Mesh manager can't find mesh named [gizmo_rotate]
[GUI] [Err] [Ogre2MeshFactory.cc:566] Cannot load null mesh [gizmo_rotate]
[GUI] [Err] [Ogre2MeshFactory.cc:125] Failed to get Ogre item for [gizmo_rotate]
[GUI] [Err] [Ogre2Visual.cc:134] Cannot attach null geometry.
[GUI] [Err] [MeshDescriptor.cc:54] Mesh manager can't find mesh named [gizmo_rotate]
[GUI] [Err] [Ogre2MeshFactory.cc:566] Cannot load null mesh [gizmo_rotate]
[GUI] [Err] [Ogre2MeshFactory.cc:125] Failed to get Ogre item for [gizmo_rotate]
[GUI] [Err] [Ogre2Visual.cc:134] Cannot attach null geometry.
[GUI] [Err] [MeshDescriptor.cc:54] Mesh manager can't find mesh named [gizmo_rotate_full]
[GUI] [Err] [Ogre2MeshFactory.cc:566] Cannot load null mesh [gizmo_rotate_full]
[GUI] [Err] [Ogre2MeshFactory.cc:125] Failed to get Ogre item for [gizmo_rotate_full]
[GUI] [Err] [Ogre2Visual.cc:134] Cannot attach null geometry.
[GUI] [Err] [MeshDescriptor.cc:54] Mesh manager can't find mesh named [gizmo_rotate_handle]
[GUI] [Err] [Ogre2MeshFactory.cc:566] Cannot load null mesh [gizmo_rotate_handle]
[GUI] [Err] [Ogre2MeshFactory.cc:125] Failed to get Ogre item for [gizmo_rotate_handle]
[GUI] [Err] [Ogre2Visual.cc:134] Cannot attach null geometry.
[GUI] [Err] [MeshDescriptor.cc:54] Mesh manager can't find mesh named [gizmo_rotate_handle]
[GUI] [Err] [Ogre2MeshFactory.cc:566] Cannot load null mesh [gizmo_rotate_handle]
[GUI] [Err] [Ogre2MeshFactory.cc:125] Failed to get Ogre item for [gizmo_rotate_handle]
[GUI] [Err] [Ogre2Visual.cc:134] Cannot attach null geometry.
[GUI] [Err] [MeshDescriptor.cc:54] Mesh manager can't find mesh named [gizmo_rotate_handle]
[GUI] [Err] [Ogre2MeshFactory.cc:566] Cannot load null mesh [gizmo_rotate_handle]
[GUI] [Err] [Ogre2MeshFactory.cc:125] Failed to get Ogre item for [gizmo_rotate_handle]
[GUI] [Err] [Ogre2Visual.cc:134] Cannot attach null geometry.
```

The attribute `gizmoVisual` is not initialize to `nullptr` which potencially might generate this issue.

```cpp
//////////////////////////////////////////////////
void TransformController::Update()
{
  if (!this->dataPtr->node)
  {
    if (this->dataPtr->gizmoVisual)
      this->dataPtr->gizmoVisual->SetTransformMode(TransformMode::TM_NONE);
    return;
  }

  if (!this->dataPtr->gizmoVisual)
  {
    this->dataPtr->gizmoVisual =
        this->dataPtr->node->Scene()->CreateGizmoVisual();
```

@azeey or @iche033 what do you think?

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
