### PR TITLE
Use proper sRGB conversion in DepthCamera

### DIFF
--- a/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
@@ -45,11 +45,21 @@ uniform float rnd;
 
 float packFloat(vec4 color)
 {
-  int rgba = (int(color.x * 255.0) << 24) +
-             (int(color.y * 255.0) << 16) +
-             (int(color.z * 255.0) << 8) +
-             int(color.w * 255.0);
+  int rgba = (int(round(color.x * 255.0)) << 24) +
+             (int(round(color.y * 255.0)) << 16) +
+             (int(round(color.z * 255.0)) << 8) +
+             int(round(color.w * 255.0));
   return intBitsToFloat(rgba);
+}
+
+float toSRGB( float x )
+{
+  return (x < 0.0031308 ? x * 12.92 : 1.055 * pow( x, 0.41666 ) - 0.055 );
+}
+
+vec4 toSRGB( vec4 x )
+{
+  return vec4( toSRGB( x.x ), toSRGB( x.y ), toSRGB( x.z ), x.w );
 }
 
 
@@ -180,9 +190,8 @@ void main()
     }
   }
 
-  // gamma correct - using same method as:
-  // https://bitbucket.org/sinbad/ogre/src/v2-1/Samples/Media/Hlms/Pbs/GLSL/PixelShader_ps.glsl#lines-513
-  color = sqrt(color);
+  // gamma correct
+  color = toSRGB(color);
 
   float rgba = packFloat(color);
   fragColor = vec4(point, rgba);

--- a/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
@@ -44,11 +44,21 @@ struct Params
 
 float packFloat(float4 color)
 {
-  int rgba = (int(color.x * 255.0) << 24) +
-             (int(color.y * 255.0) << 16) +
-             (int(color.z * 255.0) << 8) +
-             int(color.w * 255.0);
+  int rgba = (int(round(color.x * 255.0)) << 24) +
+             (int(round(color.y * 255.0)) << 16) +
+             (int(round(color.z * 255.0)) << 8) +
+             int(round(color.w * 255.0));
   return as_type<float>(rgba);
+}
+
+inline float toSRGB( float x )
+{
+  return (x < 0.0031308 ? x * 12.92 : 1.055 * pow( x, 0.41666 ) - 0.055 );
+}
+
+inline float4 toSRGB( float4 x )
+{
+  return float4( toSRGB( x.x ), toSRGB( x.y ), toSRGB( x.z ), x.w );
 }
 
 // see gaussian_noise_fs.metal for documentation on the rand and gaussrand
@@ -167,7 +177,7 @@ fragment float4 main_metal
     // due to the scatter effect. We should still render particles in the color
     // image
     // todo(iche033) handle case when background is a cubemap
-    if (hasBackground == 0 && particle.x < 1e-6)
+    if (p.hasBackground == 0 && particle.x < 1e-6)
     {
       color = float4(p.backgroundColor, 1.0);
     }
@@ -185,15 +195,14 @@ fragment float4 main_metal
 
     // clamp to background color only if it is not a particle pixel
     // todo(iche033) handle case when background is a cubemap
-    if (hasBackground == 0 && particle.x < 1e-6)
+    if (p.hasBackground == 0 && particle.x < 1e-6)
     {
       color = float4(p.backgroundColor, 1.0);
     }
   }
 
-  // gamma correct - using same method as:
-  // https://bitbucket.org/sinbad/ogre/src/v2-1/Samples/Media/Hlms/Pbs/GLSL/PixelShader_ps.glsl#lines-513
-  color = sqrt(color);
+  // gamma correct
+  color = toSRGB(color);
 
   float rgba = packFloat(color);
   float4 fragColor(point, rgba);


### PR DESCRIPTION
# 🦟 Bug fix

No ticket was filed for this issue

## Summary

Depth Camera uses an approximation for sRGB conversion.

This causes regular Camera to slightly _**but visibly**_ differ in their RGB output compared to the one done by Depth Camera (stored encoded as RGBA8888 in the A channel of the DepthCamera).

This fix causes cameras to identically match 100% both outputs (possibly some GPUs may have a margin of error of up to 1/255 due to precision issues with floating points. DepthCamera already suffers a few problems due to assembly code not understanding that we store a binary encoded value in a F32 value; and sometimes denormals or NaNs get flushed).

Without this patch, here's a an output of a Regular Camera (Note these pictures were taking using Garden while this PR is targeting Fortress):

![Original](https://user-images.githubusercontent.com/3395130/204161301-dd3d3ac5-b8b5-4a38-a6fc-3815582f19e6.png)

And here's an output of a Depth Camera:

![Depth](https://user-images.githubusercontent.com/3395130/204161321-7b30a2e2-760f-4583-a517-b736d0f4968b.png)

The shades of green are quite apart (R, G, B) and can be seen by the naked eye if you toggle between them:

| Normal    | Depth       |
|-----------|-------------|
| 5, 185, 5 | 10, 177, 10 |
| 2, 143, 2 | 6, 134, 6   |
| 0, 73, 0  | 0, 66, 0    |

The shadow is also in a different colour, but there's no point to keep pointing it out.

After this patch, the output produced is binary identical.

**Update:** Correction. It's NOT binary identical. The error seems to be up to 3 / 255. A bit more than I'd hope, but much better than having the current massive error where it's even visible with the naked eye.

**Update:**

The error depends on GPU and backend. However it is quite good. At worst case, only 14 pixels out of 10.000 pixels were not exact with a max seen error of 9 / 255.

Vulkan backend fares MUCH better in providing exact results (these tests were made in Garden, not in Fortress).

|                                    | Max. Error | Num Pixels that aren’t exact (in 100x100 image) |
|------------------------------------|------------|-------------------------------------------------|
| OpenGL (SW Mesa, llvmpipe)                   | 3          | 6                                               |
| OpenGL (Radeon RX 6800 XT, Mesa)   | 9          | 14                                              |
| Vulkan (Radeon RX 6800 XT, RADV)   | 2          | 5                                               |
| Vulkan (Radeon RX 6800 XT, AMDVLK) | 1          | 9                                               |

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
