### PR TITLE
Fixed how glb textures are loaded

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -1205,7 +1205,10 @@ void Ogre2Material::SetTextureMapDataImpl(const std::string& _name,
   {
     auto data = _img->RGBAData();
 
-    texture->setPixelFormat(Ogre::PFG_RGBA8_UNORM);
+    Ogre::PixelFormatGpu format = Ogre::PFG_RGBA8_UNORM;
+    if (this->ogreDatablock->suggestUsingSRGB(_type))
+      format = Ogre::PFG_RGBA8_UNORM_SRGB;
+    texture->setPixelFormat(format);
     texture->setTextureType(Ogre::TextureTypes::Type2D);
     texture->setNumMipmaps(1u);
     texture->setResolution(_img->Width(), _img->Height());

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -1205,7 +1205,7 @@ void Ogre2Material::SetTextureMapDataImpl(const std::string& _name,
   {
     auto data = _img->RGBAData();
 
-    texture->setPixelFormat(Ogre::PFG_RGBA8_UNORM_SRGB);
+    texture->setPixelFormat(Ogre::PFG_RGBA8_UNORM);
     texture->setTextureType(Ogre::TextureTypes::Type2D);
     texture->setNumMipmaps(1u);
     texture->setResolution(_img->Width(), _img->Height());


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/772

## Summary
Wrong texture
![Selection_102](https://user-images.githubusercontent.com/1933907/204760550-c5987c91-938f-4e8a-b4bd-a28753ce9916.png)

Right texture `Ogre::PFG_RGBA8_UNORM`

![Selection_103](https://user-images.githubusercontent.com/1933907/204760562-6ebc92e2-facc-45cf-8826-6763e66092d8.png)

Using `<material>` tag `Ogre::PFG_RGBA8_UNORM`

![Selection_104](https://user-images.githubusercontent.com/1933907/204760844-fdc20706-b091-4fb7-9dd9-e5884c550058.png)

Using `<material>` tag `Ogre::PFG_RGBA8_UNORM_SRGB`

![Selection_105](https://user-images.githubusercontent.com/1933907/204761293-444169ff-0da2-468a-9a06-b2fe3092d264.png)

These PR is still a draft, because the right behaviour is 

 - Right texture `Ogre::PFG_RGBA8_UNORM`
 - Using `<material>` tag `Ogre::PFG_RGBA8_UNORM_SRGB`

The visual are different when loading from `<material>` than `glb`

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
