### PR TITLE
Enable Heightmap Test for ogre2 & fix crash when using GpuRays camera

### DIFF
--- a/ogre2/src/media/Hlms/Terra/GLSL/VertexShader_vs.glsl
+++ b/ogre2/src/media/Hlms/Terra/GLSL/VertexShader_vs.glsl
@@ -4,8 +4,8 @@
 out gl_PerVertex
 {
 	vec4 gl_Position;
-@property( hlms_global_clip_planes )
-	float gl_ClipDistance[@value(hlms_global_clip_planes)];
+@property( hlms_pso_clip_distances )
+	float gl_ClipDistance[@value(hlms_pso_clip_distances)];
 @end
 };
 

--- a/test/common_test/Heightmap_TEST.cc
+++ b/test/common_test/Heightmap_TEST.cc
@@ -41,7 +41,7 @@ class HeightmapTest : public CommonRenderingTest
 // ogre1 not supported on Windows
 TEST_F(HeightmapTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
 {
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_UNSUPPORTED_ENGINE("optix");
 
   auto scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);


### PR DESCRIPTION
# 🦟 Bug fix

There is no ticket for this bug

## Summary

I'm in the process of writing integration tests for Heightmap (ogre2).

In the meantime I noticed:

 - Heightmap's UNIT test can be enabled for ogre2
 - GpuRays camera will crash if a Heightmap is used in it (the integration code I'm writing found this, but it's not ready for pushing it).

Since these changes are simple enough I'm submitting them as their own PR.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
