### PR TITLE
Add Support for wide-angle cameras in ogre2

### DIFF
--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderTarget.hh
@@ -120,6 +120,12 @@ namespace gz
       /// \return Value in range [1; 256). 1 means no antialiasing.
       protected: uint8_t TargetFSAA() const;
 
+      /// \brief Returns the FSAA to use based on supported specs by HW
+      /// and value specified in _fsaa
+      /// \param[in] _fsaa Value in range [1; 256). 1 means no antialiasing.
+      /// \return Value in range [1; 256). 1 means no antialiasing.
+      public: static uint8_t TargetFSAA(uint8_t _fsaa);
+
       /// \brief Get a pointer to the ogre render target containing
       /// the results of the render (implemented separately
       /// to avoid breaking ABI of the pure virtual function)

--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderTypes.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderTypes.hh
@@ -68,6 +68,7 @@ namespace gz
     class Ogre2SubMesh;
     class Ogre2ThermalCamera;
     class Ogre2Visual;
+    class Ogre2WideAngleCamera;
     class Ogre2WireBox;
 
     typedef BaseGeometryStore<Ogre2Geometry>      Ogre2GeometryStore;
@@ -120,6 +121,7 @@ namespace gz
     typedef shared_ptr<Ogre2SubMesh>              Ogre2SubMeshPtr;
     typedef shared_ptr<Ogre2ThermalCamera>        Ogre2ThermalCameraPtr;
     typedef shared_ptr<Ogre2Visual>               Ogre2VisualPtr;
+    typedef shared_ptr<Ogre2WideAngleCamera>      Ogre2WideAngleCameraPtr;
     typedef shared_ptr<Ogre2WireBox>              Ogre2WireBoxPtr;
 
     typedef shared_ptr<Ogre2GeometryStore>        Ogre2GeometryStorePtr;

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -240,6 +240,11 @@ namespace gz
                      unsigned int _id, const std::string &_name) override;
 
       // Documentation inherited
+      protected: virtual WideAngleCameraPtr CreateWideAngleCameraImpl(
+                     const unsigned int _id,
+                     const std::string &_name) override;
+
+      // Documentation inherited
       protected: virtual BoundingBoxCameraPtr CreateBoundingBoxCameraImpl(
                      unsigned int _id, const std::string &_name) override;
 

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -241,8 +241,7 @@ namespace gz
 
       // Documentation inherited
       protected: virtual WideAngleCameraPtr CreateWideAngleCameraImpl(
-                     const unsigned int _id,
-                     const std::string &_name) override;
+                     unsigned int _id, const std::string &_name) override;
 
       // Documentation inherited
       protected: virtual BoundingBoxCameraPtr CreateBoundingBoxCameraImpl(

--- a/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GZ_RENDERING_OGRE2_WIDEANGLECAMERA_HH_
+#define GZ_RENDERING_OGRE2_WIDEANGLECAMERA_HH_
+
+#include <memory>
+#include <string>
+
+#include <gz/utils/ImplPtr.hh>
+
+#include "gz/rendering/base/BaseWideAngleCamera.hh"
+#include "gz/rendering/ogre2/Export.hh"
+#include "gz/rendering/ogre2/Ogre2RenderTarget.hh"
+#include "gz/rendering/ogre2/Ogre2Sensor.hh"
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    //
+    /// \brief Ogre implementation of WideAngleCamera
+    class GZ_RENDERING_OGRE2_VISIBLE Ogre2WideAngleCamera :
+        public BaseWideAngleCamera<Ogre2Sensor>
+    {
+      /// \brief Constructor
+      protected: Ogre2WideAngleCamera();
+
+      /// \brief Destructor
+      public: virtual ~Ogre2WideAngleCamera() override;
+
+      // Documentation inherited
+      public: virtual void Init() override;
+
+      /// \brief Create a texture
+      public: virtual void CreateRenderTexture();
+
+      /// \brief Render the camera
+      public: virtual void PostRender() override;
+
+      // Documentation inherited
+      public: virtual void Destroy() override;
+
+      /// \brief Gets the environment texture size
+      /// \return Texture size
+      public: uint32_t EnvTextureSize() const;
+
+      /// \brief Sets environment texture size
+      /// \param[in] _size Texture size
+      public: void SetEnvTextureSize(uint32_t _size);
+
+      /// \brief Project 3D world coordinates to screen coordinates
+      /// \param[in] _pt 3D world coodinates
+      /// \return Screen coordinates. Z is the distance of point from camera
+      /// optical center.
+      public: math::Vector3d Project3d(const math::Vector3d &_pt) const
+          override;
+
+      // Documentation inherited.
+      public: virtual void PreRender() override;
+
+      /// \brief Implementation of the render call
+      public: virtual void Render() override;
+
+      // Documentation inherited
+      public: common::ConnectionPtr ConnectNewWideAngleFrame(
+          std::function<void(const unsigned char *, unsigned int, unsigned int,
+          unsigned int, const std::string &)>  _subscriber) override;
+
+      /// \brief Set the camera's render target
+      protected: void CreateWideAngleTexture() override;
+
+      /// \brief Create the camera.
+      protected: void CreateCamera();
+
+      /// \brief Get a pointer to the render target.
+      /// \return Pointer to the render target
+      protected: virtual RenderTargetPtr RenderTarget() const override;
+
+      /// \brief Changes the Compositor Definition to use the MSAA
+      /// settings we need. Do not call this if not using MSAA.
+      /// \param[in] _ogreCompMgr Ogre's Compositor Manager
+      /// \param[in] _msaa Value in range [2; 256)
+      protected: void SetupMSAA(Ogre::CompositorManager2 *_ogreCompMgr,
+                                uint8_t _msaa);
+
+      /// \brief Saves the CompositorPassSceneDef of each of the 6 passes
+      /// defined in WideAngleCamera.compositor data file for later
+      /// manipulation.
+      /// \param[in] _ogreCompMgr Ogre's Compositor Manager
+      /// \param[in] _withMsaa Whether the version we're retrieving is the MSAA
+      /// one
+      private: void RetrieveCubePassSceneDefs(
+            Ogre::CompositorManager2 *_ogreCompMgr, bool _withMsaa);
+
+      /// \brief Called before each cubemap face is about to be rendered
+      /// \param[in] _pass Compositor pass to set its clear colour
+      private: void PrepareForCubemapFacePass(Ogre::CompositorPass *_pass);
+
+      /// \brief Called before the final pass is about to be rendered
+      /// \param[in] _pass Material Pass to setup
+      private: void PrepareForFinalPass(Ogre::Pass *_pass);
+
+      /// \cond warning
+      /// \brief Private data pointer
+      GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+      /// \endcond
+
+      private: friend class Ogre2Scene;
+      private: friend class Ogre2WideAngleCameraWorkspaceListenerPrivate;
+    };
+    }
+  }
+}
+#endif

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -595,11 +595,17 @@ void Ogre2RenderTarget::PrepareForExternalSampling()
 //////////////////////////////////////////////////
 uint8_t Ogre2RenderTarget::TargetFSAA() const
 {
+  return Ogre2RenderTarget::TargetFSAA(
+    static_cast<uint8_t>(this->antiAliasing));
+}
+
+//////////////////////////////////////////////////
+uint8_t Ogre2RenderTarget::TargetFSAA(uint8_t _fsaa)
+{
   // check if target fsaa is supported
   std::vector<unsigned int> fsaaLevels =
       Ogre2RenderEngine::Instance()->FSAALevels();
-  unsigned int targetFSAA = this->antiAliasing;
-  auto const it = std::find(fsaaLevels.begin(), fsaaLevels.end(), targetFSAA);
+  auto const it = std::find(fsaaLevels.begin(), fsaaLevels.end(), _fsaa);
 
   if (it == fsaaLevels.end())
   {
@@ -615,18 +621,18 @@ uint8_t Ogre2RenderTarget::TargetFSAA() const
       }
       os << "]";
 
-      gzwarn << "Anti-aliasing level of '" << this->antiAliasing << "' "
+      gzwarn << "Anti-aliasing level of '" << _fsaa << "' "
               << "is not supported; valid FSAA levels are: " << os.str()
               << ". Setting to 1" << std::endl;
       ogre2FSAAWarn = true;
     }
-    targetFSAA = 0u;
+    _fsaa = 0u;
   }
 
-  if (targetFSAA == 0u)
-    targetFSAA = 1u;
+  if (_fsaa == 0u)
+    _fsaa = 1u;
 
-  return static_cast<uint8_t>(targetFSAA);
+  return _fsaa;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -48,6 +48,7 @@
 #include "gz/rendering/ogre2/Ogre2ThermalCamera.hh"
 #include "gz/rendering/ogre2/Ogre2SegmentationCamera.hh"
 #include "gz/rendering/ogre2/Ogre2Visual.hh"
+#include "gz/rendering/ogre2/Ogre2WideAngleCamera.hh"
 #include "gz/rendering/ogre2/Ogre2WireBox.hh"
 
 #ifdef _MSC_VER
@@ -1025,6 +1026,15 @@ ThermalCameraPtr Ogre2Scene::CreateThermalCameraImpl(const unsigned int _id,
     const std::string &_name)
 {
   Ogre2ThermalCameraPtr camera(new Ogre2ThermalCamera);
+  bool result = this->InitObject(camera, _id, _name);
+  return (result) ? camera : nullptr;
+}
+
+//////////////////////////////////////////////////
+WideAngleCameraPtr Ogre2Scene::CreateWideAngleCameraImpl(const unsigned int _id,
+    const std::string &_name)
+{
+  Ogre2WideAngleCameraPtr camera(new Ogre2WideAngleCamera);
   bool result = this->InitObject(camera, _id, _name);
   return (result) ? camera : nullptr;
 }

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -261,9 +261,9 @@ void Ogre2WideAngleCamera::SetupMSAA(Ogre::CompositorManager2 *_ogreCompMgr,
   auto &textureDefs = nodeDef->getLocalTextureDefinitionsNonConst();
 
   GZ_ASSERT(textureDefs.size() == 1u,
-            "WideAngleCamera.compositor out of sync?");
+            "wide_angle_camera.compositor out of sync?");
   GZ_ASSERT(textureDefs[0].getName() == "tmpMsaa",
-            "WideAngleCamera.compositor out of sync?");
+            "wide_angle_camera.compositor out of sync?");
 
   textureDefs[0].fsaa = std::to_string(_msaa);
 }
@@ -280,9 +280,9 @@ void Ogre2WideAngleCamera::RetrieveCubePassSceneDefs(
     Ogre::CompositorTargetDef *target0 = nodeDef->getTargetPass(i);
     Ogre::CompositorPassDefVec &passes = target0->getCompositorPassesNonConst();
     GZ_ASSERT(passes.size() >= 1u,
-              "WideAngleCamera.compositor is out of sync?");
+              "wide_angle_camera.compositor is out of sync?");
     GZ_ASSERT(passes[0]->getType() == Ogre::PASS_SCENE,
-              "WideAngleCamera.compositor is out of sync?");
+              "wide_angle_camera.compositor is out of sync?");
     GZ_ASSERT(dynamic_cast<Ogre::CompositorPassSceneDef *>(passes[0]),
               "Memory corruption?");
 
@@ -660,9 +660,9 @@ void Ogre2WideAngleCameraWorkspaceListenerPrivate::passPreExecute(
   }
   else if (identifier == kWideAngleCameraQuadPassId)
   {
-    GZ_ASSERT(
-      dynamic_cast<Ogre::CompositorPassQuad *>(_pass),
-      "Impossible! Corrupted memory? WideAngleCamera.compositor out of sync?");
+    GZ_ASSERT(dynamic_cast<Ogre::CompositorPassQuad *>(_pass),
+              "Impossible! Corrupted memory? wide_angle_camera.compositor out "
+              "of sync?");
     Ogre::CompositorPassQuad *passQuad =
       static_cast<Ogre::CompositorPassQuad *>(_pass);
 

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -445,9 +445,10 @@ math::Vector3d Ogre2WideAngleCamera::Project3d(const math::Vector3d &_pt) const
     Vector4 pos = viewProj * Vector4(basePos);
     pos.x /= pos.w;
     pos.y /= pos.w;
+    pos.z /= pos.w;
     // check if point is visible
     if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 &&
-        ((!isReverseDepth && pos.z > 0) || (isReverseDepth && pos.z < 1)))
+        ((!isReverseDepth && pos.z > 0) || (isReverseDepth && pos.z < 1.0)))
     {
       // determine dir vector to projected point from env camera
       // work in y up, z forward, x right clip space

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -129,8 +129,8 @@ using namespace gz;
 using namespace rendering;
 
 // Arbitrary values
-static const uint32_t kWideAngleCameraCubemapPassId = 1276660u;
-static const uint32_t kWideAngleCameraQuadPassId = 1276661u;
+static constexpr uint32_t kWideAngleCameraCubemapPassId = 1276660u;
+static constexpr uint32_t kWideAngleCameraQuadPassId = 1276661u;
 
 //////////////////////////////////////////////////
 Ogre2WideAngleCamera::Ogre2WideAngleCamera() :

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -35,7 +35,6 @@
 #include <OgreDepthBuffer.h>
 #include <OgreImage2.h>
 #include <OgrePass.h>
-#include <OgreRoot.h>
 #include <OgreSceneManager.h>
 #include <OgreTechnique.h>
 #include <OgreTextureBox.h>
@@ -424,9 +423,6 @@ math::Vector3d Ogre2WideAngleCamera::Project3d(const math::Vector3d &_pt) const
   const Quaternion oldCameraOrientation(
     this->dataPtr->ogreCamera->getOrientation());
 
-  const bool isReverseDepth =
-    Root::getSingleton().getRenderSystem()->isReverseDepth();
-
   // project world point to camera clip space.
   const Matrix4 projMatrix = this->dataPtr->ogreCamera->getProjectionMatrix();
   // const Vector4 basePos = viewProj * Vector4(Ogre2Conversions::Convert(_pt));
@@ -447,8 +443,7 @@ math::Vector3d Ogre2WideAngleCamera::Project3d(const math::Vector3d &_pt) const
     pos.y /= pos.w;
     pos.z /= pos.w;
     // check if point is visible
-    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 &&
-        ((!isReverseDepth && pos.z > 0) || (isReverseDepth && pos.z < 1.0)))
+    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 && std::fabs(pos.z) <= 1)
     {
       // determine dir vector to projected point from env camera
       // work in y up, z forward, x right clip space

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -1,0 +1,660 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/ogre2/Ogre2WideAngleCamera.hh"
+
+#include "gz/rendering/CameraLens.hh"
+#include "gz/rendering/ogre2/Ogre2Conversions.hh"
+#include "gz/rendering/ogre2/Ogre2RenderEngine.hh"
+#include "gz/rendering/ogre2/Ogre2Scene.hh"
+
+#include "gz/common/Util.hh"
+
+#ifdef _MSC_VER
+#  pragma warning(push, 0)
+#endif
+#include <Compositor/OgreCompositorManager2.h>
+#include <Compositor/OgreCompositorWorkspace.h>
+#include <Compositor/OgreCompositorWorkspaceListener.h>
+#include <Compositor/Pass/PassQuad/OgreCompositorPassQuad.h>
+#include <Compositor/Pass/PassScene/OgreCompositorPassSceneDef.h>
+#include <OgreDepthBuffer.h>
+#include <OgreImage2.h>
+#include <OgrePass.h>
+#include <OgreRoot.h>
+#include <OgreSceneManager.h>
+#include <OgreTechnique.h>
+#include <OgreTextureBox.h>
+#include <OgreTextureGpuManager.h>
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+
+// clang-format off
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+/// \brief Helper class for setting up Camera and Materials when rendering
+/// via Ogre2WideAngleCamera.
+class GZ_RENDERING_OGRE2_HIDDEN Ogre2WideAngleCameraWorkspaceListenerPrivate :
+    public Ogre::CompositorWorkspaceListener
+{
+  public: gz::rendering::Ogre2WideAngleCamera &owner;
+
+  /// \brief constructor
+  /// \param[in] _scene the scene manager responsible for rendering
+  public: explicit Ogre2WideAngleCameraWorkspaceListenerPrivate(
+        gz::rendering::Ogre2WideAngleCamera &_owner) :
+    owner(_owner)
+  {
+  }
+
+  /// \brief Called when each pass is about to be executed.
+  /// \param[in] _pass Ogre pass which is about to execute
+  public: virtual void passPreExecute(Ogre::CompositorPass *_pass) override;
+};
+}
+}
+}
+// clang-format on
+
+static const uint32_t kWideAngleNumCubemapFaces = 6u;
+
+/// \brief Private data for the WideAngleCamera class
+class gz::rendering::Ogre2WideAngleCamera::Implementation
+{
+  // clang-format off
+  /// \brief Environment texture size
+  public: uint32_t envTextureSize = 512u;
+
+  /// \brief A single cube map texture
+  public: Ogre::TextureGpu *envCubeMapTexture = nullptr;
+
+  /// \brief Output texture
+  public: Ogre::TextureGpu *ogreRenderTexture = nullptr;
+
+  /// \brief Compositor workspace. Does all the work
+  public: Ogre::CompositorWorkspace *ogreCompositorWorkspace = nullptr;
+
+  /// \brief Main pass definition (used for visibility mask manipuluation).
+  public: Ogre::CompositorPassSceneDef
+  *cubePassSceneDef[kWideAngleNumCubemapFaces]{};
+
+  /// \brief Pointer to material, used for second rendering pass
+  public: Ogre::MaterialPtr compMat;
+
+  /// \brief Camera lens description
+  public: CameraLens lens;
+
+  /// \brief Pointer to the ogre camera
+  /// OgreNext rotates to face each of the 6 sides
+  /// We use listeners to set FOV to the proper setting depending on the pass
+  public: Ogre::Camera *ogreCamera = nullptr;
+
+  /// \brief Dummy texture
+  public: Ogre2RenderTexturePtr wideAngleTexture;
+
+  /// \brief Event used to signal camera data
+  public: gz::common::EventT<void(const unsigned char *,
+              unsigned int, unsigned int, unsigned int,
+              const std::string &)> newImageFrame;
+
+  /// \brief See Ogre2WideAngleCameraWorkspaceListenerPrivate
+  public: Ogre2WideAngleCameraWorkspaceListenerPrivate workspaceListener;
+
+  explicit Implementation(gz::rendering::Ogre2WideAngleCamera &_owner) :
+    workspaceListener(_owner)
+  {
+  }
+  // clang-format on
+};
+
+using namespace gz;
+using namespace rendering;
+
+// Arbitrary values
+static const uint32_t kWideAngleCameraCubemapPassId = 1276660u;
+static const uint32_t kWideAngleCameraQuadPassId = 1276661u;
+
+//////////////////////////////////////////////////
+Ogre2WideAngleCamera::Ogre2WideAngleCamera() :
+  dataPtr(utils::MakeUniqueImpl<Implementation>(*this))
+{
+}
+
+//////////////////////////////////////////////////
+Ogre2WideAngleCamera::~Ogre2WideAngleCamera()
+{
+  this->Destroy();
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::Init()
+{
+  BaseWideAngleCamera::Init();
+  this->CreateCamera();
+  this->CreateRenderTexture();
+  this->Reset();
+}
+
+/////////////////////////////////////////////////
+void Ogre2WideAngleCamera::CreateRenderTexture()
+{
+  RenderTexturePtr base = this->scene->CreateRenderTexture();
+  this->dataPtr->wideAngleTexture =
+    std::dynamic_pointer_cast<Ogre2RenderTexture>(base);
+  this->dataPtr->wideAngleTexture->SetWidth(1);
+  this->dataPtr->wideAngleTexture->SetHeight(1);
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::PreRender()
+{
+  BaseCamera::PreRender();
+  if (!this->dataPtr->ogreRenderTexture)
+    this->CreateWideAngleTexture();
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::Destroy()
+{
+  auto engine = Ogre2RenderEngine::Instance();
+  auto ogreRoot = engine->OgreRoot();
+  Ogre::TextureGpuManager *textureMgr =
+    ogreRoot->getRenderSystem()->getTextureGpuManager();
+
+  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+
+  const Ogre::CompositorChannelVec channels = {
+    this->dataPtr->ogreRenderTexture, this->dataPtr->envCubeMapTexture
+  };
+
+  if (this->dataPtr->ogreCompositorWorkspace)
+  {
+    ogreCompMgr->removeWorkspace(this->dataPtr->ogreCompositorWorkspace);
+    this->dataPtr->ogreCompositorWorkspace = nullptr;
+  }
+
+  if (this->dataPtr->envCubeMapTexture)
+  {
+    textureMgr->destroyTexture(this->dataPtr->envCubeMapTexture);
+    this->dataPtr->envCubeMapTexture = nullptr;
+  }
+
+  if (this->dataPtr->ogreRenderTexture)
+  {
+    textureMgr->destroyTexture(this->dataPtr->ogreRenderTexture);
+    this->dataPtr->ogreRenderTexture = nullptr;
+  }
+}
+
+//////////////////////////////////////////////////
+uint32_t Ogre2WideAngleCamera::EnvTextureSize() const
+{
+  return this->dataPtr->envTextureSize;
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::SetEnvTextureSize(uint32_t _size)
+{
+  this->dataPtr->envTextureSize = _size;
+}
+
+/////////////////////////////////////////////////
+void Ogre2WideAngleCamera::CreateCamera()
+{
+  // Create dummy ogre camera object
+  Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
+  if (ogreSceneManager == nullptr)
+  {
+    gzerr << "Scene manager cannot be obtained" << std::endl;
+    return;
+  }
+
+  this->dataPtr->ogreCamera =
+    ogreSceneManager->createCamera(this->Name() + "_Camera", true, true);
+  if (this->dataPtr->ogreCamera == nullptr)
+  {
+    gzerr << "Ogre camera cannot be created" << std::endl;
+    return;
+  }
+
+  // OgreNext by default attaches the camera to the Root SceneNode
+  // Detach from it and use our own node.
+  this->dataPtr->ogreCamera->detachFromParent();
+  this->ogreNode->attachObject(this->dataPtr->ogreCamera);
+
+  this->dataPtr->ogreCamera->setFixedYawAxis(false);
+  this->dataPtr->ogreCamera->yaw(Ogre::Degree(-90));
+  this->dataPtr->ogreCamera->roll(Ogre::Degree(-90));
+  this->dataPtr->ogreCamera->setAutoAspectRatio(true);
+
+  const Ogre::Real nearPlane = static_cast<Ogre::Real>(this->NearClipPlane());
+  const Ogre::Real farPlane = static_cast<Ogre::Real>(this->FarClipPlane());
+  this->dataPtr->ogreCamera->setNearClipDistance(nearPlane);
+  this->dataPtr->ogreCamera->setFarClipDistance(farPlane);
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::SetupMSAA(Ogre::CompositorManager2 *_ogreCompMgr,
+                                     uint8_t _msaa)
+{
+  GZ_ASSERT(_msaa > 1u, "Wrong API usage. Don't call this function");
+
+  Ogre::CompositorNodeDef *nodeDef =
+    _ogreCompMgr->getNodeDefinitionNonConst("WideAngleCameraCubemapPassMsaa");
+  auto &textureDefs = nodeDef->getLocalTextureDefinitionsNonConst();
+
+  GZ_ASSERT(textureDefs.size() == 1u,
+            "WideAngleCamera.compositor out of sync?");
+  GZ_ASSERT(textureDefs[0].getName() == "tmpMsaa",
+            "WideAngleCamera.compositor out of sync?");
+
+  textureDefs[0].fsaa = std::to_string(_msaa);
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::RetrieveCubePassSceneDefs(
+  Ogre::CompositorManager2 *_ogreCompMgr, bool _withMsaa)
+{
+  Ogre::CompositorNodeDef *nodeDef = _ogreCompMgr->getNodeDefinitionNonConst(
+    _withMsaa ? "WideAngleCameraCubemapPassMsaa"
+              : "WideAngleCameraCubemapPass");
+  for (uint32_t i = 0u; i < kWideAngleNumCubemapFaces; ++i)
+  {
+    Ogre::CompositorTargetDef *target0 = nodeDef->getTargetPass(i);
+    Ogre::CompositorPassDefVec &passes = target0->getCompositorPassesNonConst();
+    GZ_ASSERT(passes.size() >= 1u,
+              "WideAngleCamera.compositor is out of sync?");
+    GZ_ASSERT(passes[0]->getType() == Ogre::PASS_SCENE,
+              "WideAngleCamera.compositor is out of sync?");
+    GZ_ASSERT(dynamic_cast<Ogre::CompositorPassSceneDef *>(passes[0]),
+              "Memory corruption?");
+
+    this->dataPtr->cubePassSceneDef[i] =
+      static_cast<Ogre::CompositorPassSceneDef *>(passes[0]);
+  }
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::CreateWideAngleTexture()
+{
+  if (this->dataPtr->ogreCamera == nullptr)
+  {
+    gzerr << "Ogre camera cannot be created" << std::endl;
+    return;
+  }
+
+  auto engine = Ogre2RenderEngine::Instance();
+  auto ogreRoot = engine->OgreRoot();
+  Ogre::TextureGpuManager *textureMgr =
+    ogreRoot->getRenderSystem()->getTextureGpuManager();
+
+  if (!this->dataPtr->ogreRenderTexture)
+  {
+    this->dataPtr->ogreRenderTexture =
+      textureMgr->createTexture(this->Name() + "_wideAngleCamera",    //
+                                Ogre::GpuPageOutStrategy::Discard,    //
+                                Ogre::TextureFlags::RenderToTexture,  //
+                                Ogre::TextureTypes::Type2D,           //
+                                Ogre::BLANKSTRING,                    //
+                                0u);
+
+    this->dataPtr->ogreRenderTexture->setResolution(this->ImageWidth(),
+                                                    this->ImageHeight());
+    this->dataPtr->ogreRenderTexture->setPixelFormat(
+      Ogre::PFG_RGBA8_UNORM_SRGB);
+    this->dataPtr->ogreRenderTexture->_setDepthBufferDefaults(
+      Ogre::DepthBuffer::POOL_NO_DEPTH, false, Ogre::PFG_UNKNOWN);
+    this->dataPtr->ogreRenderTexture->scheduleTransitionTo(
+      Ogre::GpuResidency::Resident);
+  }
+
+  this->dataPtr->envCubeMapTexture =
+    textureMgr->createTexture(this->Name() + "_cube_wideAngleCamera",  //
+                              Ogre::GpuPageOutStrategy::Discard,       //
+                              Ogre::TextureFlags::RenderToTexture,     //
+                              Ogre::TextureTypes::TypeCube,            //
+                              Ogre::BLANKSTRING,                       //
+                              0u);
+
+  this->dataPtr->envCubeMapTexture->setResolution(
+    this->dataPtr->envTextureSize, this->dataPtr->envTextureSize);
+  this->dataPtr->envCubeMapTexture->setPixelFormat(Ogre::PFG_RGBA8_UNORM_SRGB);
+
+  this->dataPtr->envCubeMapTexture->scheduleTransitionTo(
+    Ogre::GpuResidency::Resident);
+
+  // Create compositor workspace
+  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+  Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
+
+  const uint8_t msaa =
+    Ogre2RenderTarget::TargetFSAA(static_cast<uint8_t>(this->antiAliasing));
+
+  if (msaa > 1u)
+  {
+    SetupMSAA(ogreCompMgr, msaa);
+  }
+
+  this->RetrieveCubePassSceneDefs(ogreCompMgr, msaa > 1u);
+
+  const Ogre::CompositorChannelVec channels = {
+    this->dataPtr->envCubeMapTexture, this->dataPtr->ogreRenderTexture
+  };
+
+  this->dataPtr->ogreCompositorWorkspace = ogreCompMgr->addWorkspace(
+    ogreSceneManager, channels, this->dataPtr->ogreCamera,
+    "WideAngleCameraWorkspace", false);
+  this->dataPtr->ogreCompositorWorkspace->addListener(
+    &this->dataPtr->workspaceListener);
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::Render()
+{
+  {
+    auto engine = Ogre2RenderEngine::Instance();
+    auto ogreRoot = engine->OgreRoot();
+    ogreRoot->getRenderSystem()->startGpuDebuggerFrameCapture(nullptr);
+  }
+  const uint32_t currVisibilityMask = this->VisibilityMask();
+  for (uint32_t i = 0u; i < kWideAngleNumCubemapFaces; ++i)
+  {
+    this->dataPtr->cubePassSceneDef[i]->mVisibilityMask = currVisibilityMask;
+  }
+
+  this->scene->StartRendering(this->dataPtr->ogreCamera);
+
+  Ogre::vector<Ogre::TextureGpu *>::type swappedTargets;
+
+  this->dataPtr->ogreCompositorWorkspace->setEnabled(true);
+
+  this->dataPtr->ogreCompositorWorkspace->_validateFinalTarget();
+  this->dataPtr->ogreCompositorWorkspace->_beginUpdate(false);
+  this->dataPtr->ogreCompositorWorkspace->_update();
+  this->dataPtr->ogreCompositorWorkspace->_endUpdate(false);
+
+  swappedTargets.clear();
+  this->dataPtr->ogreCompositorWorkspace->_swapFinalTarget(swappedTargets);
+
+  this->dataPtr->ogreCompositorWorkspace->setEnabled(false);
+
+  this->scene->FlushGpuCommandsAndStartNewFrame(6u, false);
+  {
+    auto engine = Ogre2RenderEngine::Instance();
+    auto ogreRoot = engine->OgreRoot();
+    ogreRoot->getRenderSystem()->endGpuDebuggerFrameCapture(nullptr);
+  }
+}
+
+//////////////////////////////////////////////////
+math::Vector3d Ogre2WideAngleCamera::Project3d(const math::Vector3d &_pt) const
+{
+  using namespace Ogre;
+
+  // Matches CompositorPass::CubemapRotations from OgreCompositorPass.cpp
+  const Quaternion kCubemapRotations[6] = {
+    Quaternion(Radian(-1.570796f), Vector3(0, 1, 0)),  // +X
+    Quaternion(Radian(1.570796f), Vector3(0, 1, 0)),   // -X
+    Quaternion(Radian(1.570796f), Vector3(1, 0, 0)),   // +Y
+    Quaternion(Radian(-1.570796f), Vector3(1, 0, 0)),  // -Y
+    Quaternion(1, 0, 0, 0),                            // +Z
+    Quaternion(Radian(3.1415927f), Vector3(0, 1, 0))   // -Z
+  };
+
+  // project world point to camera clip space.
+  const Matrix4 viewProj = this->dataPtr->ogreCamera->getProjectionMatrix() *
+                           this->dataPtr->ogreCamera->getViewMatrix();
+  const Vector4 basePos = viewProj * Vector4(Ogre2Conversions::Convert(_pt));
+
+  // project onto cubemap face then onto
+  gz::math::Vector3d screenPos;
+  // loop through all env cameras can find the one that sees the 3d world point
+  for (unsigned int i = 0u; i < kWideAngleNumCubemapFaces; ++i)
+  {
+    // project world point to camera clip space for each face.
+    Vector4 pos =
+      Vector4(kCubemapRotations[i].Inverse() * basePos.xyz(), basePos.w);
+    pos.x /= pos.w;
+    pos.y /= pos.w;
+    // check if point is visible
+    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 && pos.z > 0)
+    {
+      // determine dir vector to projected point from env camera
+      // work in y up, z forward, x right clip space
+      gz::math::Vector3d dir(pos.x, pos.y, 1);
+      gz::math::Quaterniond rot = gz::math::Quaterniond::Identity;
+
+      // rotate dir vector into wide angle camera frame based on the
+      // face of the cube. Note: operate in clip space so
+      // left handed coordinate system rotation
+      if (i == 0)
+        rot = gz::math::Quaterniond(0.0, GZ_PI * 0.5, 0.0);
+      else if (i == 1)
+        rot = gz::math::Quaterniond(0.0, -GZ_PI * 0.5, 0.0);
+      else if (i == 2)
+        rot = gz::math::Quaterniond(-GZ_PI * 0.5, 0.0, 0.0);
+      else if (i == 3)
+        rot = gz::math::Quaterniond(GZ_PI * 0.5, 0.0, 0.0);
+      else if (i == 5)
+        rot = gz::math::Quaterniond(0.0, GZ_PI, 0.0);
+      dir = rot * dir;
+      dir.Normalize();
+
+      // compute theta and phi from the dir vector
+      // theta is angle to dir vector from z (forward)
+      // phi is angle from x in x-y plane
+      // direction vector (x, y, z)
+      // x = sin(theta)cos(phi)
+      // y = sin(theta)sin(phi)
+      // z = cos(theta)
+      double theta =
+        std::atan2(std::sqrt(dir.X() * dir.X() + dir.Y() * dir.Y()), dir.Z());
+      double phi = std::atan2(dir.Y(), dir.X());
+      // this also works:
+      // double theta = std::acos(dir.Z());
+      // double phi = std::asin(dir.Y() / std::sin(theta));
+
+      double f = this->Lens().F();
+      double fov = this->HFOV().Radian();
+      // recompute f if scale to HFOV is true
+      if (this->Lens().ScaleToHFOV())
+      {
+        double param = (fov / 2.0) / this->Lens().C2() + this->Lens().C3();
+        double funRes =
+          this->Lens().ApplyMappingFunction(static_cast<float>(param));
+        f = 1.0 / (this->Lens().C1() * funRes);
+      }
+
+      // Apply fisheye lens mapping function
+      // r is distance of point from image center
+      double r = this->Lens().C1() * f *
+                 this->Lens().ApplyMappingFunction(theta / this->Lens().C2() +
+                                                   this->Lens().C3());
+
+      // compute projected x and y in clip space
+      double x = cos(phi) * r;
+      double y = sin(phi) * r;
+
+      const uint32_t vpWidth = this->dataPtr->ogreRenderTexture->getWidth();
+      const uint32_t vpHeight = this->dataPtr->ogreRenderTexture->getHeight();
+      // env cam cube map texture is square and likely to be different size from
+      // viewport. We need to adjust projected pos based on aspect ratio
+      double asp = static_cast<double>(vpWidth) / static_cast<double>(vpHeight);
+      y *= asp;
+
+      // convert to screen space
+      screenPos.X() = ((x / 2.0) + 0.5) * vpWidth;
+      screenPos.Y() = (1 - ((y / 2.0) + 0.5)) * vpHeight;
+
+      // r will be > 1.0 if point is not visible (outside of image)
+      screenPos.Z() = r;
+      return screenPos;
+    }
+  }
+
+  return screenPos;
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::PostRender()
+{
+  if (this->dataPtr->newImageFrame.ConnectionCount() <= 0u)
+    return;
+
+  const unsigned int width = this->ImageWidth();
+  const unsigned int height = this->ImageHeight();
+
+  // blit data from gpu to cpu
+  Ogre::Image2 image;
+  image.convertFromTexture(this->dataPtr->ogreRenderTexture, 0u, 0u);
+  Ogre::TextureBox box = image.getData(0u);
+
+  // Convert in-place from RGBA32 to RGB24 reusing the same memory region.
+  // The data contained will no longer be meaningful to Image2, but that
+  // class will no longer manipulate that data. We also store it contiguously
+  // (which is what gazebo expects), instead of aligning rows to 4 bytes like
+  // Ogre does. This saves RAM and lots of bandwidth.
+  uint8_t *RESTRICT_ALIAS rgb24 =
+    reinterpret_cast<uint8_t * RESTRICT_ALIAS>(box.data);
+  for (size_t y = 0; y < box.height; ++y)
+  {
+    uint8_t *RESTRICT_ALIAS rgba32 =
+      reinterpret_cast<uint8_t * RESTRICT_ALIAS>(box.at(0u, y, 0u));
+    for (size_t x = 0; x < box.width; ++x)
+    {
+      *rgb24++ = *rgba32++;
+      *rgb24++ = *rgba32++;
+      *rgb24++ = *rgba32++;
+      ++rgba32;
+    }
+  }
+
+  this->dataPtr->newImageFrame(reinterpret_cast<uint8_t *>(box.data), width,
+                               height, 3u, "PF_R8G8B");
+
+  // Uncomment to debug wide angle cameraoutput
+  // gzdbg << "wxh: " << width << " x " << height << std::endl;
+  // for (unsigned int i = 0; i < height; ++i)
+  // {
+  //   for (unsigned int j = 0; j < width * channelCount; j += channelCount)
+  //   {
+  //     unsigned int idx = i * width * channelCount + j;
+  //     unsigned int r = this->dataPtr->wideAngleImage[idx];
+  //     unsigned int g = this->dataPtr->wideAngleImage[idx + 1];
+  //     unsigned int b = this->dataPtr->wideAngleImage[idx + 2];
+  //     std::cout << "[" << r << "," << g << "," << b << "]";
+  //   }
+  //   std::cout << std::endl;
+  // }
+}
+
+//////////////////////////////////////////////////
+common::ConnectionPtr Ogre2WideAngleCamera::ConnectNewWideAngleFrame(
+  std::function<void(const unsigned char *, unsigned int, unsigned int,
+                     unsigned int, const std::string &)>
+    _subscriber)
+{
+  return this->dataPtr->newImageFrame.Connect(_subscriber);
+}
+
+//////////////////////////////////////////////////
+RenderTargetPtr Ogre2WideAngleCamera::RenderTarget() const
+{
+  return this->dataPtr->wideAngleTexture;
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::PrepareForCubemapFacePass(
+  Ogre::CompositorPass *_pass)
+{
+  this->dataPtr->ogreCamera->setFOVy(Ogre::Degree(90));
+
+  auto const &bgColor = this->scene->BackgroundColor();
+  _pass->getRenderPassDesc()->setClearColour(
+    Ogre2Conversions::Convert(bgColor));
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::PrepareForFinalPass(Ogre::Pass *_pass)
+{
+  const double ratio = static_cast<double>(this->ImageWidth()) /
+                       static_cast<double>(this->ImageHeight());
+  const double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / ratio);
+  this->dataPtr->ogreCamera->setFOVy(Ogre::Radian(Ogre::Real(vfov)));
+
+  const float localHfov = static_cast<float>(this->HFOV().Radian());
+
+  Ogre::GpuProgramParametersSharedPtr psParams =
+    _pass->getFragmentProgramParameters();
+
+  psParams->setNamedConstant("c1", static_cast<Ogre::Real>(this->Lens().C1()));
+  psParams->setNamedConstant("c2", static_cast<Ogre::Real>(this->Lens().C2()));
+  psParams->setNamedConstant("c3", static_cast<Ogre::Real>(this->Lens().C3()));
+
+  if (this->Lens().ScaleToHFOV())
+  {
+    float param = (localHfov / 2) / this->Lens().C2() + this->Lens().C3();
+    float funRes = this->Lens().ApplyMappingFunction(static_cast<float>(param));
+
+    float newF = 1.0f / (this->Lens().C1() * funRes);
+
+    psParams->setNamedConstant("f", static_cast<Ogre::Real>(newF));
+  }
+  else
+  {
+    psParams->setNamedConstant("f", static_cast<Ogre::Real>(this->Lens().F()));
+  }
+
+  auto vecFun = this->Lens().MappingFunctionAsVector3d();
+
+  psParams->setNamedConstant("fun",
+                             Ogre::Vector3(vecFun.X(), vecFun.Y(), vecFun.Z()));
+
+  psParams->setNamedConstant(
+    "cutOffAngle", static_cast<Ogre::Real>(this->Lens().CutOffAngle()));
+
+  Ogre::GpuProgramParametersSharedPtr vsParams =
+    _pass->getVertexProgramParameters();
+  vsParams->setNamedConstant("ratio", static_cast<Ogre::Real>(ratio));
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCameraWorkspaceListenerPrivate::passPreExecute(
+  Ogre::CompositorPass *_pass)
+{
+  const uint32_t identifier = _pass->getDefinition()->mIdentifier;
+  if (identifier == kWideAngleCameraCubemapPassId)
+  {
+    this->owner.PrepareForCubemapFacePass(_pass);
+  }
+  else if (identifier == kWideAngleCameraQuadPassId)
+  {
+    GZ_ASSERT(
+      dynamic_cast<Ogre::CompositorPassQuad *>(_pass),
+      "Impossible! Corrupted memory? WideAngleCamera.compositor out of sync?");
+    Ogre::CompositorPassQuad *passQuad =
+      static_cast<Ogre::CompositorPassQuad *>(_pass);
+
+    Ogre::Pass *pass = passQuad->getPass();
+
+    this->owner.PrepareForFinalPass(pass);
+  }
+}

--- a/ogre2/src/media/materials/programs/GLSL/wide_lens_map_fp.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/wide_lens_map_fp.glsl
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#version ogre_glsl_ver_330
+
+vulkan( layout( ogre_P0 ) uniform Params { )
+  uniform float cutOffAngle;
+
+  // focal length
+  uniform float f;
+
+  // linear scaling constant
+  uniform float c1;
+
+  // angle scaling constant
+  uniform float c2;
+
+  // angle offset constant
+  uniform float c3;
+
+  // unit axis
+  // depends on the type of math function sin (X), tan (Y), or identity (Z)
+  uniform vec3 fun;
+vulkan( }; )
+
+vulkan_layout( location = 0 )
+in block
+{
+  vec2 fragPos;
+} inPs;
+
+vulkan_layout( ogre_t0 ) uniform textureCube envMap;
+vulkan( layout( ogre_s0 ) uniform sampler texSampler );
+
+vec3 map(float th, vec2 fragPos, float r)
+{
+  // spherical to cartesian conversion
+  return vec3(-sin(th)*fragPos.x/r, sin(th)*fragPos.y/r, cos(th));
+}
+
+vulkan_layout( location = 0 )
+out vec4 fragColor;
+
+void main()
+{
+  float r = length(inPs.fragPos);
+  // calculate angle from optical axis based on the mapping function specified
+  float param = r/(c1*f);
+  float theta = 0.0;
+  if (fun.x > 0)
+    theta = asin(param);
+  else if (fun.y > 0)
+    theta = atan(param);
+  else if (fun.z > 0)
+    theta = param;
+  theta = (theta-c3)*c2;
+
+  // compute the direction vector that will be used to sample from the cubemap
+  vec3 tc = map(theta, inPs.fragPos, r);
+
+  // sample and set resulting color
+  fragColor = vec4(texture(vkSamplerCube(envMap, texSampler), tc).rgb, 1);
+
+  // limit to visible fov
+  //TODO: move to vertex shader
+  float param2 = cutOffAngle/c2+c3;
+  float cutRadius = c1*f*(fun.x*sin(param2)+fun.y*tan(param2)+fun.z*param2);
+
+  // smooth edges
+  // gl_FragColor.rgb *= 1.0-step(cutRadius,r);
+  fragColor.rgb *= 1.0-smoothstep(cutRadius-0.02,cutRadius,r);
+}

--- a/ogre2/src/media/materials/programs/GLSL/wide_lens_map_vs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/wide_lens_map_vs.glsl
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#version ogre_glsl_ver_330
+
+vulkan_layout( OGRE_POSITION ) in vec4 vertex;
+
+vulkan( layout( ogre_P0 ) uniform Params { )
+  // aspect ratio
+  uniform float ratio;
+  uniform mat4 worldViewProj;
+vulkan( }; )
+
+vulkan_layout( location = 0 )
+out block
+{
+  vec2 fragPos;
+} outVs;
+
+void main()
+{
+  gl_Position = worldViewProj * vertex;
+
+  // get normalized fragment coordinate (3D to 2D window space transformation)
+  outVs.fragPos = gl_Position.xy/gl_Position.w*vec2(-1.0,-1.0/ratio);
+}

--- a/ogre2/src/media/materials/programs/Metal/wide_lens_map_fp.metal
+++ b/ogre2/src/media/materials/programs/Metal/wide_lens_map_fp.metal
@@ -54,22 +54,23 @@ fragment float4 main_metal
 (
   PS_INPUT inPs [[stage_in]],
   texturecube<float> envMap  [[texture(0)]],
-  sampler texSampler [[sampler(0)]]
+  sampler texSampler [[sampler(0)]],
+  constant Params &p [[buffer(PARAMETER_SLOT)]]
 )
 {
   float4 fragColor;
 
   float r = length(inPs.fragPos);
   // calculate angle from optical axis based on the mapping function specified
-  float param = r/(c1*f);
+  float param = r/(p.c1*p.f);
   float theta = 0.0;
-  if (fun.x > 0)
+  if (p.fun.x > 0)
     theta = asin(param);
-  else if (fun.y > 0)
+  else if (p.fun.y > 0)
     theta = atan(param);
-  else if (fun.z > 0)
+  else if (p.fun.z > 0)
     theta = param;
-  theta = (theta-c3)*c2;
+  theta = (theta-p.c3)*p.c2;
 
   // compute the direction vector that will be used to sample from the cubemap
   float3 tc = map(theta, inPs.fragPos, r);
@@ -79,8 +80,8 @@ fragment float4 main_metal
 
   // limit to visible fov
   //TODO: move to vertex shader
-  float param2 = cutOffAngle/c2+c3;
-  float cutRadius = c1*f*(fun.x*sin(param2)+fun.y*tan(param2)+fun.z*param2);
+  float param2 = p.cutOffAngle/p.c2+p.c3;
+  float cutRadius = p.c1*p.f*(p.fun.x*sin(param2)+p.fun.y*tan(param2)+p.fun.z*param2);
 
   // smooth edges
   // gl_FragColor.rgb *= 1.0-step(cutRadius,r);

--- a/ogre2/src/media/materials/programs/Metal/wide_lens_map_fp.metal
+++ b/ogre2/src/media/materials/programs/Metal/wide_lens_map_fp.metal
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct Params
+{
+  float cutOffAngle;
+
+  // focal length
+  float f;
+
+  // linear scaling constant
+  float c1;
+
+  // angle scaling constant
+  float c2;
+
+  // angle offset constant
+  float c3;
+
+  // unit axis
+  // depends on the type of math function sin (X), tan (Y), or identity (Z)
+  float3 fun;
+};
+
+struct PS_INPUT
+{
+  float2 fragPos;
+};
+
+float3 map(float th, float2 fragPos, float r)
+{
+  // spherical to cartesian conversion
+  return float3(-sin(th)*fragPos.x/r, sin(th)*fragPos.y/r, cos(th));
+}
+
+fragment float4 main_metal
+(
+  PS_INPUT inPs [[stage_in]],
+  texturecube<float> envMap  [[texture(0)]],
+  sampler texSampler [[sampler(0)]]
+)
+{
+  float4 fragColor;
+
+  float r = length(inPs.fragPos);
+  // calculate angle from optical axis based on the mapping function specified
+  float param = r/(c1*f);
+  float theta = 0.0;
+  if (fun.x > 0)
+    theta = asin(param);
+  else if (fun.y > 0)
+    theta = atan(param);
+  else if (fun.z > 0)
+    theta = param;
+  theta = (theta-c3)*c2;
+
+  // compute the direction vector that will be used to sample from the cubemap
+  float3 tc = map(theta, inPs.fragPos, r);
+
+  // sample and set resulting color
+  fragColor = float4(envMap.sample(texSampler, tc).rgb, 1);
+
+  // limit to visible fov
+  //TODO: move to vertex shader
+  float param2 = cutOffAngle/c2+c3;
+  float cutRadius = c1*f*(fun.x*sin(param2)+fun.y*tan(param2)+fun.z*param2);
+
+  // smooth edges
+  // gl_FragColor.rgb *= 1.0-step(cutRadius,r);
+  fragColor.rgb *= 1.0-smoothstep(cutRadius-0.02,cutRadius,r);
+
+  return fragColor;
+}

--- a/ogre2/src/media/materials/programs/Metal/wide_lens_map_vs.metal
+++ b/ogre2/src/media/materials/programs/Metal/wide_lens_map_vs.metal
@@ -26,8 +26,8 @@ struct VS_INPUT
 struct Params
 {
   // aspect ratio
-  uniform float ratio;
-  uniform float4x4 worldViewProj;
+  float ratio;
+  float4x4 worldViewProj;
 };
 
 struct PS_INPUT

--- a/ogre2/src/media/materials/programs/Metal/wide_lens_map_vs.metal
+++ b/ogre2/src/media/materials/programs/Metal/wide_lens_map_vs.metal
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <metal_stdlib>
+using namespace metal;
+
+struct VS_INPUT
+{
+  float4 position [[attribute(VES_POSITION)]];
+};
+
+struct Params
+{
+  // aspect ratio
+  uniform float ratio;
+  uniform float4x4 worldViewProj;
+};
+
+struct PS_INPUT
+{
+  float2 fragPos;
+  float4 gl_Position [[position]];
+};
+
+vertex PS_INPUT main_metal
+(
+  VS_INPUT input [[stage_in]],
+  constant Params &p [[buffer(PARAMETER_SLOT)]]
+)
+{
+  PS_INPUT outVs;
+
+  outVs.gl_Position = p.worldViewProj * input.position;
+
+  // get normalized fragment coordinate (3D to 2D window space transformation)
+  outVs.fragPos = outVs.gl_Position.xy/outVs.gl_Position.w*float2(-1.0,-1.0/p.ratio);
+
+  return outVs;
+}

--- a/ogre2/src/media/materials/scripts/wide_angle_camera.compositor
+++ b/ogre2/src/media/materials/scripts/wide_angle_camera.compositor
@@ -1,0 +1,106 @@
+abstract target cubemap_target
+{
+  pass render_scene
+  {
+    load
+    {
+      all           clear
+      clear_colour  0 0 0 1
+    }
+    store
+    {
+      depth         dont_care
+      stencil       dont_care
+    }
+
+    overlays			off
+    camera_cubemap_reorient true
+
+    shadows PbsMaterialsShadowNode recalculate
+
+    profiling_id "Cubemap WideAngleCamera pass"
+
+    // kWideAngleCameraCubemapPassId
+    identifier 1276660
+  }
+}
+
+compositor_node WideAngleCameraCubemapPass
+{
+  in 0 cubeTexture
+
+  target cubeTexture  +X : cubemap_target { }
+  target cubeTexture  -X : cubemap_target { }
+  target cubeTexture  +Y : cubemap_target { }
+  target cubeTexture  -Y : cubemap_target { }
+  target cubeTexture  +Z : cubemap_target { }
+  target cubeTexture  -Z : cubemap_target { }
+}
+
+compositor_node WideAngleCameraCubemapPassMsaa
+{
+  in 0 cubeTexture
+
+  texture tmpMsaa target_width target_height target_format msaa 4 explicit_resolve
+
+  rtv mixedCubemapRtv
+  {
+    // Specify we want to render to tmpMsaa at slot[0]
+    // but we want to resolve to tmpCubemap
+    colour	0 tmpMsaa resolve cubeTexture
+  }
+
+  target mixedCubemapRtv  +X : cubemap_target { }
+  target mixedCubemapRtv  -X : cubemap_target { }
+  target mixedCubemapRtv  +Y : cubemap_target { }
+  target mixedCubemapRtv  -Y : cubemap_target { }
+  target mixedCubemapRtv  +Z : cubemap_target { }
+  target mixedCubemapRtv  -Z : cubemap_target { }
+}
+
+compositor_node WideAngleCameraFinalPass
+{
+  in 0 cubeTexture
+  in 1 finalOutput
+
+  target finalOutput
+  {
+    pass render_quad
+    {
+      load
+      {
+        all dont_care
+      }
+      store
+      {
+        depth   dont_care
+        stencil dont_care
+      }
+
+      // kWideAngleCameraQuadPassId
+      identifier 1276661
+
+      profiling_id "Map Cubemap to Wide Lens"
+
+      material WideLensMap
+
+      input 0 cubeTexture
+    }
+  }
+}
+
+workspace WideAngleCameraWorkspace
+{
+  connect_external 0 WideAngleCameraCubemapPass 0
+
+  connect_external 0 WideAngleCameraFinalPass 0
+  connect_external 1 WideAngleCameraFinalPass 1
+}
+
+workspace WideAngleCameraWorkspaceMsaa
+{
+  connect_external 0 WideAngleCameraCubemapPassMsaa 0
+
+  connect_external 0 WideAngleCameraFinalPass 0
+  connect_external 1 WideAngleCameraFinalPass 1
+}

--- a/ogre2/src/media/materials/scripts/wide_angle_camera.material
+++ b/ogre2/src/media/materials/scripts/wide_angle_camera.material
@@ -7,6 +7,10 @@ vertex_program WideLensMapVS_GLSL glsl
 fragment_program WideLensMapFS_GLSL glsl
 {
   source wide_lens_map_fp.glsl
+  default_params
+  {
+    param_named envMap int 0
+  }
 }
 
 // Vulkan shaders
@@ -54,7 +58,6 @@ fragment_program WideLensMapFS unified
 
   default_params
   {
-    param_named envMap int 0
     param_named c1 float 1
     param_named c2 float 1
     param_named c3 float 0

--- a/ogre2/src/media/materials/scripts/wide_angle_camera.material
+++ b/ogre2/src/media/materials/scripts/wide_angle_camera.material
@@ -1,0 +1,87 @@
+// GLSL shaders
+vertex_program WideLensMapVS_GLSL glsl
+{
+  source wide_lens_map_vs.glsl
+}
+
+fragment_program WideLensMapFS_GLSL glsl
+{
+  source wide_lens_map_fp.glsl
+}
+
+// Vulkan shaders
+vertex_program WideLensMapVS_VK glslvk
+{
+  source wide_lens_map_vs.glsl
+}
+
+fragment_program WideLensMapFS_VK glslvk
+{
+  source wide_lens_map_fp.glsl
+}
+
+// Metal shaders
+vertex_program WideLensMapVS_Metal metal
+{
+  source wide_lens_map_vs.metal
+}
+
+fragment_program WideLensMapFS_Metal metal
+{
+  source wide_lens_map_fp.metal
+  shader_reflection_pair_hint WideLensMapVS_Metal
+}
+
+// Unified shaders
+vertex_program WideLensMapVS unified
+{
+  delegate WideLensMapVS_GLSL
+  delegate WideLensMapVS_Metal
+  delegate WideLensMapVS_VK
+
+  default_params
+  {
+    param_named ratio float 1
+    param_named_auto worldViewProj worldviewproj_matrix
+  }
+}
+
+fragment_program WideLensMapFS unified
+{
+  delegate WideLensMapFS_GLSL
+  delegate WideLensMapFS_Metal
+  delegate WideLensMapFS_VK
+
+  default_params
+  {
+    param_named envMap int 0
+    param_named c1 float 1
+    param_named c2 float 1
+    param_named c3 float 0
+    param_named f float 1
+    param_named fun float3 0 0 1
+    param_named cutOffAngle float 3.14
+  }
+}
+
+material WideLensMap
+{
+  technique
+  {
+    pass
+    {
+      depth_check off
+      depth_write off
+      cull_hardware none
+
+      vertex_program_ref WideLensMapVS { }
+      fragment_program_ref WideLensMapFS { }
+
+      texture_unit RT
+      {
+      }
+    }
+  }
+}
+
+

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -68,7 +68,7 @@ void OnNewWideAngleFrame(const unsigned char *_data,
 //////////////////////////////////////////////////
 TEST_F(WideAngleCameraTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(WideAngleCamera))
 {
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_UNSUPPORTED_ENGINE("optix");
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);
@@ -205,7 +205,7 @@ TEST_F(WideAngleCameraTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(WideAngleCamera))
 //////////////////////////////////////////////////
 TEST_F(WideAngleCameraTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Projection))
 {
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_UNSUPPORTED_ENGINE("optix");
 
   gz::rendering::ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);


### PR DESCRIPTION
# 🎉 New feature

Closes #729 

## Summary

This PR ports OgreWideAngleCamera to Ogre2 engine.

Includes Vulkan, OpenGL & Metal shaders (Metal support not tested)

## Test it

Edit `wide_angle_camera.sdf` so that:

```
    <plugin
      filename="gz-sim-sensors-system"
      name="gz::sim::systems::Sensors">
      <render_engine>ogre</render_engine>
    </plugin>
```

No longer says ogre and run:

`gz sim wide_angle_camera.sdf`

## Can it be backported to Garden?

The only major/blocking issue I see is that `Ogre2Scene::CreateWideAngleCameraImpl` was added (and is obviously necessary) but adding it breaks the ABI.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
