### PR TITLE
Fix non-deterministic rendering due to background texture loading

### DIFF
--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -359,6 +359,21 @@ void Ogre2Scene::StartRendering(Ogre::Camera *_camera)
                "Started rendering without first calling Scene::PreRender. "
                "See Scene::SetCameraPassCountPerGpuFlush for details");
   }
+
+#if OGRE_VERSION_MAJOR != 2 || OGRE_VERSION_MINOR != 1
+  // OgreNext 2.2+ has a feature where all textures are asynchronously loaded
+  // by default; and a blank texture will be shown until it's ready.
+  //
+  // This is great for low latency interactions & most games; but terrible
+  // if we want all our simulated frames to be perfect & deterministic
+  // results
+  //
+  // We don't want placeholder textures to be used; thus wait until all
+  // textures being loaded are done.
+  Ogre::RenderSystem *renderSys =
+    this->ogreSceneManager->getDestinationRenderSystem();
+  renderSys->getTextureGpuManager()->waitForStreamingCompletion();
+#endif
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

No ticket was created for this issue.

## Summary

OgreNext 2.2+ has a feature where all textures are asynchronously loaded by default; and a blank texture will be shown until it's ready.

This is great for low latency interactions & most games; but terrible if we want all our simulated frames to be perfect & deterministic results

We don't want placeholder textures to be used; thus wait until all textures being loaded are done.

I found this bug while working on the Heightmap Integration tests for Fortress. The test required to load some PNGs and it failed spectacularly as the first frames rendered used the placeholder textures instead of the final ones.

`waitForStreamingCompletion` doesn't have any performance impact if there are no textures waiting to finish loading; and it will obviously affect performance if there are textures still loading andhas to wait. However this is a case of "rendering ASAP vs correctness".

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
