### PR TITLE
Suppress Windows warnings

### DIFF
--- a/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreIncludes.hh
@@ -17,17 +17,17 @@
 #ifndef IGNITION_RENDERING_OGRE_OGREINCLUDES_HH_
 #define IGNITION_RENDERING_OGRE_OGREINCLUDES_HH_
 
-// This disables warning messages for OGRE
-#ifndef _MSC_VER
+#if defined(__clang__)
+  // This prevents some deprecation #warning messages on OSX 10.9
+  #pragma clang diagnostic ignored "-W#warnings"
+#elif defined(__GNUC__) || defined(__GNUG__)
   #pragma GCC system_header
-#else
-  #pragma warning(push, 0)
-  #pragma warning(disable:4275)
-  #pragma warning(disable:4005)
+#elif defined(_MSC_VER)
+  // This disables warning messages for OGRE
+  #pragma warning(push)
+  #pragma warning(disable: 4275)
+  #pragma warning(disable: 4005)
 #endif
-
-// This prevents some deprecation #warning messages on OSX 10.9
-#pragma clang diagnostic ignored "-W#warnings"
 
 #include <Ogre.h>
 #include <OgreBillboard.h>
@@ -85,8 +85,8 @@
   #include <OgreFontManager.h>
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(pop)
+#if defined(_MSC_VER)
+  #pragma warning(pop)
 #endif
 
-#endif
+#endif  // IGNITION_RENDERING_OGRE_OGREINCLUDES_HH_

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -19,7 +19,7 @@
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 #else
-# pragma warning(push, 0)
+# pragma warning(push)
 # pragma warning(disable: 4005)
 # pragma warning(disable: 4275)
 #endif

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Includes.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Includes.hh
@@ -17,15 +17,18 @@
 #ifndef IGNITION_RENDERING_OGRE2_OGRE2INCLUDES_HH_
 #define IGNITION_RENDERING_OGRE2_OGRE2INCLUDES_HH_
 
-// This disables warning messages for OGRE
-#ifndef _MSC_VER
+#if defined(__clang__)
+  // This prevents some deprecation #warning messages on OSX 10.9
+  #pragma clang diagnostic ignored "-W#warnings"
+#elif defined(__GNUC__) || defined(__GNUG__)
   #pragma GCC system_header
-#else
-  #pragma warning(push, 0)
+#elif defined(_MSC_VER)
+  // This disables warning messages for OGRE
+  #pragma warning(push)
+  #pragma warning(disable: 4275)
+  #pragma warning(disable: 4005)
+  #pragma warning(disable: 5033)
 #endif
-
-// This prevents some deprecation #warning messages on OSX 10.9
-#pragma clang diagnostic ignored "-W#warnings"
 
 #include <Ogre.h>
 #include <OgreBillboard.h>
@@ -99,8 +102,8 @@
 // #include <Terrain/OgreTerrain.h>
 // #include <Terrain/OgreTerrainGroup.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 
-#endif
+#endif  // IGNITION_RENDERING_OGRE2_OGRE2INCLUDES_HH_

--- a/ogre2/src/Ogre2DynamicRenderable.cc
+++ b/ogre2/src/Ogre2DynamicRenderable.cc
@@ -17,11 +17,12 @@
 
 // Note this include is placed in the src file because
 // otherwise ogre produces compile errors
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 5033)
 #endif
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -226,13 +226,13 @@ void Ogre2LaserRetroMaterialSwitcher::preRenderTargetUpdate(
         {
           try
           {
-            retroValue = std::get<double>(tempLaserRetro);
+            retroValue = static_cast<float>(std::get<double>(tempLaserRetro));
           }
           catch(...)
           {
             try
             {
-              retroValue = std::get<int>(tempLaserRetro);
+              retroValue = static_cast<float>(std::get<int>(tempLaserRetro));
             }
             catch(std::bad_variant_access &e)
             {
@@ -486,19 +486,19 @@ math::Vector2d Ogre2GpuRays::SampleCubemap(const math::Vector3d &_v,
   math::Vector2d uv;
   if (vAbs.Z() >= vAbs.X() && vAbs.Z() >= vAbs.Y())
   {
-    _faceIndex = _v.Z() < 0.0 ? 5.0 : 4.0;
+    _faceIndex = _v.Z() < 0.0 ? 5 : 4;
     ma = 0.5 / vAbs.Z();
     uv = math::Vector2d(_v.Z() < 0.0 ? -_v.X() : _v.X(), -_v.Y());
   }
   else if (vAbs.Y() >= vAbs.X())
   {
-    _faceIndex = _v.Y() < 0.0 ? 3.0 : 2.0;
+    _faceIndex = _v.Y() < 0.0 ? 3 : 2;
     ma = 0.5 / vAbs.Y();
     uv = math::Vector2d(_v.X(), _v.Y() < 0.0 ? -_v.Z() : _v.Z());
   }
   else
   {
-    _faceIndex = _v.X() < 0.0 ? 1.0 : 0.0;
+    _faceIndex = _v.X() < 0.0 ? 1 : 0;
     ma = 0.5 / vAbs.X();
     uv = math::Vector2d(_v.X() < 0.0 ? _v.Z() : -_v.Z(), -_v.Y());
   }
@@ -564,7 +564,7 @@ void Ogre2GpuRays::CreateSampleTexture()
       // v
       *pDest++ = uv.Y();
       // face
-      *pDest++ = faceIdx;
+      *pDest++ = static_cast<float>(faceIdx);
 
        h += hStep;
     }

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -17,11 +17,13 @@
 
 // Note this include is placed in the src file because
 // otherwise ogre produces compile errors
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4005)  // Macro redefinition
+#pragma warning(disable: 5033)  // 'register' is no longer supported
 #endif
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 

--- a/ogre2/src/Ogre2MaterialSwitcher.cc
+++ b/ogre2/src/Ogre2MaterialSwitcher.cc
@@ -28,7 +28,7 @@ using namespace rendering;
 /////////////////////////////////////////////////
 Ogre2MaterialSwitcher::Ogre2MaterialSwitcher(Ogre2ScenePtr _scene)
 {
-  this->currentColor = math::Color(0.0, 0.0, 0.1);
+  this->currentColor = math::Color(0.0f, 0.0f, 0.1f);
   this->scene = _scene;
 
   // plain opaque material

--- a/ogre2/src/Ogre2Mesh.cc
+++ b/ogre2/src/Ogre2Mesh.cc
@@ -17,11 +17,13 @@
 
 // Note this include is placed in the src file because
 // otherwise ogre produces compile errors
-#ifdef _MSC_VER
-#pragma warning(push, 0)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4005)  // Macro redefinition
+#pragma warning(disable: 5033)  // 'register' is no longer supported
 #endif
 #include <Hlms/Pbs/OgreHlmsPbsDatablock.h>
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -18,7 +18,9 @@
 // leave this out of OgreIncludes as it conflicts with other files requiring
 // gl.h
 #ifdef _MSC_VER
-#pragma warning(push, 0)
+#pragma warning(push)
+#pragma warning(disable: 4005)  // Macro redefinition
+#pragma warning(disable: 5033)  // 'register' is no longer supported
 #endif
 #include <OgreGL3PlusFBORenderTexture.h>
 #ifdef _MSC_VER
@@ -380,7 +382,7 @@ void Ogre2RenderTarget::UpdateShadowNode()
   // directional lights
   unsigned int atlasId = 0u;
   unsigned int texSize = 2048u;
-  unsigned int halfTexSize = texSize * 0.5;
+  unsigned int halfTexSize = static_cast<unsigned int>(texSize * 0.5);
   for (unsigned int i = 0; i < dirLightCount; ++i)
   {
     shadowParam.technique = Ogre::SHADOWMAP_PSSM;
@@ -589,12 +591,18 @@ void Ogre2RenderTarget::CreateShadowNodeWithSettings(
     for (size_t j = 0; j < numSplits; ++j)
     {
       Ogre::Vector2 uvOffset(
-          shadowParam.atlasStart[j].x, shadowParam.atlasStart[j].y);
+          static_cast<Ogre::Real>(shadowParam.atlasStart[j].x),
+          static_cast<Ogre::Real>(shadowParam.atlasStart[j].y));
       Ogre::Vector2 uvLength(
-          shadowParam.resolution[j].x, shadowParam.resolution[j].y);
+          static_cast<Ogre::Real>(shadowParam.resolution[j].x),
+          static_cast<Ogre::Real>(shadowParam.resolution[j].y));
 
-      uvOffset /= Ogre::Vector2(texResolution.x, texResolution.y);
-      uvLength /= Ogre::Vector2(texResolution.x, texResolution.y);
+      Ogre::Vector2 resolution(
+          static_cast<Ogre::Real>(texResolution.x),
+          static_cast<Ogre::Real>(texResolution.y));
+
+      uvOffset /= resolution;
+      uvLength /= resolution;
 
       const Ogre::String texName =
           "atlas" + Ogre::StringConverter::toString(shadowParam.atlasId);

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -30,7 +30,7 @@
 using namespace ignition;
 using namespace rendering;
 
-class ignition::rendering::Ogre2SelectionBufferPrivate
+struct ignition::rendering::Ogre2SelectionBufferPrivate
 {
   /// \brief This is a material listener and a RenderTargetListener.
   /// The material switcher is applied to only the selection camera
@@ -237,7 +237,7 @@ Ogre::Item *Ogre2SelectionBuffer::OnSelectionClick(const int _x, const int _y)
       this->dataPtr->camera->getDerivedOrientation());
   Ogre::Viewport* renderViewport =
       this->dataPtr->renderTexture->getViewport(0);
-  renderViewport->setDimensions(0, 0, width, height);
+  renderViewport->setDimensions(0, 0, Ogre::Real(width), Ogre::Real(height));
 
   // update render texture
   this->Update();

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -194,13 +194,13 @@ void Ogre2ThermalCameraMaterialSwitcher::preRenderTargetUpdate(
         {
           try
           {
-            temp = std::get<double>(tempAny);
+            temp = static_cast<float>(std::get<double>(tempAny));
           }
           catch(...)
           {
             try
             {
-              temp = std::get<int>(tempAny);
+              temp = static_cast<float>(std::get<int>(tempAny));
             }
             catch(std::bad_variant_access &e)
             {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Cleans up Windows warnings from OGRE headers.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.