### PR TITLE
Initialize wide angle camera pixel format

### DIFF
--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -321,7 +321,7 @@ void OgreWideAngleCamera::CreateWideAngleTexture()
       Ogre::TextureManager::getSingleton().createManual(
       this->Name() + "_wideAngleCamera", "General", Ogre::TEX_TYPE_2D,
       this->ImageWidth(), this->ImageHeight(), 0,
-      Ogre::PF_R8G8B8, Ogre::TU_RENDERTARGET,
+      OgreConversions::Convert(this->ImageFormat()), Ogre::TU_RENDERTARGET,
       0, false, 0).get();
     Ogre::RenderTarget *rt =
         this->dataPtr->ogreRenderTexture->getBuffer()->getRenderTarget();
@@ -620,7 +620,7 @@ void OgreWideAngleCamera::PostRender()
   unsigned int height = this->ImageHeight();
   unsigned int len = width * height;
 
-  PixelFormat format = PF_R8G8B8;
+  PixelFormat format = this->ImageFormat();
   unsigned int channelCount = PixelUtil::ChannelCount(format);
   unsigned int bytesPerChannel = PixelUtil::BytesPerChannel(format);
 
@@ -641,7 +641,8 @@ void OgreWideAngleCamera::PostRender()
       height*width*channelCount*bytesPerChannel);
 
   this->dataPtr->newImageFrame(
-      this->dataPtr->wideAngleImage, width, height, channelCount, "PF_R8G8B8");
+      this->dataPtr->wideAngleImage, width, height, channelCount,
+      PixelUtil::Name(this->ImageFormat()));
 
   // Uncomment to debug wide angle cameraoutput
   // gzdbg << "wxh: " << width << " x " << height << std::endl;

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -62,7 +62,7 @@ class gz::rendering::OgreWideAngleCamera::Implementation
   public: Ogre::Viewport *envViewports[6];
 
   /// \brief Pixel format for cube map texture
-  public: Ogre::PixelFormat envCubeMapTextureFormat;
+  public: Ogre::PixelFormat envCubeMapTextureFormat = Ogre::PF_BYTE_RGB;
 
   /// \brief A single cube map texture
   public: Ogre::Texture *envCubeMapTexture = nullptr;
@@ -361,6 +361,9 @@ void OgreWideAngleCamera::CreateWideAngleTexture()
       ogreFSAAWarn = true;
     }
   }
+
+  this->dataPtr->envCubeMapTextureFormat =
+      OgreConversions::Convert(this->ImageFormat());
 
   this->dataPtr->envCubeMapTexture =
       Ogre::TextureManager::getSingleton().createManual(

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -142,6 +142,7 @@ TEST_F(WideAngleCameraTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(WideAngleCamera))
   EXPECT_EQ(1, g_counter);
 
   // Compare image pixels
+  EXPECT_EQ(PF_R8G8B8, camera->ImageFormat());
   unsigned int channelCount = PixelUtil::ChannelCount(camera->ImageFormat());
   unsigned int step = width * channelCount;
 

--- a/test/integration/wide_angle_camera.cc
+++ b/test/integration/wide_angle_camera.cc
@@ -51,7 +51,7 @@ int g_counter = 0;
 void OnNewWideAngleFrame(const unsigned char *_data,
                     unsigned int _width, unsigned int _height,
                     unsigned int _channels,
-                    const std::string &/*_format*/)
+                    const std::string &_format)
 {
   g_mutex.lock();
   auto bufferSize = _width * _height * _channels;
@@ -60,6 +60,9 @@ void OnNewWideAngleFrame(const unsigned char *_data,
     g_buffer = new unsigned char[bufferSize];
 
   memcpy(g_buffer, _data, bufferSize);
+
+
+  EXPECT_EQ("R8G8B8", _format);
 
   g_counter++;
   g_mutex.unlock();


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

In response to bug reported in https://github.com/gazebosim/gz-rendering/issues/729#issuecomment-1272381346

## Summary

Initializes wide angle camera's env map pixel format to the same format that is set to the wide angle camera. I also updated other parts in the code that has use the hardcoded `R8G8B8` type.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

