### PR TITLE
Calculate camera intrinsics : Refactor https://github.com/gazebosim/gz-rendering/pull/700

### DIFF
--- a/include/gz/rendering/Utils.hh
+++ b/include/gz/rendering/Utils.hh
@@ -98,6 +98,16 @@ namespace gz
         const gz::math::AxisAlignedBox &_box,
         const gz::math::Pose3d &_pose);
     }
+
+    /// \brief Get the camera's intrinsic matrix.
+    /// This matrix is different than the matrix returned from
+    /// ProjectionMatrix() which is used by OpenGL internally.
+    /// The matrix returned contains the camera calibrated values.
+    /// \return intrinsic matrix
+    GZ_RENDERING_VISIBLE
+    gz::math::Matrix3d projectionToCameraIntrinsic(
+        gz::math::Matrix4d _projectionMatrix,
+        double _width, double _height);
   }
 }
 #endif

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -164,6 +164,25 @@ float screenScalingFactor()
 }
 
 /////////////////////////////////////////////////
+gz::math::Matrix3d projectionToCameraIntrinsic(
+    gz::math::Matrix4d _projectionMatrix,
+    double _width, double _height)
+{
+  // Extracting the intrinsic matrix :
+  // https://ogrecave.github.io/ogre/api/13/class_ogre_1_1_math.html
+  double fX = (_projectionMatrix(0, 0) * _width) / 2.0;
+  double fY = (_projectionMatrix(1, 1) * _height) / 2.0;
+  double cX = (-1.0 * _width *
+               (_projectionMatrix(0, 2) - 1.0)) / 2.0;
+  double cY = _height + (_height *
+               (_projectionMatrix(1, 2) - 1)) / 2.0;
+
+  return gz::math::Matrix3d(fX, 0, cX,
+                            0, fY, cY,
+                            0, 0, 1);
+}
+
+/////////////////////////////////////////////////
 gz::math::AxisAlignedBox transformAxisAlignedBox(
     const gz::math::AxisAlignedBox &_bbox,
     const gz::math::Pose3d &_pose)

--- a/test/common_test/Camera_TEST.cc
+++ b/test/common_test/Camera_TEST.cc
@@ -19,10 +19,13 @@
 
 #include "CommonRenderingTest.hh"
 
+#include <gz/utils/ExtraTestMacros.hh>
+
 #include "gz/rendering/Camera.hh"
 #include "gz/rendering/GaussianNoisePass.hh"
 #include "gz/rendering/RenderPassSystem.hh"
 #include "gz/rendering/Scene.hh"
+#include "gz/rendering/Utils.hh"
 
 using namespace gz;
 using namespace rendering;
@@ -294,6 +297,73 @@ TEST_F(CameraTest, VisibilityMask)
 
   camera->SetVisibilityMask(0u);
   EXPECT_EQ(0u, camera->VisibilityMask());
+
+  // Clean up
+  engine->DestroyScene(scene);
+}
+
+/////////////////////////////////////////////////
+TEST_F(CameraTest, IntrinsicMatrix)
+{
+  ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+
+  CameraPtr camera = scene->CreateCamera();
+  EXPECT_TRUE(camera != nullptr);
+
+  unsigned int width = 320;
+  unsigned int height = 240;
+  double hfov = 1.047;
+
+  camera->SetImageHeight(height);
+  camera->SetImageWidth(width);
+  camera->SetHFOV(hfov);
+
+  double error = 1e-1;
+  EXPECT_EQ(camera->ImageHeight(), height);
+  EXPECT_EQ(camera->ImageWidth(), width);
+  EXPECT_NEAR(camera->HFOV().Radian(), hfov, error);
+
+  // Verify focal length and optical center from intrinsics
+  auto cameraIntrinsics = projectionToCameraIntrinsic(
+      camera->ProjectionMatrix(),
+      camera->ImageWidth(),
+      camera->ImageHeight()
+    );
+  EXPECT_NEAR(cameraIntrinsics(0, 0), 277.1913, error);
+  EXPECT_NEAR(cameraIntrinsics(1, 1), 277.1913, error);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(0, 2), 160);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(1, 2), 120);
+
+  // Verify rest of the intrinsics
+  EXPECT_EQ(cameraIntrinsics(0, 1), 0);
+  EXPECT_EQ(cameraIntrinsics(1, 0), 0);
+  EXPECT_EQ(cameraIntrinsics(0, 1), 0);
+  EXPECT_EQ(cameraIntrinsics(2, 0), 0);
+  EXPECT_EQ(cameraIntrinsics(2, 1), 0);
+  EXPECT_EQ(cameraIntrinsics(2, 2), 1);
+
+  // Verify that changing camera size changes intrinsics
+  height = 1000;
+  width = 1000;
+  camera->SetImageHeight(height);
+  camera->SetImageWidth(width);
+  camera->SetHFOV(hfov);
+
+  EXPECT_EQ(camera->ImageHeight(), height);
+  EXPECT_EQ(camera->ImageWidth(), width);
+  EXPECT_NEAR(camera->HFOV().Radian(), hfov, error);
+
+  // Verify if intrinsics have changed
+  cameraIntrinsics = projectionToCameraIntrinsic(
+      camera->ProjectionMatrix(),
+      camera->ImageWidth(),
+      camera->ImageHeight()
+    );
+  EXPECT_NEAR(cameraIntrinsics(0, 0), 866.223, error);
+  EXPECT_NEAR(cameraIntrinsics(1, 1), 866.223, error);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(0, 2), 500);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(1, 2), 500);
 
   // Clean up
   engine->DestroyScene(scene);


### PR DESCRIPTION
🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

## Summary
This PR backports https://github.com/gazebosim/gz-rendering/pull/700 so that it can be used in garden. This adds a function to Utils.cc that calculates camera intrinsics when supplied with the projection matrix.

## Test it
Added a test case to Camera_TEST.cc

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸