### PR TITLE
Implement consistent Auto Aspect Ratio

### DIFF
--- a/include/gz/rendering/Camera.hh
+++ b/include/gz/rendering/Camera.hh
@@ -94,16 +94,23 @@ namespace gz
       public: virtual void SetHFOV(const math::Angle &_hfov) = 0;
 
       /// \brief Get the camera's aspect ratio
-      /// \return The camera's aspect ratio
+      /// \remarks If SetAspectRatio() gets called with an input <= 0
+      /// this function returns the Aspect Ratio autocalculated based
+      /// on the camera's dimensions.
+      /// \return The camera's aspect ratio. This value is always in range
+      /// (0; inf) unless the dimensions are invalid (e.g. 0 width or height,
+      /// NaN resolution, etc)
       public: virtual double AspectRatio() const = 0;
 
       /// \brief Set the camera's aspect ratio. This value determines the
       /// cameras vertical field-of-view. It is often the \code image_height /
       /// image_width \endcode but this is not necessarily true.
+      ///
+      /// Setting a value <= 0.0 indicates the aspect ratio will be
+      /// automatically calculated based on width & height.
+      ///
       /// \return The camera's aspect ratio
       public: virtual void SetAspectRatio(const double _ratio) = 0;
-
-      // TODO(anyone): add auto-aspect ratio
 
       /// \brief Get the level of anti-aliasing used during rendering
       /// \return The level of anti-aliasing used during rendering

--- a/include/gz/rendering/base/BaseCamera.hh
+++ b/include/gz/rendering/base/BaseCamera.hh
@@ -658,7 +658,8 @@ namespace gz
       // See https://github.com/gazebosim/gz-rendering/issues/763
       if (this->aspect <= 0.0)
       {
-        return (double)this->ImageWidth() / (double)this->ImageHeight();
+        return static_cast<double>(this->ImageWidth()) /
+               static_cast<double>(this->ImageHeight());
       }
       return this->aspect;
     }

--- a/include/gz/rendering/base/BaseCamera.hh
+++ b/include/gz/rendering/base/BaseCamera.hh
@@ -481,7 +481,7 @@ namespace gz
       this->SetImageWidth(1);
       this->SetImageHeight(1);
       this->SetImageFormat(PF_R8G8B8);
-      this->SetAspectRatio(1.33333);
+      this->SetAspectRatio(0.0);
       this->SetAntiAliasing(0u);
       this->SetHFOV(fov);
       this->SetNearClipPlane(0.01);
@@ -653,6 +653,13 @@ namespace gz
     template <class T>
     double BaseCamera<T>::AspectRatio() const
     {
+      // Invalid AR values fallback to auto aspect ratio to maintain
+      // ABI compatibility.
+      // See https://github.com/gazebosim/gz-rendering/issues/763
+      if (this->aspect <= 0.0)
+      {
+        return (double)this->ImageWidth() / (double)this->ImageHeight();
+      }
       return this->aspect;
     }
 

--- a/ogre/include/gz/rendering/ogre/OgreCamera.hh
+++ b/ogre/include/gz/rendering/ogre/OgreCamera.hh
@@ -135,6 +135,10 @@ namespace gz
 
       protected: virtual void SetSelectionBuffer();
 
+      /// \brief Synchronizes every setting that depends on AspectRatio
+      /// with Ogre's camera
+      protected: void SyncOgreCameraAspectRatio();
+
       private: void CreateCamera();
 
       protected: virtual void CreateRenderTexture();

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -69,31 +69,27 @@ void OgreCamera::Destroy()
 //////////////////////////////////////////////////
 math::Angle OgreCamera::HFOV() const
 {
-  double vfov = this->ogreCamera->getFOVy().valueRadians();
-  double hFOV = 2.0 * atan(tan(vfov / 2.0) * this->AspectRatio());
-  return math::Angle(hFOV);
+  return BaseCamera::HFOV();
 }
 
 //////////////////////////////////////////////////
 void OgreCamera::SetHFOV(const math::Angle &_angle)
 {
   BaseCamera::SetHFOV(_angle);
-  double angle = _angle.Radian();
-  double vfov = 2.0 * atan(tan(angle / 2.0) / this->AspectRatio());
-  this->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  this->SyncOgreCameraAspectRatio();
 }
 
 //////////////////////////////////////////////////
 double OgreCamera::AspectRatio() const
 {
-  return this->ogreCamera->getAspectRatio();
+  return BaseCamera::AspectRatio();
 }
 
 //////////////////////////////////////////////////
 void OgreCamera::SetAspectRatio(const double _ratio)
 {
   BaseCamera::SetAspectRatio(_ratio);
-  return this->ogreCamera->setAspectRatio(_ratio);
+  this->SyncOgreCameraAspectRatio();
 }
 
 //////////////////////////////////////////////////
@@ -149,6 +145,16 @@ void OgreCamera::Init()
 }
 
 //////////////////////////////////////////////////
+void OgreCamera::SyncOgreCameraAspectRatio()
+{
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov = 2.0 * atan(tan(angle / 2.0) / aspectRatio);
+  this->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
+}
+
+//////////////////////////////////////////////////
 void OgreCamera::CreateCamera()
 {
   // create ogre camera object
@@ -173,7 +179,6 @@ void OgreCamera::CreateCamera()
   this->ogreCamera->setFixedYawAxis(false);
 
   // TODO(anyone): provide api access
-  this->ogreCamera->setAutoAspectRatio(true);
   this->ogreCamera->setRenderingDistance(0);
   this->ogreCamera->setPolygonMode(Ogre::PM_SOLID);
   this->ogreCamera->setProjectionType(Ogre::PT_PERSPECTIVE);

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -175,7 +175,6 @@ void OgreDepthCamera::CreateCamera()
   this->ogreCamera->setFixedYawAxis(false);
 
   // TODO(anyone): provide api access
-  this->ogreCamera->setAutoAspectRatio(true);
   this->ogreCamera->setRenderingDistance(0);
   this->ogreCamera->setPolygonMode(Ogre::PM_SOLID);
   this->ogreCamera->setProjectionType(Ogre::PT_PERSPECTIVE);
@@ -268,12 +267,12 @@ void OgreDepthCamera::CreateDepthTexture()
     this->depthTexture->SetHeight(1);
   }
 
-  double ratio = static_cast<double>(this->ImageWidth()) /
-                 static_cast<double>(this->ImageHeight());
-
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / ratio);
-  this->ogreCamera->setAspectRatio(ratio);
-  this->ogreCamera->setFOVy(Ogre::Radian(this->LimitFOV(vfov)));
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov =
+    this->LimitFOV(2.0 * atan(tan(angle / 2.0) / aspectRatio));
+  this->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -385,7 +385,6 @@ void OgreThermalCamera::CreateCamera()
   this->ogreCamera->setFixedYawAxis(false);
 
   // TODO(anyone): provide api access
-  this->ogreCamera->setAutoAspectRatio(true);
   this->ogreCamera->setRenderingDistance(0);
   this->ogreCamera->setPolygonMode(Ogre::PM_SOLID);
   this->ogreCamera->setProjectionType(Ogre::PT_PERSPECTIVE);
@@ -418,12 +417,11 @@ void OgreThermalCamera::CreateThermalTexture()
     vp->setOverlaysEnabled(false);
   }
 
-  double ratio = static_cast<double>(this->ImageWidth()) /
-                 static_cast<double>(this->ImageHeight());
-
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / ratio);
-  this->ogreCamera->setAspectRatio(ratio);
-  this->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov = 2.0 * atan(tan(angle / 2.0) / aspectRatio);
+  this->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
 
   // near and far plane are passed to heat source frag shaders through
   // material switcher. They are used to normalize depth values which are then

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
@@ -152,6 +152,10 @@ namespace gz
       /// TODO(anyone) to be implemented
       protected: virtual void SetSelectionBuffer();
 
+      /// \brief Synchronizes every setting that depends on AspectRatio
+      /// with Ogre's camera
+      protected: void SyncOgreCameraAspectRatio();
+
       /// \brief Create internal camera object
       private: void CreateCamera();
 

--- a/ogre2/src/Ogre2BoundingBoxCamera.cc
+++ b/ogre2/src/Ogre2BoundingBoxCamera.cc
@@ -394,7 +394,6 @@ void Ogre2BoundingBoxCamera::CreateCamera()
   this->dataPtr->ogreCamera->roll(Ogre::Degree(-90));
   this->dataPtr->ogreCamera->setFixedYawAxis(false);
 
-  this->dataPtr->ogreCamera->setAutoAspectRatio(true);
   this->dataPtr->ogreCamera->setRenderingDistance(100);
   this->dataPtr->ogreCamera->setProjectionType(
       Ogre::ProjectionType::PT_PERSPECTIVE);
@@ -472,10 +471,11 @@ void Ogre2BoundingBoxCamera::CreateBoundingBoxTexture()
   // Camera Parameters
   this->dataPtr->ogreCamera->setNearClipDistance(this->NearClipPlane());
   this->dataPtr->ogreCamera->setFarClipDistance(this->FarClipPlane());
-  this->dataPtr->ogreCamera->setAspectRatio(this->AspectRatio());
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) /
-    this->AspectRatio());
-  this->dataPtr->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov = 2.0 * atan(tan(angle / 2.0) / aspectRatio);
+  this->dataPtr->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->dataPtr->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
 
   // render texture
   auto engine = Ogre2RenderEngine::Instance();

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -74,31 +74,27 @@ void Ogre2Camera::Destroy()
 //////////////////////////////////////////////////
 math::Angle Ogre2Camera::HFOV() const
 {
-  double vfov = this->ogreCamera->getFOVy().valueRadians();
-  double hFOV = 2.0 * atan(tan(vfov / 2.0) * this->AspectRatio());
-  return math::Angle(hFOV);
+  return BaseCamera::HFOV();
 }
 
 //////////////////////////////////////////////////
 void Ogre2Camera::SetHFOV(const math::Angle &_angle)
 {
   BaseCamera::SetHFOV(_angle);
-  double angle = _angle.Radian();
-  double vfov = 2.0 * atan(tan(angle / 2.0) / this->AspectRatio());
-  this->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  this->SyncOgreCameraAspectRatio();
 }
 
 //////////////////////////////////////////////////
 double Ogre2Camera::AspectRatio() const
 {
-  return this->ogreCamera->getAspectRatio();
+  return BaseCamera::AspectRatio();
 }
 
 //////////////////////////////////////////////////
 void Ogre2Camera::SetAspectRatio(const double _ratio)
 {
   BaseCamera::SetAspectRatio(_ratio);
-  return this->ogreCamera->setAspectRatio(_ratio);
+  this->SyncOgreCameraAspectRatio();
 }
 
 //////////////////////////////////////////////////
@@ -166,6 +162,16 @@ void Ogre2Camera::Init()
 }
 
 //////////////////////////////////////////////////
+void Ogre2Camera::SyncOgreCameraAspectRatio()
+{
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov = 2.0 * atan(tan(angle / 2.0) / aspectRatio);
+  this->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
+}
+
+//////////////////////////////////////////////////
 void Ogre2Camera::CreateCamera()
 {
   // create ogre camera object
@@ -182,7 +188,6 @@ void Ogre2Camera::CreateCamera()
   this->ogreCamera->setFixedYawAxis(false);
 
   // TODO(anyone): provide api access
-  this->ogreCamera->setAutoAspectRatio(true);
   this->ogreCamera->setProjectionType(Ogre::PT_PERSPECTIVE);
   this->ogreCamera->setCustomProjectionMatrix(false);
 }

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -966,10 +966,6 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
-  auto engine = Ogre2RenderEngine::Instance();
-  auto ogreRoot = engine->OgreRoot();
-  ogreRoot->getRenderSystem()->startGpuDebuggerFrameCapture(0);
-
   // Our shaders rely on clamped values so enable it for this sensor
   //
   // TODO(anyone): Matias N. Goldberg (dark_sylinc) insists this is a hack
@@ -993,8 +989,6 @@ void Ogre2DepthCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
   this->ogreCamera->_setNeedsDepthClamp(bOldDepthClamp);
-
-  ogreRoot->getRenderSystem()->endGpuDebuggerFrameCapture(0);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -389,7 +389,6 @@ void Ogre2DepthCamera::CreateCamera()
   this->ogreCamera->setFixedYawAxis(false);
 
   // TODO(anyone): provide api access
-  this->ogreCamera->setAutoAspectRatio(true);
   this->ogreCamera->setRenderingDistance(100);
   this->ogreCamera->setProjectionType(Ogre::PT_PERSPECTIVE);
   this->ogreCamera->setCustomProjectionMatrix(false);
@@ -409,9 +408,12 @@ void Ogre2DepthCamera::CreateRenderTexture()
 void Ogre2DepthCamera::CreateDepthTexture()
 {
   // set aspect ratio and fov
-  double vfov;
-  vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
-  this->ogreCamera->setFOVy(Ogre::Radian(this->LimitFOV(vfov)));
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov =
+    this->LimitFOV(2.0 * atan(tan(angle / 2.0) / aspectRatio));
+  this->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
 
   // Load depth material
   // The DepthCamera material is defined in script (depth_camera.material).
@@ -964,6 +966,10 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
+  auto engine = Ogre2RenderEngine::Instance();
+  auto ogreRoot = engine->OgreRoot();
+  ogreRoot->getRenderSystem()->startGpuDebuggerFrameCapture(0);
+
   // Our shaders rely on clamped values so enable it for this sensor
   //
   // TODO(anyone): Matias N. Goldberg (dark_sylinc) insists this is a hack
@@ -987,6 +993,8 @@ void Ogre2DepthCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
   this->ogreCamera->_setNeedsDepthClamp(bOldDepthClamp);
+
+  ogreRoot->getRenderSystem()->endGpuDebuggerFrameCapture(0);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -187,7 +187,6 @@ void Ogre2SegmentationCamera::CreateCamera()
   this->ogreCamera->roll(Ogre::Degree(-90));
   this->ogreCamera->setFixedYawAxis(false);
 
-  this->ogreCamera->setAutoAspectRatio(true);
   this->ogreCamera->setRenderingDistance(100);
   this->ogreCamera->setProjectionType(Ogre::ProjectionType::PT_PERSPECTIVE);
   this->ogreCamera->setCustomProjectionMatrix(false);
@@ -199,10 +198,11 @@ void Ogre2SegmentationCamera::CreateSegmentationTexture()
   // Camera Parameters
   this->ogreCamera->setNearClipDistance(this->NearClipPlane());
   this->ogreCamera->setFarClipDistance(this->FarClipPlane());
-  this->ogreCamera->setAspectRatio(this->AspectRatio());
-  double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) /
-    this->AspectRatio());
-  this->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov = 2.0 * atan(tan(angle / 2.0) / aspectRatio);
+  this->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
 
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -811,7 +811,6 @@ void Ogre2ThermalCamera::CreateCamera()
   this->ogreCamera->setFixedYawAxis(false);
 
   // TODO(anyone): provide api access
-  this->ogreCamera->setAutoAspectRatio(true);
   this->ogreCamera->setProjectionType(Ogre::PT_PERSPECTIVE);
   this->ogreCamera->setCustomProjectionMatrix(false);
 }
@@ -830,9 +829,11 @@ void Ogre2ThermalCamera::CreateRenderTexture()
 void Ogre2ThermalCamera::CreateThermalTexture()
 {
   // set aspect ratio and fov
-  double vfov;
-  vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / this->AspectRatio());
-  this->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  const double aspectRatio = this->AspectRatio();
+  const double angle = this->HFOV().Radian();
+  const double vfov = 2.0 * atan(tan(angle / 2.0) / aspectRatio);
+  this->ogreCamera->setFOVy(Ogre::Radian((Ogre::Real)vfov));
+  this->ogreCamera->setAspectRatio((Ogre::Real)aspectRatio);
 
   // Load thermal material
   // The ThermalCamera material is defined in script (thermal_camera.material).

--- a/test/common_test/Camera_TEST.cc
+++ b/test/common_test/Camera_TEST.cc
@@ -317,10 +317,11 @@ TEST_F(CameraTest, IntrinsicMatrix)
   camera->SetImageWidth(width);
   camera->SetHFOV(hfov);
 
-  double error = 1e-1;
+  double error = 1e-2;
   EXPECT_EQ(camera->ImageHeight(), height);
   EXPECT_EQ(camera->ImageWidth(), width);
-  EXPECT_NEAR(camera->HFOV().Radian(), hfov, error);
+  EXPECT_DOUBLE_EQ(camera->HFOV().Radian(), hfov);
+  EXPECT_DOUBLE_EQ(camera->AspectRatio(), (double)width / (double)height);
 
   // Verify focal length and optical center from intrinsics
   auto cameraIntrinsics = projectionToCameraIntrinsic(
@@ -350,7 +351,8 @@ TEST_F(CameraTest, IntrinsicMatrix)
 
   EXPECT_EQ(camera->ImageHeight(), height);
   EXPECT_EQ(camera->ImageWidth(), width);
-  EXPECT_NEAR(camera->HFOV().Radian(), hfov, error);
+  EXPECT_DOUBLE_EQ(camera->HFOV().Radian(), hfov);
+  EXPECT_DOUBLE_EQ(camera->AspectRatio(), (double)width / (double)height);
 
   // Verify if intrinsics have changed
   cameraIntrinsics = projectionToCameraIntrinsic(

--- a/test/common_test/Camera_TEST.cc
+++ b/test/common_test/Camera_TEST.cc
@@ -365,6 +365,15 @@ TEST_F(CameraTest, IntrinsicMatrix)
   EXPECT_DOUBLE_EQ(cameraIntrinsics(0, 2), 500);
   EXPECT_DOUBLE_EQ(cameraIntrinsics(1, 2), 500);
 
+
+  const double newAspectRatio = 1.7;
+  camera->SetAspectRatio(newAspectRatio);
+  EXPECT_DOUBLE_EQ(camera->AspectRatio(), newAspectRatio);
+  camera->SetAspectRatio(0.0);
+  EXPECT_DOUBLE_EQ(camera->AspectRatio(), (double)width / (double)height);
+  camera->SetAspectRatio(-1.0);
+  EXPECT_DOUBLE_EQ(camera->AspectRatio(), (double)width / (double)height);
+
   // Clean up
   engine->DestroyScene(scene);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #763

## Summary

The old default Aspect Ratio would be 1.3333
Now it is 0.0 which indicates Gazebo should autocalculate the Aspect Ratio.

This results in a nice backwards-compatible behavior while fixing various bugs mentioned in gazebosim/gz-rendering#763

Fixes gazebosim/gz-rendering#763

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
