### PR TITLE
Fix bounding box for glbs

### DIFF
--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -440,7 +440,8 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
     math::Vector3d max = _desc.mesh->Max();
     math::Vector3d min = _desc.mesh->Min();
 
-    if (_desc.mesh->HasSkeleton())
+    if (_desc.mesh->HasSkeleton() &&
+        _desc.mesh->MeshSkeleton()->AnimationCount() != 0)
     {
       min = math::Vector3d(-1, -1, -1);
       max = math::Vector3d(1, 1, 1);

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -493,7 +493,8 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
     math::Vector3d max = _desc.mesh->Max();
     math::Vector3d min = _desc.mesh->Min();
 
-    if (_desc.mesh->HasSkeleton())
+    if (_desc.mesh->HasSkeleton() &&
+        _desc.mesh->MeshSkeleton()->AnimationCount() != 0)
     {
       min = math::Vector3d(-1, -1, -1);
       max = math::Vector3d(1, 1, 1);


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/1820

## Summary

When loading `glb`s with `ASSIMP` are considered meshes with skeleton, this PR add one more check to know if the skeleton has animations, if it has animations then the bouding box it's (-1, -1, -1)(1, 1, 1) otherwise it's the maximum and minimum element of the mesh.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
