### PR TITLE
Enable GPU based ray queries on mac

### DIFF
--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -130,10 +130,6 @@ RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
 {
   RayQueryResult result;
 
-
-#ifdef __APPLE__
-  return this->ClosestPointByIntersection(_forceSceneUpdate);
-#else
   if (!this->dataPtr->camera ||
       !this->dataPtr->camera->Parent() ||
       std::this_thread::get_id() != this->dataPtr->threadId)
@@ -153,7 +149,6 @@ RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
 
     return this->ClosestPointBySelectionBuffer();
   }
-#endif
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>


# 🦟 Bug fix

## Summary

Enable GPU based ray queries on macOS since we now have the metal shaders in place, see https://github.com/gazebosim/gz-rendering/issues/747. 

I tested locally on my mac and mouse picking, camera control, and transform control are working.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

