### PR TITLE
Prevent multiple singletons from being instantiated

### DIFF
--- a/examples/hello_world_plugin/HelloWorldPlugin.cc
+++ b/examples/hello_world_plugin/HelloWorldPlugin.cc
@@ -27,8 +27,7 @@ namespace mock
 {
   /// \brief The render engine class which implements a render engine.
   class HelloWorldRenderEngine :
-    public virtual gz::rendering::BaseRenderEngine,
-    public gz::common::SingletonT<HelloWorldRenderEngine>
+    public virtual gz::rendering::BaseRenderEngine
   {
     // Documentation Inherited.
     public: virtual bool IsEnabled() const override
@@ -40,6 +39,13 @@ namespace mock
     public: virtual std::string Name() const override
     {
       return "HelloWorldPlugin";
+    }
+
+    /// \brief Get a pointer to the render engine
+    /// \return a pointer to the render engine
+    public: static HelloWorldRenderEngine *Instance()
+    {
+      return gz::common::SingletonT<HelloWorldRenderEngine>::Instance();
     }
 
     // Documentation Inherited.

--- a/include/gz/rendering/RenderEngineManager.hh
+++ b/include/gz/rendering/RenderEngineManager.hh
@@ -135,6 +135,11 @@ namespace gz
       /// \param[in] _paths The list of the plugin paths
       public: void SetPluginPaths(const std::list<std::string> &_paths);
 
+      /// \brief Get a pointer to the render engine manager
+      /// \todo(anyone) Remove inheritance from Singleton base class
+      /// \return a pointer to the render engine manager
+      public: static RenderEngineManager *Instance();
+
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief private implementation details
       private: std::unique_ptr<RenderEngineManagerPrivate> dataPtr;

--- a/ogre/include/gz/rendering/ogre/OgreRTShaderSystem.hh
+++ b/ogre/include/gz/rendering/ogre/OgreRTShaderSystem.hh
@@ -168,6 +168,11 @@ namespace gz
       /// \sa OgreScene::PreRender
       public: void Update();
 
+      /// \brief Get a pointer to the Ogre RT shader system
+      /// \todo(anyone) Remove inheritance from Singleton base class
+      /// \return a pointer to the Ogre RT shader system
+      public: static OgreRTShaderSystem *Instance();
+
       /// \brief Make the RTShader system a singleton.
       private: friend class common::SingletonT<OgreRTShaderSystem>;
 

--- a/ogre/include/gz/rendering/ogre/OgreRenderEngine.hh
+++ b/ogre/include/gz/rendering/ogre/OgreRenderEngine.hh
@@ -113,6 +113,11 @@ namespace gz
       /// \return a list of FSAA levels
       public: std::vector<unsigned int> FSAALevels() const;
 
+      /// \brief Get a pointer to the render engine
+      /// \todo(anyone) Remove inheritance from Singleton base class
+      /// \return a pointer to the render engine
+      public: static OgreRenderEngine *Instance();
+
       protected: virtual ScenePtr CreateSceneImpl(unsigned int _id,
                   const std::string &_name) override;
 

--- a/ogre/src/OgreRTShaderSystem.cc
+++ b/ogre/src/OgreRTShaderSystem.cc
@@ -752,3 +752,9 @@ bool OgreRTShaderSystem::IsInitialized() const
 {
   return this->dataPtr->initialized;
 }
+
+//////////////////////////////////////////////////
+OgreRTShaderSystem *OgreRTShaderSystem::Instance()
+{
+  return SingletonT<OgreRTShaderSystem>::Instance();
+}

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -835,6 +835,12 @@ Ogre::OverlaySystem *OgreRenderEngine::OverlaySystem() const
 }
 #endif
 
+//////////////////////////////////////////////////
+OgreRenderEngine *OgreRenderEngine::Instance()
+{
+  return SingletonT<OgreRenderEngine>::Instance();
+}
+
 // Register this plugin
 GZ_ADD_PLUGIN(gz::rendering::OgreRenderEnginePlugin,
                     gz::rendering::RenderEnginePlugin)

--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderEngine.hh
@@ -224,6 +224,11 @@ namespace gz
       public: Ogre::CompositorWorkspaceListener
           *TerraWorkspaceListener() const;
 
+      /// \brief Get a pointer to the render engine
+      /// \todo(anyone) Remove inheritance from Singleton base class
+      /// \return a pointer to the render engine
+      public: static Ogre2RenderEngine *Instance();
+
       /// \brief Pointer to the ogre's overlay system
       private: Ogre::v1::OverlaySystem *ogreOverlaySystem = nullptr;
 

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1184,6 +1184,12 @@ Ogre::CompositorWorkspaceListener *Ogre2RenderEngine::TerraWorkspaceListener()
   return this->dataPtr->terraWorkspaceListener.get();
 }
 
+//////////////////////////////////////////////////
+Ogre2RenderEngine *Ogre2RenderEngine::Instance()
+{
+  return SingletonT<Ogre2RenderEngine>::Instance();
+}
+
 // Register this plugin
 GZ_ADD_PLUGIN(gz::rendering::Ogre2RenderEnginePlugin,
                     gz::rendering::RenderEnginePlugin)

--- a/optix/include/gz/rendering/optix/OptixRenderEngine.hh
+++ b/optix/include/gz/rendering/optix/OptixRenderEngine.hh
@@ -65,6 +65,11 @@ namespace gz
 
       public: std::string PtxFile(const std::string& _fileBase) const;
 
+      /// \brief Get a pointer to the render engine
+      /// \todo(anyone) Remove inheritance from Singleton base class
+      /// \return a pointer to the render engine
+      public: static OptixRenderEngine *Instance();
+
       protected: virtual ScenePtr CreateSceneImpl(unsigned int _id,
                   const std::string &_name);
 

--- a/optix/src/OptixRenderEngine.cc
+++ b/optix/src/OptixRenderEngine.cc
@@ -147,6 +147,12 @@ bool OptixRenderEngine::InitImpl()
   return true;
 }
 
+//////////////////////////////////////////////////
+OptixRenderEngine *OptixRenderEngine::Instance()
+{
+  return SingletonT<OptixRenderEngine>::Instance();
+}
+
 // Register this plugin
 GZ_ADD_PLUGIN(gz::rendering::OptixRenderEnginePlugin,
                     gz::rendering::RenderEnginePlugin)

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -384,6 +384,12 @@ void RenderEngineManager::SetPluginPaths(const std::list<std::string> &_paths)
 }
 
 //////////////////////////////////////////////////
+RenderEngineManager *RenderEngineManager::Instance()
+{
+  return SingletonT<RenderEngineManager>::Instance();
+}
+
+//////////////////////////////////////////////////
 // RenderEngineManagerPrivate
 //////////////////////////////////////////////////
 RenderEngine *RenderEngineManagerPrivate::Engine(EngineInfo _info,


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

# 🦟 Bug fix

## Summary

Similar to the fix done in https://github.com/gazebosim/gz-common/pull/451, the changes here aim to prevent multiple copies of a singleton from being instantiated in the plugins. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
