### PR TITLE
Fix wrong Z check in OgreWideAngleCamera::Project3d

### DIFF
--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -505,8 +505,9 @@ math::Vector3d OgreWideAngleCamera::Project3d(
     auto pos = viewProj * Ogre::Vector4(OgreConversions::Convert(_pt));
     pos.x /= pos.w;
     pos.y /= pos.w;
+    pos.z /= pos.w;
     // check if point is visible
-    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 && pos.z > 0)
+    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 && std::fabs(pos.z) <= 1)
     {
       // determine dir vector to projected point from env camera
       // work in y up, z forward, x right clip space

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -505,9 +505,11 @@ math::Vector3d OgreWideAngleCamera::Project3d(
     auto pos = viewProj * Ogre::Vector4(OgreConversions::Convert(_pt));
     pos.x /= pos.w;
     pos.y /= pos.w;
-    pos.z /= pos.w;
-    // check if point is visible
-    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 && std::fabs(pos.z) <= 1)
+    // check if point is visible.
+    // pos.z is in range [-w; w] so we check if it's > -w then
+    // it means it's in front of us.
+    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 &&
+        pos.z > -std::fabs(pos.w))
     {
       // determine dir vector to projected point from env camera
       // work in y up, z forward, x right clip space


### PR DESCRIPTION
# 🦟 Bug fix

There is no ticket assigned to this bug

## Summary

The matrix returned by Ogre::Camera::getProjectionMatrix has Z in range [-1; 1], not range [0; 1]

This means we can't do pos.z > 0. We must do pos.z / pos.w > -1 Additionally, we must check against against z < 1; otherwise the point may get picked by the wrong face (and fail tests).

I found this bug while porting OgreWideAngleCamera to ogre2

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.