### PR TITLE
Disable flaky VisualAt test on mac

### DIFF
--- a/test/integration/scene.cc
+++ b/test/integration/scene.cc
@@ -127,6 +127,10 @@ TEST_F(SceneTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(VisualAt))
   // Optix doesn't support RayQuery
   CHECK_UNSUPPORTED_ENGINE("optix");
 
+#ifdef __APPLE__
+  GTEST_SKIP() << "Test is flaky on macOS, see issue #170.";
+#endif
+
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

Disable `Scene.VisualAt` test as it's flaky on macOS, see https://github.com/gazebosim/gz-rendering/pull/758#issuecomment-1329246890

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
