### PR TITLE
Add LensFlare to ogre1

### DIFF
--- a/include/gz/rendering/Camera.hh
+++ b/include/gz/rendering/Camera.hh
@@ -348,6 +348,9 @@ namespace gz
       /// \param[in] _pass render pass to remove
       public: virtual void RemoveRenderPass(const RenderPassPtr &_pass) = 0;
 
+      /// \brief Remove all render passes from the camera
+      public: virtual void RemoveAllRenderPasses() = 0;
+
       /// \brief Get the number of render passes applied to the camera
       /// \return Number of render passes applied
       public: virtual unsigned int RenderPassCount() const = 0;

--- a/include/gz/rendering/LensFlarePass.hh
+++ b/include/gz/rendering/LensFlarePass.hh
@@ -34,6 +34,12 @@ namespace gz
     class GZ_RENDERING_VISIBLE LensFlarePass
       : public virtual RenderPass
     {
+      /// \brief Constructor
+      public: LensFlarePass();
+
+      /// \brief Destructor
+      public: virtual ~LensFlarePass();
+
       /// \brief Initializes the Lens Flare Pass with given scene
       /// \param[in] _scene Pointer to scene
       public: virtual void Init(ScenePtr _scene) = 0;

--- a/include/gz/rendering/RenderPass.hh
+++ b/include/gz/rendering/RenderPass.hh
@@ -50,6 +50,25 @@ namespace gz
       /// to the camera that is about to render
       /// \param[in] _camera Camera that is about to render
       public: virtual void PreRender(const CameraPtr &_camera) = 0;
+
+      /// \brief WideAngleCamera renders to 6 faces; then stitches all 6
+      /// into a final "fish-eye" lens result.
+      ///
+      /// This function controls whether the effect is applied to each 6
+      /// faces individually; or during the "stitching" pass.
+      ///
+      /// The default setting depends on the RenderPass (e.g. LensFlare
+      /// defaults to true)
+      /// \remark This setting must not be changed after adding the RenderPass
+      /// to a Camera.
+      /// \param[in] _afterStitching True if it should be done after stitching,
+      /// False if it should be done to each of the 6 faces separately.
+      public: virtual void SetWideAngleCameraAfterStitching(
+            bool _afterStitching) = 0;
+
+      /// \brief See SetWideAngleCameraAfterStitching()
+      /// \return The current value set by SetWideAngleCameraAfterStitching
+      public: virtual bool WideAngleCameraAfterStitching() const = 0;
     };
     }
   }

--- a/include/gz/rendering/RenderTarget.hh
+++ b/include/gz/rendering/RenderTarget.hh
@@ -99,6 +99,9 @@ namespace gz
       /// \param[in] _pass render pass to remove
       public: virtual void RemoveRenderPass(const RenderPassPtr &_pass) = 0;
 
+      /// \brief Remove all render passes from the render target
+      public: virtual void RemoveAllRenderPasses() = 0;
+
       /// \brief Get the number of render passes applied to the render target
       /// \return Number of render passes applied
       public: virtual unsigned int RenderPassCount() const = 0;

--- a/include/gz/rendering/base/BaseCamera.hh
+++ b/include/gz/rendering/base/BaseCamera.hh
@@ -196,6 +196,9 @@ namespace gz
           override;
 
       // Documentation inherited.
+      public: void RemoveAllRenderPasses() override;
+
+      // Documentation inherited.
       public: virtual unsigned int RenderPassCount() const override;
 
       // Documentation inherited.
@@ -858,6 +861,13 @@ namespace gz
     void BaseCamera<T>::RemoveRenderPass(const RenderPassPtr &_pass)
     {
       this->RenderTarget()->RemoveRenderPass(_pass);
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseCamera<T>::RemoveAllRenderPasses()
+    {
+      this->RenderTarget()->RemoveAllRenderPasses();
     }
 
     //////////////////////////////////////////////////

--- a/include/gz/rendering/base/BaseCamera.hh
+++ b/include/gz/rendering/base/BaseCamera.hh
@@ -867,7 +867,11 @@ namespace gz
     template <class T>
     void BaseCamera<T>::RemoveAllRenderPasses()
     {
-      this->RenderTarget()->RemoveAllRenderPasses();
+      RenderTargetPtr renderTarget = this->RenderTarget();
+      if (renderTarget)
+      {
+        renderTarget->RemoveAllRenderPasses();
+      }
     }
 
     //////////////////////////////////////////////////

--- a/include/gz/rendering/base/BaseRenderPass.hh
+++ b/include/gz/rendering/base/BaseRenderPass.hh
@@ -50,8 +50,19 @@ namespace gz
       // Documentation inherited
       public: void PreRender(const CameraPtr &_camera) override;
 
+      // Documentation inherited
+      public: void SetWideAngleCameraAfterStitching(bool _afterStitching)
+          override;
+
+      // Documentation inherited
+      public: bool WideAngleCameraAfterStitching() const  override;
+
       /// \brief Flag to indicate if render pass is enabled or not
       protected: bool enabled = true;
+
+      /// \brief Flag tracking the current value of
+      /// SetWideAngleCameraAfterStitching()
+      protected: bool afterStitching = false;
     };
 
     //////////////////////////////////////////////////
@@ -88,6 +99,21 @@ namespace gz
     {
       T *thisT = this;
       thisT->PreRender();  // NOT the same as doing T::PreRender
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseRenderPass<T>::SetWideAngleCameraAfterStitching(
+          bool _afterStitching)
+    {
+      this->afterStitching = _afterStitching;
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    bool BaseRenderPass<T>::WideAngleCameraAfterStitching() const
+    {
+      return this->afterStitching;
     }
     }
   }

--- a/include/gz/rendering/base/BaseRenderTarget.hh
+++ b/include/gz/rendering/base/BaseRenderTarget.hh
@@ -76,6 +76,9 @@ namespace gz
           override;
 
       // Documentation inherited
+      public: void RemoveAllRenderPasses() override;
+
+      // Documentation inherited
       public: virtual unsigned int RenderPassCount() const override;
 
       // Documentation inherited
@@ -274,6 +277,21 @@ namespace gz
       {
         (*it)->Destroy();
         this->renderPasses.erase(it);
+        this->renderPassDirty = true;
+      }
+    }
+
+    //////////////////////////////////////////////////
+    template <class T>
+    void BaseRenderTarget<T>::RemoveAllRenderPasses()
+    {
+      if (!this->renderPasses.empty())
+      {
+        for (RenderPassPtr &renderPass : this->renderPasses)
+        {
+          renderPass->Destroy();
+        }
+        this->renderPasses.clear();
         this->renderPassDirty = true;
       }
     }

--- a/ogre/include/gz/rendering/ogre/OgreGaussianNoisePass.hh
+++ b/ogre/include/gz/rendering/ogre/OgreGaussianNoisePass.hh
@@ -58,7 +58,8 @@ namespace gz
       public: void CreateRenderPass() override;
 
       /// \brief Gaussian noise compositor.
-      public: Ogre::CompositorInstance *gaussianNoiseInstance = nullptr;
+      public: Ogre::CompositorInstance *gaussianNoiseInstance
+          [kMaxOgreRenderPassCameras] = {};
 
       /// \brief Gaussian noise compositor listener
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING

--- a/ogre/include/gz/rendering/ogre/OgreLensFlarePass.hh
+++ b/ogre/include/gz/rendering/ogre/OgreLensFlarePass.hh
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_RENDERING_OGRE_OGRELENSFLAREPASS_HH_
+#define GZ_RENDERING_OGRE_OGRELENSFLAREPASS_HH_
+
+#include <memory>
+
+#include <gz/utils/ImplPtr.hh>
+
+#include "gz/math/Vector3.hh"
+
+#include "gz/rendering/base/BaseLensFlarePass.hh"
+#include "gz/rendering/ogre/Export.hh"
+#include "gz/rendering/ogre/OgreRenderPass.hh"
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    /// \brief Ogre Implementation of a Lens Flare render pass.
+    class GZ_RENDERING_OGRE_VISIBLE OgreLensFlarePass :
+      public BaseLensFlarePass<OgreRenderPass>
+    {
+      /// \brief Constructor
+      public: OgreLensFlarePass();
+
+      /// \brief Destructor
+      public: ~OgreLensFlarePass() override;
+
+      // Documentation inherited
+      public: void Init(ScenePtr _scene) override;
+
+      // Documentation inherited
+      public: void Destroy() override;
+
+      // Documentation inherited
+      public: void CreateRenderPass() override;
+
+      // Documentation inherited
+      public: void PreRender(const CameraPtr &_camera) override;
+
+      // Documentation inherited
+      public: void PostRender() override;
+
+      // Documentation inherited
+      public: void SetScale(double _scale) override;
+
+      // Documentation inherited
+      public: double Scale() const override;
+
+      // Documentation inherited
+      public: void SetColor(const math::Vector3d &_color) override;
+
+      // Documentation inherited
+      public: const math::Vector3d &Color() const override;
+
+      // Documentation inherited
+      public: void SetOcclusionSteps(uint32_t _occlusionSteps) override;
+
+      // Documentation inherited
+      public: uint32_t OcclusionSteps() const override;
+
+      /// \brief Check to see if the lens flare is occluded and return a scaling
+      /// factor that is proportional to the lens flare's visibility
+      /// \remark OgreLensFlarePass::PreRender must have been called first.
+      /// \param[in] _imgPos light pos in clip space
+      /// \param[in] _faceIdx Face idx in range [0; 6)
+      /// See RayQuery::SetFromCamera for what each value means
+      /// This value is ignored if the camera is not WideAngleCamera
+      private: double OcclusionScale(const math::Vector3d &_imgPos,
+                                     uint32_t _faceIdx);
+
+      /// \cond warning
+      /// \brief Private data pointer
+      GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
+      /// \endcond
+
+      private: friend class OgreLensFlareCompositorListenerPrivate;
+    };
+    }
+  }
+}
+#endif

--- a/ogre/include/gz/rendering/ogre/OgreRenderPass.hh
+++ b/ogre/include/gz/rendering/ogre/OgreRenderPass.hh
@@ -50,7 +50,7 @@ namespace gz
 
       /// \brief Set all ogre cameras that the render pass applies to
       /// at once.
-      /// \param[in] _camera Pointer to the ogre cameras.
+      /// \param[in] _cameras Pointer to the ogre cameras.
       public: virtual void SetCameras(
             Ogre::Camera *_cameras[kMaxOgreRenderPassCameras]);
 

--- a/ogre/include/gz/rendering/ogre/OgreRenderPass.hh
+++ b/ogre/include/gz/rendering/ogre/OgreRenderPass.hh
@@ -27,6 +27,9 @@ namespace gz
   namespace rendering
   {
     inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+    static constexpr uint32_t kMaxOgreRenderPassCameras = 6u;
+
     //
     /* \class OgreRenderPass OgreRenderPass.hh \
      * gz/rendering/ogre/OgreRenderPass.hh
@@ -45,6 +48,12 @@ namespace gz
       /// \param[in] _camera Pointer to the ogre camera.
       public: virtual void SetCamera(Ogre::Camera *_camera);
 
+      /// \brief Set all ogre cameras that the render pass applies to
+      /// at once.
+      /// \param[in] _camera Pointer to the ogre cameras.
+      public: virtual void SetCameras(
+            Ogre::Camera *_cameras[kMaxOgreRenderPassCameras]);
+
       // Documentation inherited.
       public: void Destroy() override;
 
@@ -52,7 +61,9 @@ namespace gz
       public: virtual void CreateRenderPass();
 
       /// \brief Pointer to the ogre camera
-      protected: Ogre::Camera *ogreCamera = nullptr;
+      /// May have more than one. Must check for nullptr on all of them.
+      /// Not all RenderPasses support multiple cameras
+      protected: Ogre::Camera *ogreCamera[kMaxOgreRenderPassCameras] = {};
     };
     }
   }

--- a/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
+++ b/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
@@ -114,6 +114,9 @@ namespace gz
       /// \brief Implementation of the render call
       public: virtual void Render() override;
 
+      // Documentation inherited.
+      public: void Copy(Image &_image) const override;
+
       // Documentation inherited
       public: common::ConnectionPtr ConnectNewWideAngleFrame(
           std::function<void(const unsigned char *, unsigned int, unsigned int,

--- a/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
+++ b/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
@@ -59,6 +59,10 @@ namespace gz
       /// \brief Create a texture
       public: virtual void CreateRenderTexture();
 
+      /// \brief Destroy render texture created by CreateRenderTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyRenderTexture();
+
       /// \brief Render the camera
       public: virtual void PostRender() override;
 

--- a/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
+++ b/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
@@ -65,6 +65,15 @@ namespace gz
       // Documentation inherited
       public: virtual void Destroy() override;
 
+      // Documentation inherited
+      public: void AddRenderPass(const RenderPassPtr &_pass) override;
+
+      // Documentation inherited
+      public: void RemoveRenderPass(const RenderPassPtr &_pass) override;
+
+      /// \brief Update render pass chain if changes were made
+      protected: void UpdateRenderPassChain();
+
       /// \brief Gets the environment texture size
       /// \return Texture size
       public: unsigned int EnvTextureSize() const;

--- a/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
+++ b/ogre/include/gz/rendering/ogre/OgreWideAngleCamera.hh
@@ -71,6 +71,9 @@ namespace gz
       // Documentation inherited
       public: void RemoveRenderPass(const RenderPassPtr &_pass) override;
 
+      // Documentation inherited
+      public: void RemoveAllRenderPasses() override;
+
       /// \brief Update render pass chain if changes were made
       protected: void UpdateRenderPassChain();
 

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -44,6 +44,7 @@ void OgreCamera::Destroy()
   if (!this->ogreCamera)
     return;
 
+  this->RemoveAllRenderPasses();
   this->DestroyRenderTexture();
 
   Ogre::SceneManager *ogreSceneManager;

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -89,6 +89,8 @@ OgreDepthCamera::~OgreDepthCamera()
 //////////////////////////////////////////////////
 void OgreDepthCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   if (this->dataPtr->depthBuffer)
   {
     delete [] this->dataPtr->depthBuffer;

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -309,16 +309,6 @@ void OgreDepthCamera::DestroyDepthTexture()
 }
 
 //////////////////////////////////////////////////
-void OgreDepthCamera::DestroyDepthTexture()
-{
-  if (this->depthTexture)
-  {
-    dynamic_cast<OgreRenderTexture *>(this->depthTexture.get())->Destroy();
-    this->depthTexture.reset();
-  }
-}
-
-//////////////////////////////////////////////////
 void OgreDepthCamera::PreRender()
 {
   if (!this->depthTexture)

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -307,6 +307,16 @@ void OgreDepthCamera::DestroyDepthTexture()
 }
 
 //////////////////////////////////////////////////
+void OgreDepthCamera::DestroyDepthTexture()
+{
+  if (this->depthTexture)
+  {
+    dynamic_cast<OgreRenderTexture *>(this->depthTexture.get())->Destroy();
+    this->depthTexture.reset();
+  }
+}
+
+//////////////////////////////////////////////////
 void OgreDepthCamera::PreRender()
 {
   if (!this->depthTexture)

--- a/ogre/src/OgreDistortionPass.cc
+++ b/ogre/src/OgreDistortionPass.cc
@@ -131,7 +131,7 @@ void OgreDistortionPass::PreRender()
 //////////////////////////////////////////////////
 void OgreDistortionPass::CreateRenderPass()
 {
-  if (!this->ogreCamera)
+  if (!this->ogreCamera[0])
   {
     gzerr << "No camera set for applying Distortion Pass" << std::endl;
     return;

--- a/ogre/src/OgreDistortionPass.cc
+++ b/ogre/src/OgreDistortionPass.cc
@@ -153,9 +153,9 @@ void OgreDistortionPass::CreateRenderPass()
     return;
   }
 
-  float viewportWidth = static_cast<float>(this->ogreCamera->
+  float viewportWidth = static_cast<float>(this->ogreCamera[0]->
       getViewport()->getActualWidth());
-  float viewportHeight = static_cast<float>(this->ogreCamera->
+  float viewportHeight = static_cast<float>(this->ogreCamera[0]->
       getViewport()->getActualHeight());
 
   // seems to work best with a square distortion map texture
@@ -163,9 +163,9 @@ void OgreDistortionPass::CreateRenderPass()
       viewportWidth ? viewportHeight : viewportWidth);
   // calculate focal length from largest fov
   const double fov = viewportHeight > viewportWidth ?
-      this->ogreCamera->getFOVy().valueRadians() :
-      (this->ogreCamera->getFOVy().valueRadians() *
-      this->ogreCamera->getAspectRatio());
+      this->ogreCamera[0]->getFOVy().valueRadians() :
+      (this->ogreCamera[0]->getFOVy().valueRadians() *
+      this->ogreCamera[0]->getAspectRatio());
   const double focalLength = texSize / (2 * tan(fov / 2));
   this->dataPtr->distortionTexWidth = texSize;
   this->dataPtr->distortionTexHeight = texSize;
@@ -279,10 +279,10 @@ void OgreDistortionPass::CreateRenderPass()
         "Distortion");
   this->dataPtr->distortionMaterial =
     this->dataPtr->distortionMaterial->clone(
-        this->ogreCamera->getName() + "_Distortion");
+        this->ogreCamera[0]->getName() + "_Distortion");
 
   // create the distortion map texture for the distortion instance
-  std::string texName = this->ogreCamera->getName() + "_distortionTex";
+  std::string texName = this->ogreCamera[0]->getName() + "_distortionTex";
   this->dataPtr->distortionTexture =
       Ogre::TextureManager::getSingleton().createManual(
           texName,
@@ -413,7 +413,7 @@ void OgreDistortionPass::CreateRenderPass()
   // create compositor instance
   this->dataPtr->distortionInstance =
     Ogre::CompositorManager::getSingleton().addCompositor(
-        this->ogreCamera->getViewport(), "RenderPass/Distortion");
+        this->ogreCamera[0]->getViewport(), "RenderPass/Distortion");
   this->dataPtr->distortionInstance->getTechnique()->getOutputTargetPass()->
       getPass(0)->setMaterial(this->dataPtr->distortionMaterial);
 
@@ -439,7 +439,7 @@ void OgreDistortionPass::Destroy()
           this->dataPtr->distortionCompositorListener.get());
     }
     Ogre::CompositorManager::getSingleton().removeCompositor(
-        this->ogreCamera->getViewport(), "RenderPass/Distortion");
+        this->ogreCamera[0]->getViewport(), "RenderPass/Distortion");
 
     this->dataPtr->distortionInstance = nullptr;
     this->dataPtr->distortionCompositorListener.reset();
@@ -500,18 +500,18 @@ void OgreDistortionPass::CalculateAndApplyDistortionScale()
   // Scale up image if cropping enabled and valid
   if (this->dataPtr->distortionCrop && this->k1 < 0)
   {
-    float viewportWidth = static_cast<float>(this->ogreCamera->getViewport()->
-        getActualWidth());
-    float viewportHeight = static_cast<float>(this->ogreCamera->getViewport()->
-        getActualHeight());
+    float viewportWidth =
+      static_cast<float>(this->ogreCamera[0]->getViewport()->getActualWidth());
+    float viewportHeight =
+      static_cast<float>(this->ogreCamera[0]->getViewport()->getActualHeight());
 
     unsigned int texSize = static_cast<unsigned int>(viewportHeight >
         viewportWidth ? viewportHeight : viewportWidth);
 
     const double fov = viewportHeight > viewportWidth ?
-        this->ogreCamera->getFOVy().valueRadians() :
-        (this->ogreCamera->getFOVy().valueRadians() *
-        this->ogreCamera->getAspectRatio());
+        this->ogreCamera[0]->getFOVy().valueRadians() :
+        (this->ogreCamera[0]->getFOVy().valueRadians() *
+        this->ogreCamera[0]->getAspectRatio());
 
     const double focalLength = texSize / (2 * tan(fov / 2));
 

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -164,7 +164,7 @@ void OgreLensFlarePass::CreateRenderPass()
   // create compositor instance
   this->dataPtr->lensFlareInstance =
     Ogre::CompositorManager::getSingleton().addCompositor(
-      this->ogreCamera->getViewport(), "RenderPass/GaussianNoise");
+      this->ogreCamera->getViewport(), "RenderPass/LensFlare");
   this->dataPtr->lensFlareInstance->setEnabled(this->enabled);
 
   this->dataPtr->lensFlareInstance->addListener(

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -354,9 +354,23 @@ void OgreLensFlareCompositorListenerPrivate::notifyMaterialRender(
   Ogre::GpuProgramParametersSharedPtr params =
     pass->getFragmentProgramParameters();
 
-  const Ogre::Camera *camera =
-    dynamic_cast<OgreCamera *>(this->owner.dataPtr->currentCamera.get())
-      ->Camera();
+  const Ogre::Camera *camera;
+
+  {
+    OgreWideAngleCamera *wideAngleCamera = dynamic_cast<OgreWideAngleCamera *>(
+      this->owner.dataPtr->currentCamera.get());
+    if (wideAngleCamera)
+    {
+      camera =
+        wideAngleCamera->OgreEnvCameras()[this->owner.dataPtr->currentFaceIdx];
+    }
+    else
+    {
+      camera =
+        dynamic_cast<OgreCamera *>(this->owner.dataPtr->currentCamera.get())
+          ->Camera();
+    }
+  }
 
   const Matrix4 viewProj =
     camera->getProjectionMatrix() * camera->getViewMatrix();

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -364,7 +364,7 @@ void OgreLensFlareCompositorListenerPrivate::notifyMaterialRender(
   // 2. media/materials/scripts/lens_flare_fs.glsl
   Ogre::Technique *technique = _mat->getTechnique(0);
   GZ_ASSERT(technique, "Null OGRE material technique");
-  Ogre::Pass *pass = technique->getPass((unsigned short)_passId);
+  Ogre::Pass *pass = technique->getPass(static_cast<uint16_t>(_passId));
   GZ_ASSERT(pass, "Null OGRE material pass");
   Ogre::GpuProgramParametersSharedPtr params =
     pass->getFragmentProgramParameters();

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -229,7 +229,10 @@ void OgreLensFlarePass::PostRender()
   // WideAngleCamera is supposed to rendered 6 times. Nothin more, nothing less.
   // Normal cameras are supposed to be rendered 1 time.
   GZ_ASSERT((!wideAngleCamera && this->dataPtr->currentFaceIdx == 1u) ||
-              (wideAngleCamera && this->dataPtr->currentFaceIdx == 6u),
+              (wideAngleCamera && this->WideAngleCameraAfterStitching() &&
+               this->dataPtr->currentFaceIdx == 1u) ||
+              (wideAngleCamera && !this->WideAngleCameraAfterStitching() &&
+               this->dataPtr->currentFaceIdx == 6u),
             "The lens flare pass was done more times than expected");
 }
 

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -1,0 +1,393 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "gz/rendering/ogre/OgreLensFlarePass.hh"
+
+#include <gz/common/Util.hh>
+
+#include "gz/rendering/RayQuery.hh"
+#include "gz/rendering/RenderPassSystem.hh"
+#include "gz/rendering/ogre/OgreCamera.hh"
+#include "gz/rendering/ogre/OgreConversions.hh"
+#include "gz/rendering/ogre/OgreLight.hh"
+#include "gz/rendering/ogre/OgreScene.hh"
+#include "gz/rendering/ogre/OgreWideAngleCamera.hh"
+
+#ifdef _MSC_VER
+#  pragma warning(push, 0)
+#endif
+#include <OgreCamera.h>
+#include <OgreGpuProgram.h>
+#include <OgrePass.h>
+#include <OgreTechnique.h>
+#include <OgreVector3.h>
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+
+// clang-format off
+namespace gz
+{
+namespace rendering
+{
+inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+/// \brief Helper class for setting up Camera and Materials when rendering
+/// via Ogre2LensFlarePass.
+class GZ_RENDERING_OGRE_HIDDEN OgreLensFlareCompositorListenerPrivate
+    final : public Ogre::CompositorInstance::Listener
+{
+  public: gz::rendering::OgreLensFlarePass &owner;
+
+  /// \brief constructor
+  /// \param[in] _owner our creator for direct access to variables
+  public: explicit OgreLensFlareCompositorListenerPrivate(
+        gz::rendering::OgreLensFlarePass &_owner) :
+    owner(_owner)
+  {
+  }
+
+  /// \brief Callback that OGRE will invoke for us on each render call
+  /// \param[in] _passID OGRE material pass ID.
+  /// \param[in] _mat Pointer to OGRE material.
+  public: void notifyMaterialRender(unsigned int _passId,
+                                    Ogre::MaterialPtr &_mat) override;
+};
+}
+}
+}
+// clang-format on
+
+/// \brief Private data for the OgreLensFlarePass class
+class gz::rendering::OgreLensFlarePass::Implementation
+{
+  // clang-format off
+
+  /// \brief Position of light in world frame
+  public: math::Vector3d lightWorldPos;
+
+  /// \brief Color of lens flare.
+  public: math::Vector3d color = math::Vector3d(1.0, 1.0, 1.0);
+
+  /// \brief Scale of lens flare.
+  public: double scale = 1.0;
+
+  /// \brief Number of steps to take in each
+  /// direction when checking for occlusion.
+  public: double occlusionSteps = 10.0;
+
+  /// \brief Current Camera rendering
+  public: CameraPtr currentCamera;
+
+  /// \brief Current Face index being rendered. In range [0; 6)
+  public: uint32_t currentFaceIdx = 1u;
+
+  /// \brief RayQuery to perform occlusion tests
+  public: RayQueryPtr rayQuery;
+
+  /// \brief See OgreLensFlarePassPrivate
+  public: OgreLensFlareCompositorListenerPrivate compositorListener;
+
+  /// \brief Lens Flare compositor.
+  public: Ogre::CompositorInstance *lensFlareInstance = nullptr;
+
+  public: explicit Implementation(gz::rendering::OgreLensFlarePass &_owner) :
+    compositorListener(_owner)
+  {
+  }
+  // clang-format on
+};
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+OgreLensFlarePass::OgreLensFlarePass() :
+  dataPtr(utils::MakeUniqueImpl<Implementation>(*this))
+{
+}
+
+//////////////////////////////////////////////////
+OgreLensFlarePass::~OgreLensFlarePass()
+{
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::Init(ScenePtr _scene)
+{
+  this->scene = std::dynamic_pointer_cast<OgreScene>(_scene);
+  this->dataPtr->rayQuery = _scene->CreateRayQuery();
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::Destroy()
+{
+  if (this->dataPtr->lensFlareInstance)
+  {
+    this->dataPtr->lensFlareInstance->setEnabled(false);
+    this->dataPtr->lensFlareInstance->removeListener(
+      &this->dataPtr->compositorListener);
+    Ogre::CompositorManager::getSingleton().removeCompositor(
+      this->ogreCamera->getViewport(), "RenderPass/LensFlare");
+
+    this->dataPtr->lensFlareInstance = nullptr;
+  }
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::CreateRenderPass()
+{
+  if (!this->ogreCamera)
+  {
+    gzerr << "No camera set for applying Lens Flare Pass" << std::endl;
+    return;
+  }
+
+  if (this->dataPtr->lensFlareInstance)
+  {
+    gzwarn << "Lens Flare pass already created. " << std::endl;
+    return;
+  }
+
+  // create compositor instance
+  this->dataPtr->lensFlareInstance =
+    Ogre::CompositorManager::getSingleton().addCompositor(
+      this->ogreCamera->getViewport(), "RenderPass/GaussianNoise");
+  this->dataPtr->lensFlareInstance->setEnabled(this->enabled);
+
+  this->dataPtr->lensFlareInstance->addListener(
+    &this->dataPtr->compositorListener);
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::PreRender(const CameraPtr &_camera)
+{
+  if (!this->dataPtr->lensFlareInstance)
+    return;
+
+  if (this->enabled != this->dataPtr->lensFlareInstance->getEnabled())
+    this->dataPtr->lensFlareInstance->setEnabled(this->enabled);
+
+  if (!this->enabled || this->light == nullptr)
+    return;
+
+  // use light's world position for lens flare position
+  DirectionalLight *dirLight =
+    dynamic_cast<DirectionalLight *>(this->light.get());
+  if (dirLight)
+  {
+    // Directional lights misuse position as a direction.
+    // The large multiplier is for occlusion testing and assumes the light
+    // is very far away. Larger values cause the light to disappear on
+    // some frames for some unknown reason.
+    this->dataPtr->lightWorldPos =
+      -(this->light->WorldPose().Rot() * dirLight->Direction()) * 100000.0;
+  }
+  else
+    this->dataPtr->lightWorldPos = this->light->WorldPose().Pos();
+
+  this->dataPtr->currentCamera = _camera;
+  this->dataPtr->currentFaceIdx = 0u;
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::PostRender()
+{
+  if (!this->enabled || this->light == nullptr)
+    return;
+
+  OgreWideAngleCameraPtr wideAngleCamera =
+    std::dynamic_pointer_cast<OgreWideAngleCamera>(
+      this->dataPtr->currentCamera);
+  // WideAngleCamera is supposed to rendered 6 times. Nothin more, nothing less.
+  // Normal cameras are supposed to be rendered 1 time.
+  GZ_ASSERT((!wideAngleCamera && this->dataPtr->currentFaceIdx == 1u) ||
+              (wideAngleCamera && this->dataPtr->currentFaceIdx == 6u),
+            "The lens flare pass was done more times than expected");
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::SetScale(const double _scale)
+{
+  this->dataPtr->scale = _scale;
+}
+
+//////////////////////////////////////////////////
+double OgreLensFlarePass::Scale() const
+{
+  return this->dataPtr->scale;
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::SetColor(const math::Vector3d &_color)
+{
+  this->dataPtr->color = _color;
+}
+
+//////////////////////////////////////////////////
+const math::Vector3d &OgreLensFlarePass::Color() const
+{
+  return this->dataPtr->color;
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlarePass::SetOcclusionSteps(const uint32_t _occlusionSteps)
+{
+  this->dataPtr->occlusionSteps = static_cast<double>(_occlusionSteps);
+}
+
+//////////////////////////////////////////////////
+uint32_t OgreLensFlarePass::OcclusionSteps() const
+{
+  return static_cast<uint32_t>(this->dataPtr->occlusionSteps);
+}
+
+//////////////////////////////////////////////////
+double OgreLensFlarePass::OcclusionScale(const math::Vector3d &_imgPos,
+                                         uint32_t _faceIdx)
+{
+  if (std::abs(this->dataPtr->occlusionSteps) <= 1e-7)
+  {
+    return this->dataPtr->scale;
+  }
+
+  OgreWideAngleCameraPtr wideAngleCamera =
+    std::dynamic_pointer_cast<OgreWideAngleCamera>(
+      this->dataPtr->currentCamera);
+  if (wideAngleCamera)
+  {
+    this->dataPtr->rayQuery->SetFromCamera(
+      wideAngleCamera, _faceIdx, math::Vector2d(_imgPos.X(), _imgPos.Y()));
+  }
+  else
+  {
+    this->dataPtr->rayQuery->SetFromCamera(
+      this->dataPtr->currentCamera, math::Vector2d(_imgPos.X(), _imgPos.Y()));
+  }
+
+  const math::Vector3d lightWorldPos = this->dataPtr->lightWorldPos;
+
+  {
+    // check center point
+    // if occluded than set scale to 0
+    RayQueryResult result = this->dataPtr->rayQuery->ClosestPoint(false);
+    bool intersect = result.distance >= 0.0;
+    if (intersect &&
+        (result.point.SquaredLength() < lightWorldPos.SquaredLength()))
+    {
+      return 0;
+    }
+  }
+
+  unsigned int rays = 0;
+  unsigned int occluded = 0u;
+  // work in normalized device coordinates
+  // lens flare's halfSize is just an approximated value
+  const double halfSize = 0.05 * this->dataPtr->scale;
+  const double steps = this->dataPtr->occlusionSteps;
+  const double stepSize = halfSize * 2 / steps;
+  const double cx = _imgPos.X();
+  const double cy = _imgPos.Y();
+  const double startx = cx - halfSize;
+  const double starty = cy - halfSize;
+  const double endx = cx + halfSize;
+  const double endy = cy + halfSize;
+  // do sparse ray cast occlusion check
+  for (double i = starty; i < endy; i += stepSize)
+  {
+    for (double j = startx; j < endx; j += stepSize)
+    {
+      if (wideAngleCamera)
+      {
+        this->dataPtr->rayQuery->SetFromCamera(wideAngleCamera, _faceIdx,
+                                               math::Vector2d(j, i));
+      }
+      else
+      {
+        this->dataPtr->rayQuery->SetFromCamera(this->dataPtr->currentCamera,
+                                               math::Vector2d(j, i));
+      }
+      RayQueryResult result = this->dataPtr->rayQuery->ClosestPoint(false);
+      bool intersect = result.distance >= 0.0;
+      if (intersect &&
+          (result.point.SquaredLength() < lightWorldPos.SquaredLength()))
+      {
+        occluded++;
+      }
+
+      rays++;
+    }
+  }
+  double s = static_cast<double>(rays - occluded) / static_cast<double>(rays);
+  return s * this->dataPtr->scale;
+}
+
+//////////////////////////////////////////////////
+void OgreLensFlareCompositorListenerPrivate::notifyMaterialRender(
+  unsigned int _passId, Ogre::MaterialPtr &_mat)
+{
+  if (!this->owner.enabled)
+    return;
+
+  using namespace Ogre;
+
+  // These calls are setting parameters that are declared in two places:
+  // 1. media/materials/scripts/lens_flare.material, in
+  //    fragment_program LensFlareFS
+  // 2. media/materials/scripts/lens_flare_fs.glsl
+  Ogre::Technique *technique = _mat->getTechnique(0);
+  GZ_ASSERT(technique, "Null OGRE material technique");
+  Ogre::Pass *pass = technique->getPass((unsigned short)_passId);
+  GZ_ASSERT(pass, "Null OGRE material pass");
+  Ogre::GpuProgramParametersSharedPtr params =
+    pass->getFragmentProgramParameters();
+
+  const Ogre::Camera *camera =
+    dynamic_cast<OgreCamera *>(this->owner.dataPtr->currentCamera.get())
+      ->Camera();
+
+  const Matrix4 viewProj =
+    camera->getProjectionMatrix() * camera->getViewMatrix();
+  const Vector4 pos =
+    viewProj *
+    Vector4(OgreConversions::Convert(this->owner.dataPtr->lightWorldPos));
+
+  // normalize x and y, keep z for visibility test
+  Vector3 lightPos;
+  lightPos.x = pos.x / pos.w;
+  lightPos.y = pos.y / pos.w;
+  // Make lightPos.z > 0 mean we're in front of near plane
+  // since pos.z is in range [-|pos.w|; |pos.w|]
+  lightPos.z = pos.z + std::abs(pos.w);
+
+  double lensFlareScale = 1.0;
+  if (lightPos.z >= 0.0)
+  {
+    lensFlareScale = this->owner.OcclusionScale(
+      OgreConversions::Convert(lightPos), this->owner.dataPtr->currentFaceIdx);
+  }
+
+  ++this->owner.dataPtr->currentFaceIdx;
+
+  GpuProgramParametersSharedPtr psParams = pass->getFragmentProgramParameters();
+
+  psParams->setNamedConstant("vpAspectRatio", camera->getAspectRatio());
+  psParams->setNamedConstant("lightPos", lightPos);
+  psParams->setNamedConstant("scale", static_cast<Real>(lensFlareScale));
+  psParams->setNamedConstant(
+    "color", OgreConversions::Convert(this->owner.dataPtr->color));
+}
+
+GZ_RENDERING_REGISTER_RENDER_PASS(OgreLensFlarePass, LensFlarePass)

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -118,6 +118,7 @@ using namespace rendering;
 OgreLensFlarePass::OgreLensFlarePass() :
   dataPtr(utils::MakeUniqueImpl<Implementation>(*this))
 {
+  this->afterStitching = true;
 }
 
 //////////////////////////////////////////////////
@@ -374,13 +375,18 @@ void OgreLensFlareCompositorListenerPrivate::notifyMaterialRender(
 
   const Ogre::Camera *camera;
 
+  uint32_t currentFaceIdx = this->owner.dataPtr->currentFaceIdx;
+  if (this->owner.WideAngleCameraAfterStitching())
+  {
+    currentFaceIdx = 4u;
+  }
+
   {
     OgreWideAngleCamera *wideAngleCamera = dynamic_cast<OgreWideAngleCamera *>(
       this->owner.dataPtr->currentCamera.get());
     if (wideAngleCamera)
     {
-      camera =
-        wideAngleCamera->OgreEnvCameras()[this->owner.dataPtr->currentFaceIdx];
+      camera = wideAngleCamera->OgreEnvCameras()[currentFaceIdx];
     }
     else
     {
@@ -408,7 +414,7 @@ void OgreLensFlareCompositorListenerPrivate::notifyMaterialRender(
   if (lightPos.z >= 0.0)
   {
     lensFlareScale = this->owner.OcclusionScale(
-      OgreConversions::Convert(lightPos), this->owner.dataPtr->currentFaceIdx);
+      OgreConversions::Convert(lightPos), currentFaceIdx);
   }
 
   ++this->owner.dataPtr->currentFaceIdx;

--- a/ogre/src/OgreRenderPass.cc
+++ b/ogre/src/OgreRenderPass.cc
@@ -33,12 +33,8 @@ OgreRenderPass::~OgreRenderPass()
 //////////////////////////////////////////////////
 void OgreRenderPass::SetCamera(Ogre::Camera *_camera)
 {
-  if (this->ogreCamera[0] != _camera)
-  {
-    this->ogreCamera[0] = _camera;
-  }
+  this->ogreCamera[0] = _camera;
 }
-
 
 //////////////////////////////////////////////////
 void OgreRenderPass::SetCameras(

--- a/ogre/src/OgreRenderPass.cc
+++ b/ogre/src/OgreRenderPass.cc
@@ -33,10 +33,19 @@ OgreRenderPass::~OgreRenderPass()
 //////////////////////////////////////////////////
 void OgreRenderPass::SetCamera(Ogre::Camera *_camera)
 {
-  if (this->ogreCamera != _camera)
+  if (this->ogreCamera[0] != _camera)
   {
-    this->ogreCamera = _camera;
+    this->ogreCamera[0] = _camera;
   }
+}
+
+
+//////////////////////////////////////////////////
+void OgreRenderPass::SetCameras(
+  Ogre::Camera *_cameras[kMaxOgreRenderPassCameras])
+{
+  for (size_t i = 0u; i < kMaxOgreRenderPassCameras; ++i)
+    this->ogreCamera[i] = _cameras[i];
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -314,6 +314,7 @@ OgreRenderTexture::~OgreRenderTexture()
 //////////////////////////////////////////////////
 void OgreRenderTexture::Destroy()
 {
+  this->RemoveAllRenderPasses();
   this->DestroyTarget();
 }
 
@@ -460,6 +461,7 @@ Ogre::RenderTarget *OgreRenderWindow::RenderTarget() const
 //////////////////////////////////////////////////
 void OgreRenderWindow::Destroy()
 {
+  this->RemoveAllRenderPasses();
   // if (this->ogreRenderWindow)
   //  this->ogreRenderWindow->destroy();
 }

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -356,6 +356,7 @@ void OgreRenderTexture::DestroyTarget()
 
   this->ogreViewport = nullptr;
   this->ogreTexture = nullptr;
+  this->ogreViewport = nullptr;
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -279,6 +279,8 @@ OgreThermalCamera::~OgreThermalCamera()
 //////////////////////////////////////////////////
 void OgreThermalCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   if (this->dataPtr->thermalBuffer)
   {
     delete [] this->dataPtr->thermalBuffer;

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -149,6 +149,12 @@ void OgreWideAngleCamera::PreRender()
     this->CreateWideAngleTexture();
 
   this->UpdateRenderPassChain();
+
+  for (auto pass : this->dataPtr->renderPasses)
+  {
+    pass->PreRender(
+      std::dynamic_pointer_cast<Camera>(this->shared_from_this()));
+  }
 }
 
 //////////////////////////////////////////////////
@@ -666,6 +672,11 @@ void OgreWideAngleCamera::PostRender()
 {
   if (this->dataPtr->newImageFrame.ConnectionCount() <= 0u)
     return;
+
+  for (auto pass : this->dataPtr->renderPasses)
+  {
+    pass->PostRender();
+  }
 
   unsigned int width = this->ImageWidth();
   unsigned int height = this->ImageHeight();

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -134,11 +134,23 @@ void OgreWideAngleCamera::Init()
 /////////////////////////////////////////////////
 void OgreWideAngleCamera::CreateRenderTexture()
 {
+  this->DestroyRenderTexture();
   RenderTexturePtr base = this->scene->CreateRenderTexture();
   this->dataPtr->wideAngleTexture =
       std::dynamic_pointer_cast<OgreRenderTexture>(base);
   this->dataPtr->wideAngleTexture->SetWidth(1);
   this->dataPtr->wideAngleTexture->SetHeight(1);
+}
+
+//////////////////////////////////////////////////
+void OgreWideAngleCamera::DestroyRenderTexture()
+{
+  if (this->dataPtr->wideAngleTexture)
+  {
+    dynamic_cast<OgreRenderTexture *>(this->dataPtr->wideAngleTexture.get())
+      ->Destroy();
+    this->dataPtr->wideAngleTexture.reset();
+  }
 }
 
 //////////////////////////////////////////////////
@@ -218,6 +230,8 @@ void OgreWideAngleCamera::Destroy()
         this->dataPtr->compMat->getName());
     this->dataPtr->compMat.setNull();
   }
+
+  this->DestroyRenderTexture();
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -160,6 +160,8 @@ void OgreWideAngleCamera::PreRender()
 //////////////////////////////////////////////////
 void OgreWideAngleCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   if (this->dataPtr->imageBuffer)
   {
     delete [] this->dataPtr->imageBuffer;
@@ -238,6 +240,17 @@ void OgreWideAngleCamera::RemoveRenderPass(const RenderPassPtr &_pass)
     this->dataPtr->renderPasses.erase(it);
     this->dataPtr->renderPassDirty = true;
   }
+}
+
+//////////////////////////////////////////////////
+void OgreWideAngleCamera::RemoveAllRenderPasses()
+{
+  for (auto pass : this->dataPtr->renderPasses)
+  {
+    pass->Destroy();
+  }
+  this->dataPtr->renderPasses.clear();
+  this->dataPtr->renderPassDirty = true;
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -465,7 +465,7 @@ void OgreWideAngleCamera::UpdateRenderPassChain()
   {
     OgreRenderPass *ogreRenderPass =
         dynamic_cast<OgreRenderPass *>(pass.get());
-    ogreRenderPass->SetCamera(this->dataPtr->ogreCamera);
+    ogreRenderPass->SetCameras(this->dataPtr->envCameras);
     ogreRenderPass->CreateRenderPass();
   }
   this->dataPtr->renderPassDirty = false;
@@ -486,6 +486,27 @@ void OgreWideAngleCamera::Render()
       this->dataPtr->ogreRenderTexture->getBuffer()->getRenderTarget();
   rt->setAutoUpdated(false);
   rt->update(false);
+}
+
+//////////////////////////////////////////////////
+void OgreWideAngleCamera::Copy(Image &_image) const
+{
+  const unsigned int width = this->ImageWidth();
+  const unsigned int height = this->ImageHeight();
+
+  if (_image.Width() != width || _image.Height() != height)
+  {
+    gzerr << "Invalid image dimensions" << std::endl;
+    return;
+  }
+
+  void *data = _image.Data();
+  Ogre::PixelFormat imageFormat = OgreConversions::Convert(_image.Format());
+  Ogre::PixelBox ogrePixelBox(width, height, 1, imageFormat, data);
+
+  Ogre::RenderTarget *rt =
+    this->dataPtr->ogreRenderTexture->getBuffer()->getRenderTarget();
+  rt->copyContentsToMemory(ogrePixelBox);
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/media/materials/programs/lens_flare_fs.glsl
+++ b/ogre/src/media/materials/programs/lens_flare_fs.glsl
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Viewport's aspect ratio
+uniform float vpAspectRatio;
+
+// light pos in clip space
+uniform vec3 lightPos;
+
+// lens flare scale
+uniform float scale;
+
+// lens flare color
+uniform vec3 color;
+
+uniform sampler2D srcTex;
+
+vec3 lensflare(vec2 uv,vec2 pos)
+{
+  vec2 main = uv-pos;
+
+  vec2 uvd = uv*length(uv);
+
+  float dist = length(main); dist = pow(dist,.1);
+
+  float f0 = 1.0/(length(uv-pos)*16.0/scale+1.0);
+
+  float f2 = max(1.0/(1.0+32.0*pow(length(uvd+0.8*pos),2.0)),.0)*00.25;
+  float f22 = max(1.0/(1.0+32.0*pow(length(uvd+0.85*pos),2.0)),.0)*00.23;
+  float f23 = max(1.0/(1.0+32.0*pow(length(uvd+0.9*pos),2.0)),.0)*00.21;
+
+  vec2 uvx = mix(uv,uvd,-0.5);
+
+  float f4 = max(0.01-pow(length(uvx+0.4*pos),2.4),.0)*6.0;
+  float f42 = max(0.01-pow(length(uvx+0.45*pos),2.4),.0)*5.0;
+  float f43 = max(0.01-pow(length(uvx+0.5*pos),2.4),.0)*3.0;
+
+  uvx = mix(uv,uvd,-.4);
+
+  float f5 = max(0.01-pow(length(uvx+0.2*pos),5.5),.0)*2.0;
+  float f52 = max(0.01-pow(length(uvx+0.4*pos),5.5),.0)*2.0;
+  float f53 = max(0.01-pow(length(uvx+0.6*pos),5.5),.0)*2.0;
+
+  uvx = mix(uv,uvd,-0.5);
+
+  float f6 = max(0.01-pow(length(uvx-0.3*pos),1.6),.0)*6.0;
+  float f62 = max(0.01-pow(length(uvx-0.325*pos),1.6),.0)*3.0;
+  float f63 = max(0.01-pow(length(uvx-0.35*pos),1.6),.0)*5.0;
+
+  vec3 c = vec3(.0);
+
+  c.r+=f2+f4+f5+f6; c.g+=f22+f42+f52+f62; c.b+=f23+f43+f53+f63;
+  c *= min(scale, 0.2)/0.2;
+  c+=vec3(f0);
+
+  return c;
+}
+
+void main()
+{
+  if (lightPos.z < 0.0)
+  {
+    // light is behind the view
+    gl_FragColor = texture(srcTex, gl_TexCoord[0].xy);
+  }
+  else
+  {
+    vec3 pos = lightPos;
+
+    // flip y
+    pos.y *= -1.0;
+
+    vec2 uv = gl_TexCoord[0].xy - 0.5;
+    // scale lightPos to be same range as uv
+    pos *= 0.5;
+    // fix aspect ratio
+    uv.x *= vpAspectRatio;
+    pos.x *= vpAspectRatio;
+
+    // compute lens flare
+    vec3 finalColor = color * lensflare(uv, pos.xy);
+
+    // apply lens flare
+    gl_FragColor = texture(srcTex, gl_TexCoord[0].xy) +
+                vec4(finalColor, 1.0);
+  }
+}

--- a/ogre/src/media/materials/programs/lens_flare_fs.glsl
+++ b/ogre/src/media/materials/programs/lens_flare_fs.glsl
@@ -75,7 +75,7 @@ void main()
   if (lightPos.z < 0.0)
   {
     // light is behind the view
-    gl_FragColor = texture(srcTex, gl_TexCoord[0].xy);
+    gl_FragColor = texture2D(srcTex, gl_TexCoord[0].xy);
   }
   else
   {
@@ -95,7 +95,7 @@ void main()
     vec3 finalColor = color * lensflare(uv, pos.xy);
 
     // apply lens flare
-    gl_FragColor = texture(srcTex, gl_TexCoord[0].xy) +
-                vec4(finalColor, 1.0);
+    gl_FragColor = texture2D(srcTex, gl_TexCoord[0].xy) +
+                   vec4(finalColor, 1.0);
   }
 }

--- a/ogre/src/media/materials/programs/lens_flare_vs.glsl
+++ b/ogre/src/media/materials/programs/lens_flare_vs.glsl
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Simple vertex shader; just setting things up for the real work to be done in
+// camera_distortion_fs.glsl.
+void main()
+{
+  gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;
+  gl_TexCoord[0] = gl_MultiTexCoord0;
+}
+

--- a/ogre/src/media/materials/scripts/lens_flare.compositor
+++ b/ogre/src/media/materials/scripts/lens_flare.compositor
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+compositor RenderPass/LensFlare
+{
+  technique
+  {
+    // Temporary textures
+    texture rt0 target_width target_height PF_A8R8G8B8
+
+    target rt0
+    {
+      // Render output from previous compositor (or original scene)
+      input previous
+    }
+
+    target_output
+    {
+      // Start with clear output
+      input none
+
+      // Draw a fullscreen quad with noise
+      pass render_quad
+      {
+        // Renders a fullscreen quad with a material
+        material LensFlare
+        input 0 rt0
+      }
+    }
+  }
+}

--- a/ogre/src/media/materials/scripts/lens_flare.material
+++ b/ogre/src/media/materials/scripts/lens_flare.material
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+vertex_program LensFlareVS glsl
+{
+  source lens_flare_vs.glsl
+}
+
+fragment_program LensFlareFS glsl
+{
+  source lens_flare_fs.glsl
+
+  default_params
+  {
+    param_named srcTex int 0
+  }
+}
+
+material LensFlare
+{
+  technique
+  {
+    pass
+    {
+      depth_check off
+      depth_write off
+      cull_hardware none
+
+      vertex_program_ref GaussianNoiseVS { }
+      fragment_program_ref LensFlareFS { }
+
+      texture_unit RT
+      {
+        tex_address_mode  border
+        filtering         none
+      }
+    }
+  }
+}
+

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
@@ -93,10 +93,6 @@ namespace gz
       // Documentation inherited.
       public: virtual RenderWindowPtr CreateRenderWindow() override;
 
-      /// \brief Destroy render texture created by CreateRenderTexture()
-      /// Note: It's not virtual.
-      protected: void DestroyRenderTexture();
-
       // Documentation inherited.
       public: virtual math::Matrix4d ProjectionMatrix() const override;
 

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Camera.hh
@@ -155,6 +155,10 @@ namespace gz
       /// \brief Create a render texture for the camera for offscreen rendering
       protected: virtual void CreateRenderTexture();
 
+      /// \brief Destroy render texture created by CreateRenderTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyRenderTexture();
+
       /// \brief Create and set selection buffer object
       /// TODO(anyone) to be implemented
       protected: virtual void SetSelectionBuffer();

--- a/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
@@ -32,9 +32,6 @@ namespace gz
   namespace rendering
   {
     inline namespace GZ_RENDERING_VERSION_NAMESPACE {
-    //
-    // forward declaration
-    class Ogre2LensFlarePassPrivate;
 
     /// \brief Ogre2 Implementation of a Lens Flare render pass.
     class GZ_RENDERING_OGRE2_VISIBLE Ogre2LensFlarePass :

--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderTarget.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderTarget.hh
@@ -259,6 +259,9 @@ namespace gz
       // Documentation inherited
       public: void RemoveRenderPass(const RenderPassPtr &_pass) override;
 
+      // Documentation inherited
+      public: void RemoveAllRenderPasses() override;
+
       // Documentation inherited.
       public: virtual void Destroy() override;
 

--- a/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
@@ -49,6 +49,10 @@ namespace gz
       /// \brief Create a texture
       public: virtual void CreateRenderTexture();
 
+      /// \brief Destroy render texture created by CreateRenderTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyRenderTexture();
+
       /// \brief Render the camera
       public: virtual void PostRender() override;
 

--- a/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
@@ -59,6 +59,10 @@ namespace gz
       // Documentation inherited
       public: virtual void Destroy() override;
 
+      /// \brief Destroys all textures and workspaces, possibly
+      /// for recreation.
+      public: void DestroyTextures();
+
       // Documentation inherited
       public: void AddRenderPass(const RenderPassPtr &_pass) override;
 
@@ -106,6 +110,37 @@ namespace gz
           std::function<void(const unsigned char *, unsigned int, unsigned int,
           unsigned int, const std::string &)>  _subscriber) override;
 
+
+      /// \brief Returns the workspace name for the final pass
+      /// that stitches all faces.
+      /// \return Workspace definition's name
+      protected: std::string WorkspaceFinalPassDefinitionName() const;
+
+      /// \brief Creates the workspace definition for stitch (final) pass,
+      /// including effects.
+      protected: void CreateStitchWorkspaceDefinition();
+
+      /// \brief Creates the stitch workspaces & their definitions.
+      protected: void CreateStitchWorkspace();
+
+      /// \brief Destroys the stitch workspaces & their definitions.
+      protected: void DestroyStitchWorkspace();
+
+      /// \brief Returns true if we have a temp texture for Render passes
+      /// with WideAngleCameraAfterStitching = true
+      /// \return See description.
+      protected: bool HasTempStitchTexture() const;
+
+      /// \brief Returns what HasTempStitchTexture() should return
+      /// \return True if there are RenderPases with
+      /// WideAngleCameraAfterStitching = true. False otherwise.
+      protected: bool NeedsTempStitchTexture() const;
+
+      /// \brief Returns what HasTempStitchTexture() should return
+      /// \return Returns which channel kStichTmpTexture should be in.
+      /// Depends on whether number of render passes with
+      /// RenderPass::WideAngleCameraAfterStitching == true is odd or even
+      protected: uint32_t TempStitchTextureChannel() const;
 
       /// \brief Returns the workspace name. It's unique for each camera.
       /// \param[in] _faceIdx Face index in range [0; 6)

--- a/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2WideAngleCamera.hh
@@ -61,6 +61,9 @@ namespace gz
       // Documentation inherited
       public: void RemoveRenderPass(const RenderPassPtr &_pass) override;
 
+      // Documentation inherited
+      public: void RemoveAllRenderPasses() override;
+
       /// \brief Gets the environment texture size
       /// \return Texture size
       public: uint32_t EnvTextureSize() const;

--- a/ogre2/src/Ogre2BoundingBoxCamera.cc
+++ b/ogre2/src/Ogre2BoundingBoxCamera.cc
@@ -403,6 +403,8 @@ void Ogre2BoundingBoxCamera::CreateCamera()
 /////////////////////////////////////////////////
 void Ogre2BoundingBoxCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   if (this->dataPtr->buffer)
   {
     delete [] this->dataPtr->buffer;

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -58,6 +58,7 @@ void Ogre2Camera::Destroy()
   if (!this->ogreCamera || !this->Scene()->IsInitialized())
     return;
 
+  this->RemoveAllRenderPasses();
   this->DestroyRenderTexture();
 
   Ogre::SceneManager *ogreSceneManager;

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -208,6 +208,16 @@ void Ogre2Camera::CreateRenderTexture()
   this->renderTexture->SetVisibilityMask(this->visibilityMask);
 }
 
+
+//////////////////////////////////////////////////
+void Ogre2Camera::DestroyRenderTexture()
+{
+  if (this->renderTexture)
+  {
+    dynamic_cast<Ogre2RenderTexture *>(this->renderTexture.get())->Destroy();
+    this->renderTexture.reset();
+  }
+}
 //////////////////////////////////////////////////
 void Ogre2Camera::DestroyRenderTexture()
 {

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -209,25 +209,16 @@ void Ogre2Camera::CreateRenderTexture()
   this->renderTexture->SetVisibilityMask(this->visibilityMask);
 }
 
+//////////////////////////////////////////////////
+void Ogre2Camera::DestroyRenderTexture()
+{
+  if (this->renderTexture)
+  {
+    dynamic_cast<Ogre2RenderTarget *>(this->renderTexture.get())->Destroy();
+    this->renderTexture.reset();
+  }
+}
 
-//////////////////////////////////////////////////
-void Ogre2Camera::DestroyRenderTexture()
-{
-  if (this->renderTexture)
-  {
-    dynamic_cast<Ogre2RenderTarget *>(this->renderTexture.get())->Destroy();
-    this->renderTexture.reset();
-  }
-}
-//////////////////////////////////////////////////
-void Ogre2Camera::DestroyRenderTexture()
-{
-  if (this->renderTexture)
-  {
-    dynamic_cast<Ogre2RenderTarget *>(this->renderTexture.get())->Destroy();
-    this->renderTexture.reset();
-  }
-}
 //////////////////////////////////////////////////
 unsigned int Ogre2Camera::RenderTextureGLId() const
 {

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -215,7 +215,7 @@ void Ogre2Camera::DestroyRenderTexture()
 {
   if (this->renderTexture)
   {
-    dynamic_cast<Ogre2RenderTexture *>(this->renderTexture.get())->Destroy();
+    dynamic_cast<Ogre2RenderTarget *>(this->renderTexture.get())->Destroy();
     this->renderTexture.reset();
   }
 }

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -273,6 +273,8 @@ void Ogre2DepthCamera::Init()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   if (this->dataPtr->depthBuffer)
   {
     delete [] this->dataPtr->depthBuffer;

--- a/ogre2/src/Ogre2GaussianNoisePass.cc
+++ b/ogre2/src/Ogre2GaussianNoisePass.cc
@@ -94,16 +94,7 @@ void Ogre2GaussianNoisePass::PreRender()
 //////////////////////////////////////////////////
 void Ogre2GaussianNoisePass::CreateRenderPass()
 {
-  static int gaussianNodeCounter = 0;
-
-  auto engine = Ogre2RenderEngine::Instance();
-  auto ogreRoot = engine->OgreRoot();
-  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
-
-  std::string nodeDefName = "GaussianNoiseNodeNode_"
-      + std::to_string(gaussianNodeCounter);
-
-  if (ogreCompMgr->hasNodeDefinition(nodeDefName))
+  if (!this->ogreCompositorNodeDefName.empty())
     return;
 
   // The GaussianNoise material is defined in script (gaussian_noise.material).
@@ -119,6 +110,9 @@ void Ogre2GaussianNoisePass::CreateRenderPass()
   }
   if (!ogreMat->isLoaded())
     ogreMat->load();
+
+  static int gaussianNodeCounter = 0;
+
   std::string materialName = matName + "_" +
       std::to_string(gaussianNodeCounter);
   this->dataPtr->gaussianNoiseMat = ogreMat->clone(materialName).get();
@@ -153,6 +147,13 @@ void Ogre2GaussianNoisePass::CreateRenderPass()
   //   // where the texture is reused to store its result
   //   out 1 rt_input
   // }
+
+  auto engine = Ogre2RenderEngine::Instance();
+  auto ogreRoot = engine->OgreRoot();
+  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+
+  std::string nodeDefName = "GaussianNoiseNodeNode_"
+      + std::to_string(gaussianNodeCounter);
 
   this->ogreCompositorNodeDefName = nodeDefName;
   gaussianNodeCounter++;

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -99,9 +99,6 @@ class gz::rendering::Ogre2RenderTargetPrivate
   /// actual window
   ///
   public: Ogre::TextureGpu *ogreTexture[2] = {nullptr, nullptr};
-
-  /// \brief A chain of render passes applied to the render target
-  protected: std::vector<RenderPassPtr> renderPasses;
 };
 
 using namespace gz;
@@ -123,7 +120,8 @@ Ogre2RenderTarget::~Ogre2RenderTarget()
   GZ_ASSERT(this->dataPtr->rtListener == nullptr &&
             this->dataPtr->ogreTexture[0] == nullptr &&
             this->dataPtr->ogreTexture[1] == nullptr &&
-            this->ogreCompositorWorkspace == nullptr,
+            this->ogreCompositorWorkspace == nullptr &&
+            this->renderPasses.empty(),
             "Ogre2RenderTarget::Destroy not called!");
 }
 

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -959,8 +959,29 @@ void Ogre2RenderTexture::RemoveRenderPass(const RenderPassPtr &_pass)
 }
 
 //////////////////////////////////////////////////
+void Ogre2RenderTexture::RemoveAllRenderPasses()
+{
+  if (!this->renderPasses.empty())
+  {
+    for (RenderPassPtr &renderPass : this->renderPasses)
+    {
+      Ogre2RenderPass *ogre2RenderPass =
+        dynamic_cast<Ogre2RenderPass *>(renderPass.get());
+      if (this->ogreCompositorWorkspace)
+      {
+        ogre2RenderPass->WorkspaceRemoved(this->ogreCompositorWorkspace);
+      }
+      ogre2RenderPass->Destroy();
+    }
+    this->renderPasses.clear();
+    this->renderPassDirty = true;
+  }
+}
+
+//////////////////////////////////////////////////
 void Ogre2RenderTexture::Destroy()
 {
+  this->RemoveAllRenderPasses();
   this->DestroyTarget();
 }
 
@@ -1040,6 +1061,7 @@ Ogre::TextureGpu *Ogre2RenderWindow::RenderTarget() const
 //////////////////////////////////////////////////
 void Ogre2RenderWindow::Destroy()
 {
+  this->RemoveAllRenderPasses();
   // TODO(anyone)
 }
 

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -102,6 +102,8 @@ void Ogre2SegmentationCamera::Init()
 /////////////////////////////////////////////////
 void Ogre2SegmentationCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   if (this->dataPtr->buffer)
   {
     delete [] this->dataPtr->buffer;

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -723,6 +723,8 @@ void Ogre2ThermalCamera::Init()
 //////////////////////////////////////////////////
 void Ogre2ThermalCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   if (this->dataPtr->thermalImage)
   {
     delete [] this->dataPtr->thermalImage;

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -182,11 +182,23 @@ void Ogre2WideAngleCamera::Init()
 /////////////////////////////////////////////////
 void Ogre2WideAngleCamera::CreateRenderTexture()
 {
+  this->DestroyRenderTexture();
   RenderTexturePtr base = this->scene->CreateRenderTexture();
   this->dataPtr->wideAngleTexture =
     std::dynamic_pointer_cast<Ogre2RenderTexture>(base);
   this->dataPtr->wideAngleTexture->SetWidth(1);
   this->dataPtr->wideAngleTexture->SetHeight(1);
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::DestroyRenderTexture()
+{
+  if (this->dataPtr->wideAngleTexture)
+  {
+    dynamic_cast<Ogre2RenderTexture *>(this->dataPtr->wideAngleTexture.get())
+      ->Destroy();
+    this->dataPtr->wideAngleTexture.reset();
+  }
 }
 
 //////////////////////////////////////////////////
@@ -241,11 +253,7 @@ void Ogre2WideAngleCamera::Destroy()
     this->dataPtr->ogreRenderTexture = nullptr;
   }
 
-  if (this->dataPtr->wideAngleTexture)
-  {
-    this->dataPtr->wideAngleTexture->Destroy();
-    this->dataPtr->wideAngleTexture.reset();
-  }
+  this->DestroyRenderTexture();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -89,6 +89,10 @@ static const char *kWideAngleCameraSuffixes[6] = { "PX", "NX", "PY",
 
 static const uint32_t kWideAngleNumCubemapFaces = 6u;
 
+static const uint32_t kStichTmpTexture = 0u;
+static const uint32_t kStichFinalTexture = 1u;
+static const uint32_t kNumStichTextures = 2u;
+
 /// \brief Private data for the WideAngleCamera class
 class gz::rendering::Ogre2WideAngleCamera::Implementation
 {
@@ -103,8 +107,11 @@ class gz::rendering::Ogre2WideAngleCamera::Implementation
   /// We use two for ping pong effects.
   public: Ogre::TextureGpu *ogreTmpTextures[2]{};
 
-  /// \brief Output texture
-  public: Ogre::TextureGpu *ogreRenderTexture = nullptr;
+  /// \brief Output texture with the the toutput for stitches
+  /// [kStichTmpTexture] = Temp 2D texture for ping poing effects
+  /// [kStichFinalTexture] = Output texture with the final output
+  public: Ogre::TextureGpu *ogreStitchTexture[kNumStichTextures] =
+  { nullptr, nullptr };
 
   /// \brief Compositor workspace. Does all the work. One for each face
   public: Ogre::CompositorWorkspace *ogreCompositorWorkspace[6];
@@ -131,6 +138,9 @@ class gz::rendering::Ogre2WideAngleCamera::Implementation
 
   /// \brief A chain of render passes applied to the render target
   public: std::vector<RenderPassPtr> renderPasses;
+
+  /// \brief A chain of render passes applied to final stitched render target
+  public: std::vector<RenderPassPtr> finalStitchRenderPasses;
 
   /// \brief Event used to signal camera data
   public: gz::common::EventT<void(const unsigned char *,
@@ -205,43 +215,74 @@ void Ogre2WideAngleCamera::DestroyRenderTexture()
 void Ogre2WideAngleCamera::PreRender()
 {
   BaseCamera::PreRender();
-  if (!this->dataPtr->ogreRenderTexture)
+
+  {
+    auto thisAsCameraPtr =
+      std::dynamic_pointer_cast<Camera>(this->shared_from_this());
+
+    for (RenderPassPtr &pass : this->dataPtr->renderPasses)
+    {
+      pass->PreRender(thisAsCameraPtr);
+    }
+    for (RenderPassPtr &pass : this->dataPtr->finalStitchRenderPasses)
+    {
+      pass->PreRender(thisAsCameraPtr);
+    }
+  }
+
+  if (!this->dataPtr->ogreStitchTexture[kStichFinalTexture])
   {
     this->CreateWideAngleTexture();
   }
-  else if (!this->dataPtr->ogreCompositorWorkspace[0])
-  {
-    // If render passes were added/destroyed, ogreCompositorWorkspace
-    // will become nullptr and must be recreated.
-    const uint8_t msaa =
-      Ogre2RenderTarget::TargetFSAA(static_cast<uint8_t>(this->antiAliasing));
-    this->CreateFacesWorkspaces(msaa > 1u);
-  }
   else
   {
-    this->UpdateRenderPasses();
+    if (!this->dataPtr->ogreCompositorWorkspace[0])
+    {
+      // If render passes were added/destroyed, ogreCompositorWorkspace
+      // will become nullptr and must be recreated.
+      const uint8_t msaa =
+        Ogre2RenderTarget::TargetFSAA(static_cast<uint8_t>(this->antiAliasing));
+      this->CreateFacesWorkspaces(msaa > 1u);
+    }
+
+    if (!this->dataPtr->ogreCompositorFinalPass)
+    {
+      // If render passes were added/destroyed, ogreCompositorWorkspace
+      // will become nullptr and must be recreated.
+      this->CreateStitchWorkspace();
+    }
   }
+
+  this->UpdateRenderPasses();
 }
 
 //////////////////////////////////////////////////
 void Ogre2WideAngleCamera::Destroy()
 {
   this->RemoveAllRenderPasses();
+  this->DestroyTextures();
+  this->DestroyRenderTexture();
+}
 
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::DestroyTextures()
+{
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
   Ogre::TextureGpuManager *textureMgr =
     ogreRoot->getRenderSystem()->getTextureGpuManager();
 
-  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
-
-  if (this->dataPtr->ogreCompositorFinalPass)
-  {
-    ogreCompMgr->removeWorkspace(this->dataPtr->ogreCompositorFinalPass);
-    this->dataPtr->ogreCompositorFinalPass = nullptr;
-  }
-
+  this->DestroyStitchWorkspace();
   this->DestroyFacesWorkspaces();
+
+  for (uint32_t i = 0u; i < 2u; ++i)
+  {
+    if (this->dataPtr->ogreTmpTextures[i])
+    {
+      textureMgr->destroyTexture(this->dataPtr->ogreTmpTextures[i]);
+      this->dataPtr->ogreTmpTextures[i] = nullptr;
+    }
+  }
 
   if (this->dataPtr->envCubeMapTexture)
   {
@@ -249,42 +290,88 @@ void Ogre2WideAngleCamera::Destroy()
     this->dataPtr->envCubeMapTexture = nullptr;
   }
 
-  if (this->dataPtr->ogreRenderTexture)
+  for (uint32_t i = 0; i < kNumStichTextures; ++i)
   {
-    textureMgr->destroyTexture(this->dataPtr->ogreRenderTexture);
-    this->dataPtr->ogreRenderTexture = nullptr;
+    if (this->dataPtr->ogreStitchTexture[i])
+    {
+      textureMgr->destroyTexture(this->dataPtr->ogreStitchTexture[i]);
+      this->dataPtr->ogreStitchTexture[i] = nullptr;
+    }
   }
-
-  this->DestroyRenderTexture();
 }
 
 //////////////////////////////////////////////////
 void Ogre2WideAngleCamera::AddRenderPass(const RenderPassPtr &_pass)
 {
-  BaseWideAngleCamera::AddRenderPass(_pass);
-  this->dataPtr->renderPasses.push_back(_pass);
-  this->DestroyFacesWorkspaces();
+  // Do NOT pass it to super class.
+  if (_pass->WideAngleCameraAfterStitching())
+  {
+    this->dataPtr->finalStitchRenderPasses.push_back(_pass);
+    this->DestroyStitchWorkspace();
+
+    if (this->HasTempStitchTexture() != this->NeedsTempStitchTexture())
+    {
+      this->DestroyTextures();
+    }
+  }
+  else
+  {
+    this->dataPtr->renderPasses.push_back(_pass);
+    this->DestroyFacesWorkspaces();
+  }
 }
 
 //////////////////////////////////////////////////
 void Ogre2WideAngleCamera::RemoveRenderPass(const RenderPassPtr &_pass)
 {
+  // Do NOT pass it to super class.
   auto it = std::find(this->dataPtr->renderPasses.begin(),
                       this->dataPtr->renderPasses.end(), _pass);
   if (it != this->dataPtr->renderPasses.end())
   {
     (*it)->Destroy();
     this->dataPtr->renderPasses.erase(it);
+    this->DestroyFacesWorkspaces();
   }
-  this->DestroyFacesWorkspaces();
-  BaseWideAngleCamera::RemoveRenderPass(_pass);
+  else
+  {
+    it = std::find(this->dataPtr->finalStitchRenderPasses.begin(),
+                   this->dataPtr->finalStitchRenderPasses.end(), _pass);
+    if (it != this->dataPtr->finalStitchRenderPasses.end())
+    {
+      (*it)->Destroy();
+      this->dataPtr->finalStitchRenderPasses.erase(it);
+      this->DestroyStitchWorkspace();
+
+      if (this->HasTempStitchTexture() != this->NeedsTempStitchTexture())
+      {
+        this->DestroyTextures();
+      }
+    }
+    else
+    {
+      gzwarn << "Ogre2WideAngleCamera::RemoveRenderPass pass not found. This "
+                "is fine if you called this function twice. But it may not be "
+                "fine if you changed the value "
+                "RenderPass::WideAngleCameraAfterStitching (see docs)"
+             << std::endl;
+    }
+  }
 }
 
 //////////////////////////////////////////////////
 void Ogre2WideAngleCamera::RemoveAllRenderPasses()
 {
-  BaseWideAngleCamera::RemoveAllRenderPasses();
+  for (RenderPassPtr &pass : this->dataPtr->renderPasses)
+  {
+    pass->Destroy();
+  }
+  for (RenderPassPtr &pass : this->dataPtr->finalStitchRenderPasses)
+  {
+    pass->Destroy();
+  }
   this->dataPtr->renderPasses.clear();
+  this->dataPtr->finalStitchRenderPasses.clear();
   this->DestroyFacesWorkspaces();
 }
 
@@ -333,6 +420,146 @@ void Ogre2WideAngleCamera::CreateCamera()
   const Ogre::Real farPlane = static_cast<Ogre::Real>(this->FarClipPlane());
   this->dataPtr->ogreCamera->setNearClipDistance(nearPlane);
   this->dataPtr->ogreCamera->setFarClipDistance(farPlane);
+}
+
+//////////////////////////////////////////////////
+std::string Ogre2WideAngleCamera::WorkspaceFinalPassDefinitionName() const
+{
+  const std::string wsDefName = "WideAngleCamera/" + this->Name() + "/Final";
+  return wsDefName;
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::CreateStitchWorkspaceDefinition()
+{
+  using namespace Ogre;
+  auto engine = Ogre2RenderEngine::Instance();
+  auto ogreRoot = engine->OgreRoot();
+  CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+
+  const std::string wsDefName = this->WorkspaceFinalPassDefinitionName();
+
+  CompositorWorkspaceDef *workDef =
+    ogreCompMgr->addWorkspaceDefinition(wsDefName);
+
+  const IdString stitchPassNodeName = "WideAngleCameraFinalPass";
+
+  const uint32_t tempStitchTextureChannel = this->TempStitchTextureChannel();
+
+  workDef->connectExternal(0, stitchPassNodeName, tempStitchTextureChannel);
+  workDef->connectExternal(1, stitchPassNodeName, !tempStitchTextureChannel);
+  workDef->connectExternal(2, stitchPassNodeName, 2);
+
+  IdString prevNode = stitchPassNodeName;
+  for (RenderPassPtr &pass : this->dataPtr->finalStitchRenderPasses)
+  {
+    GZ_ASSERT(pass->WideAngleCameraAfterStitching(),
+              "Cannot change the setting of WideAngleCameraAfterStitching "
+              "after adding it to Camera");
+
+    Ogre2RenderPass *ogre2RenderPass =
+      dynamic_cast<Ogre2RenderPass *>(pass.get());
+
+    if (ogre2RenderPass->IsEnabled())
+    {
+      ogre2RenderPass->CreateRenderPass();
+      IdString currNode = ogre2RenderPass->OgreCompositorNodeDefinitionName();
+      workDef->connect(prevNode, currNode);
+      prevNode = currNode;
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::CreateStitchWorkspace()
+{
+  this->CreateStitchWorkspaceDefinition();
+
+  auto engine = Ogre2RenderEngine::Instance();
+  auto ogreRoot = engine->OgreRoot();
+  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+  Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
+
+  Ogre::CompositorChannelVec channelsFinalPass = {
+    nullptr, nullptr, this->dataPtr->envCubeMapTexture
+  };
+
+  if (!this->NeedsTempStitchTexture())
+  {
+    // Set both to kStichFinalTexture to keep OgreNext happy about
+    // all channels having been connected
+    channelsFinalPass[0] = this->dataPtr->ogreStitchTexture[kStichFinalTexture];
+    channelsFinalPass[1] = this->dataPtr->ogreStitchTexture[kStichFinalTexture];
+  }
+  else
+  {
+    channelsFinalPass[0] = this->dataPtr->ogreStitchTexture[kStichTmpTexture];
+    channelsFinalPass[1] = this->dataPtr->ogreStitchTexture[kStichFinalTexture];
+  }
+
+  this->dataPtr->ogreCompositorFinalPass = ogreCompMgr->addWorkspace(
+    ogreSceneManager, channelsFinalPass, this->dataPtr->ogreCamera,
+    this->WorkspaceFinalPassDefinitionName(), false);
+  this->dataPtr->ogreCompositorFinalPass->addListener(
+    &this->dataPtr->workspaceListener);
+  for (RenderPassPtr &pass : this->dataPtr->finalStitchRenderPasses)
+  {
+    Ogre2RenderPass *ogre2RenderPass =
+      dynamic_cast<Ogre2RenderPass *>(pass.get());
+    ogre2RenderPass->WorkspaceAdded(this->dataPtr->ogreCompositorFinalPass);
+  }
+}
+
+//////////////////////////////////////////////////
+void Ogre2WideAngleCamera::DestroyStitchWorkspace()
+{
+  if (this->dataPtr->ogreCompositorFinalPass)
+  {
+    auto engine = Ogre2RenderEngine::Instance();
+    auto ogreRoot = engine->OgreRoot();
+    Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+
+    const Ogre::IdString workspaceName =
+      this->dataPtr->ogreCompositorFinalPass->getDefinition()->getName();
+
+    for (RenderPassPtr &pass : this->dataPtr->finalStitchRenderPasses)
+    {
+      Ogre2RenderPass *ogre2RenderPass =
+        dynamic_cast<Ogre2RenderPass *>(pass.get());
+      ogre2RenderPass->WorkspaceRemoved(this->dataPtr->ogreCompositorFinalPass);
+    }
+
+    ogreCompMgr->removeWorkspace(this->dataPtr->ogreCompositorFinalPass);
+    this->dataPtr->ogreCompositorFinalPass = nullptr;
+
+    ogreCompMgr->removeWorkspaceDefinition(workspaceName);
+  }
+}
+
+//////////////////////////////////////////////////
+bool Ogre2WideAngleCamera::HasTempStitchTexture() const
+{
+  return this->dataPtr->ogreStitchTexture[kStichTmpTexture];
+}
+
+//////////////////////////////////////////////////
+bool Ogre2WideAngleCamera::NeedsTempStitchTexture() const
+{
+  return !this->dataPtr->finalStitchRenderPasses.empty();
+}
+
+//////////////////////////////////////////////////
+uint32_t Ogre2WideAngleCamera::TempStitchTextureChannel() const
+{
+  uint32_t enabledPasses = 0u;
+  for (const auto &pass : this->dataPtr->finalStitchRenderPasses)
+  {
+    if (pass->IsEnabled())
+    {
+      ++enabledPasses;
+    }
+  }
+  return enabledPasses & 0x1u ? 1u : 0u;
 }
 
 //////////////////////////////////////////////////
@@ -396,7 +623,7 @@ void Ogre2WideAngleCamera::CreateWorkspaceDefinition(bool _withMsaa)
 
   for (uint32_t faceIdx = 0u; faceIdx < kWideAngleNumCubemapFaces; ++faceIdx)
   {
-    const std::string wsDefName = WorkspaceDefinitionName(faceIdx);
+    const std::string wsDefName = this->WorkspaceDefinitionName(faceIdx);
     CompositorWorkspaceDef *workDef =
       ogreCompMgr->addWorkspaceDefinition(wsDefName);
 
@@ -406,6 +633,10 @@ void Ogre2WideAngleCamera::CreateWorkspaceDefinition(bool _withMsaa)
     IdString prevNode = cubemapPassNodeName;
     for (RenderPassPtr &pass : this->dataPtr->renderPasses)
     {
+      GZ_ASSERT(!pass->WideAngleCameraAfterStitching(),
+                "Cannot change the setting of WideAngleCameraAfterStitching "
+                "after adding it to Camera");
+
       Ogre2RenderPass *ogre2RenderPass =
         dynamic_cast<Ogre2RenderPass *>(pass.get());
 
@@ -508,6 +739,10 @@ void Ogre2WideAngleCamera::UpdateRenderPasses()
     const IdString currNode =
       ogre2RenderPass->OgreCompositorNodeDefinitionName();
 
+    GZ_ASSERT(!pass->WideAngleCameraAfterStitching(),
+              "Cannot change the setting of WideAngleCameraAfterStitching "
+              "after adding it to Camera");
+
     for (size_t i = 0u; i < kWideAngleNumCubemapFaces; ++i)
     {
       Ogre::CompositorNode *node =
@@ -516,6 +751,9 @@ void Ogre2WideAngleCamera::UpdateRenderPasses()
       // RemoveRenderPass destroys the workspace; which means we can't reach
       // here where we update an already existing workspace; but rather
       // have ended up in CreateFacesWorkspaces()
+      //
+      // Note: We assume ogre2RenderPass->OgreCompositorNodeDefinitionName
+      // returns the same name (given the same ogre2RenderPass ptr)
       GZ_ASSERT(node,
                 "This can't be possible. "
                 "RemoveRenderPass() should've destroyed the workspace.");
@@ -525,6 +763,37 @@ void Ogre2WideAngleCamera::UpdateRenderPasses()
         node->setEnabled(ogre2RenderPass->IsEnabled());
         updateConnection = true;
       }
+    }
+  }
+
+  for (const auto &pass : this->dataPtr->finalStitchRenderPasses)
+  {
+    Ogre2RenderPass *ogre2RenderPass =
+      dynamic_cast<Ogre2RenderPass *>(pass.get());
+
+    const IdString currNode =
+      ogre2RenderPass->OgreCompositorNodeDefinitionName();
+
+    GZ_ASSERT(pass->WideAngleCameraAfterStitching(),
+              "Cannot change the setting of WideAngleCameraAfterStitching "
+              "after adding it to Camera");
+    Ogre::CompositorNode *node =
+      this->dataPtr->ogreCompositorFinalPass->findNodeNoThrow(currNode);
+
+    // RemoveRenderPass destroys the workspace; which means we can't reach
+    // here where we update an already existing workspace; but rather
+    // have ended up in CreateFacesWorkspaces()
+    //
+    // Note: We assume ogre2RenderPass->OgreCompositorNodeDefinitionName
+    // returns the same name (given the same ogre2RenderPass ptr)
+    GZ_ASSERT(node,
+              "This can't be possible. "
+              "RemoveRenderPass() should've destroyed the workspace.");
+
+    if (node->getEnabled() != ogre2RenderPass->IsEnabled())
+    {
+      node->setEnabled(ogre2RenderPass->IsEnabled());
+      updateConnection = true;
     }
   }
 
@@ -544,11 +813,12 @@ void Ogre2WideAngleCamera::UpdateRenderPasses()
 
   for (uint32_t faceIdx = 0u; faceIdx < kWideAngleNumCubemapFaces; ++faceIdx)
   {
-    const std::string wsDefName = WorkspaceDefinitionName(faceIdx);
+    const std::string wsDefName = this->WorkspaceDefinitionName(faceIdx);
     CompositorWorkspaceDef *workDef =
       ogreCompMgr->getWorkspaceDefinitionNoThrow(wsDefName);
 
     workDef->clearAllInterNodeConnections();
+    workDef->clearOutputConnections();
 
     workDef->connectExternal(0, cubemapPassNodeName, 0);
     workDef->connectExternal(1, cubemapPassNodeName, 1);
@@ -556,6 +826,10 @@ void Ogre2WideAngleCamera::UpdateRenderPasses()
     IdString prevNode = cubemapPassNodeName;
     for (RenderPassPtr &pass : this->dataPtr->renderPasses)
     {
+      GZ_ASSERT(!pass->WideAngleCameraAfterStitching(),
+                "Cannot change the setting of WideAngleCameraAfterStitching "
+                "after adding it to Camera");
+
       Ogre2RenderPass *ogre2RenderPass =
         dynamic_cast<Ogre2RenderPass *>(pass.get());
 
@@ -574,8 +848,48 @@ void Ogre2WideAngleCamera::UpdateRenderPasses()
     workDef->connectExternal(2, copyPass, 2);
   }
 
+  {
+    const std::string wsDefName = this->WorkspaceFinalPassDefinitionName();
+    CompositorWorkspaceDef *workDef =
+      ogreCompMgr->getWorkspaceDefinitionNoThrow(wsDefName);
+
+    workDef->clearAllInterNodeConnections();
+    workDef->clearOutputConnections();
+
+    const IdString stitchPassNodeName = "WideAngleCameraFinalPass";
+
+    const uint32_t tempStitchTextureChannel = this->TempStitchTextureChannel();
+
+    workDef->connectExternal(0, stitchPassNodeName, tempStitchTextureChannel);
+    workDef->connectExternal(1, stitchPassNodeName, !tempStitchTextureChannel);
+    workDef->connectExternal(2, stitchPassNodeName, 2);
+
+    IdString prevNode = stitchPassNodeName;
+    for (RenderPassPtr &pass : this->dataPtr->finalStitchRenderPasses)
+    {
+      GZ_ASSERT(pass->WideAngleCameraAfterStitching(),
+                "Cannot change the setting of WideAngleCameraAfterStitching "
+                "after adding it to Camera");
+
+      Ogre2RenderPass *ogre2RenderPass =
+        dynamic_cast<Ogre2RenderPass *>(pass.get());
+
+      if (ogre2RenderPass->IsEnabled())
+      {
+        ogre2RenderPass->CreateRenderPass();
+        IdString currNode = ogre2RenderPass->OgreCompositorNodeDefinitionName();
+        workDef->connect(prevNode, currNode);
+        prevNode = currNode;
+      }
+    }
+  }
+
   for (size_t i = 0u; i < kWideAngleNumCubemapFaces; ++i)
+  {
     this->dataPtr->ogreCompositorWorkspace[i]->reconnectAllNodes();
+  }
+
+  this->dataPtr->ogreCompositorFinalPass->reconnectAllNodes();
 }
 
 //////////////////////////////////////////////////
@@ -592,23 +906,28 @@ void Ogre2WideAngleCamera::CreateWideAngleTexture()
   Ogre::TextureGpuManager *textureMgr =
     ogreRoot->getRenderSystem()->getTextureGpuManager();
 
-  GZ_ASSERT(!this->dataPtr->ogreRenderTexture, "Should be nullptr");
+  for (uint32_t i = this->NeedsTempStitchTexture() ? 0u : 1u;
+       i < kNumStichTextures; ++i)
+  {
+    GZ_ASSERT(!this->dataPtr->ogreStitchTexture[i], "Should be nullptr");
 
-  this->dataPtr->ogreRenderTexture =
-    textureMgr->createTexture(this->Name() + "_wideAngleCamera",    //
-                              Ogre::GpuPageOutStrategy::Discard,    //
-                              Ogre::TextureFlags::RenderToTexture,  //
-                              Ogre::TextureTypes::Type2D,           //
-                              Ogre::BLANKSTRING,                    //
-                              0u);
+    this->dataPtr->ogreStitchTexture[i] = textureMgr->createTexture(
+      this->Name() + "_wideAngleCameraStitchTex" + std::to_string(i),  //
+      Ogre::GpuPageOutStrategy::Discard,                               //
+      Ogre::TextureFlags::RenderToTexture,                             //
+      Ogre::TextureTypes::Type2D,                                      //
+      Ogre::BLANKSTRING,                                               //
+      0u);
 
-  this->dataPtr->ogreRenderTexture->setResolution(this->ImageWidth(),
-                                                  this->ImageHeight());
-  this->dataPtr->ogreRenderTexture->setPixelFormat(Ogre::PFG_RGBA8_UNORM_SRGB);
-  this->dataPtr->ogreRenderTexture->_setDepthBufferDefaults(
-    Ogre::DepthBuffer::POOL_NO_DEPTH, false, Ogre::PFG_UNKNOWN);
-  this->dataPtr->ogreRenderTexture->scheduleTransitionTo(
-    Ogre::GpuResidency::Resident);
+    this->dataPtr->ogreStitchTexture[i]->setResolution(this->ImageWidth(),
+                                                       this->ImageHeight());
+    this->dataPtr->ogreStitchTexture[i]->setPixelFormat(
+      Ogre::PFG_RGBA8_UNORM_SRGB);
+    this->dataPtr->ogreStitchTexture[i]->_setDepthBufferDefaults(
+      Ogre::DepthBuffer::POOL_NO_DEPTH, false, Ogre::PFG_UNKNOWN);
+    this->dataPtr->ogreStitchTexture[i]->scheduleTransitionTo(
+      Ogre::GpuResidency::Resident);
+  }
 
   this->dataPtr->envCubeMapTexture =
     textureMgr->createTexture(this->Name() + "_cube_wideAngleCamera",  //
@@ -644,7 +963,6 @@ void Ogre2WideAngleCamera::CreateWideAngleTexture()
 
   // Create compositor workspace
   Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
-  Ogre::SceneManager *ogreSceneManager = this->scene->OgreSceneManager();
 
   const uint8_t msaa =
     Ogre2RenderTarget::TargetFSAA(static_cast<uint8_t>(this->antiAliasing));
@@ -655,16 +973,7 @@ void Ogre2WideAngleCamera::CreateWideAngleTexture()
   }
 
   this->CreateFacesWorkspaces(msaa > 1u);
-
-  const Ogre::CompositorChannelVec channelsFinalPass = {
-    this->dataPtr->envCubeMapTexture, this->dataPtr->ogreRenderTexture
-  };
-
-  this->dataPtr->ogreCompositorFinalPass = ogreCompMgr->addWorkspace(
-    ogreSceneManager, channelsFinalPass, this->dataPtr->ogreCamera,
-    "WideAngleCameraFinalPass", false);
-  this->dataPtr->ogreCompositorFinalPass->addListener(
-    &this->dataPtr->workspaceListener);
+  this->CreateStitchWorkspace();
 }
 
 //////////////////////////////////////////////////
@@ -730,7 +1039,8 @@ void Ogre2WideAngleCamera::Copy(Image &_image) const
   }
 
   Ogre::PixelFormatGpu dstOgrePf = Ogre2Conversions::Convert(_image.Format());
-  Ogre::TextureGpu *texture = this->dataPtr->ogreRenderTexture;
+  Ogre::TextureGpu *texture =
+    this->dataPtr->ogreStitchTexture[kStichFinalTexture];
 
   if (Ogre::PixelFormatGpuUtils::isSRgb(dstOgrePf) !=
       Ogre::PixelFormatGpuUtils::isSRgb(texture->getPixelFormat()))
@@ -848,8 +1158,10 @@ math::Vector3d Ogre2WideAngleCamera::Project3d(const math::Vector3d &_pt) const
       double x = cos(phi) * r;
       double y = sin(phi) * r;
 
-      const uint32_t vpWidth = this->dataPtr->ogreRenderTexture->getWidth();
-      const uint32_t vpHeight = this->dataPtr->ogreRenderTexture->getHeight();
+      const uint32_t vpWidth =
+        this->dataPtr->ogreStitchTexture[kStichFinalTexture]->getWidth();
+      const uint32_t vpHeight =
+        this->dataPtr->ogreStitchTexture[kStichFinalTexture]->getHeight();
       // env cam cube map texture is square and likely to be different size from
       // viewport. We need to adjust projected pos based on aspect ratio
       double asp = static_cast<double>(vpWidth) / static_cast<double>(vpHeight);
@@ -897,6 +1209,15 @@ Ogre::Ray Ogre2WideAngleCamera::CameraToViewportRay(
 //////////////////////////////////////////////////
 void Ogre2WideAngleCamera::PostRender()
 {
+  for (RenderPassPtr &pass : this->dataPtr->renderPasses)
+  {
+    pass->PostRender();
+  }
+  for (RenderPassPtr &pass : this->dataPtr->finalStitchRenderPasses)
+  {
+    pass->PostRender();
+  }
+
   if (this->dataPtr->newImageFrame.ConnectionCount() <= 0u)
     return;
 
@@ -905,7 +1226,8 @@ void Ogre2WideAngleCamera::PostRender()
 
   // blit data from gpu to cpu
   Ogre::Image2 image;
-  image.convertFromTexture(this->dataPtr->ogreRenderTexture, 0u, 0u);
+  image.convertFromTexture(this->dataPtr->ogreStitchTexture[kStichFinalTexture],
+                           0u, 0u);
   Ogre::TextureBox box = image.getData(0u);
 
   // Convert in-place from RGBA32 to RGB24 reusing the same memory region.

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -271,6 +271,14 @@ void Ogre2WideAngleCamera::RemoveRenderPass(const RenderPassPtr &_pass)
 }
 
 //////////////////////////////////////////////////
+void Ogre2WideAngleCamera::RemoveAllRenderPasses()
+{
+  BaseWideAngleCamera::RemoveAllRenderPasses();
+  this->dataPtr->renderPasses.clear();
+  this->DestroyFacesWorkspaces();
+}
+
+//////////////////////////////////////////////////
 uint32_t Ogre2WideAngleCamera::EnvTextureSize() const
 {
   return this->dataPtr->envTextureSize;

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -226,6 +226,8 @@ void Ogre2WideAngleCamera::PreRender()
 //////////////////////////////////////////////////
 void Ogre2WideAngleCamera::Destroy()
 {
+  this->RemoveAllRenderPasses();
+
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
   Ogre::TextureGpuManager *textureMgr =

--- a/ogre2/src/media/materials/scripts/wide_angle_camera.compositor
+++ b/ogre2/src/media/materials/scripts/wide_angle_camera.compositor
@@ -125,8 +125,9 @@ compositor_node WideAngleCameraCubemapCopyNZ
 // Remaps the cubemap (final output) into a 2D fish-eye output
 compositor_node WideAngleCameraFinalPass
 {
-  in 0 cubeTexture
+  in 0 rt_unused
   in 1 finalOutput
+  in 2 cubeTexture
 
   target finalOutput
   {
@@ -152,6 +153,9 @@ compositor_node WideAngleCameraFinalPass
       input 0 cubeTexture
     }
   }
+
+  out 0 finalOutput   // Inverted on purpose
+  out 1 rt_unused     // Inverted on purpose
 }
 
 /*
@@ -168,8 +172,11 @@ workspace WideAngleCamera/NAME/PX
 }
 */
 
+/*
+This is generated in C++
 workspace WideAngleCameraFinalPass
 {
   connect_external 0 WideAngleCameraFinalPass 0
   connect_external 1 WideAngleCameraFinalPass 1
 }
+*/

--- a/src/LensFlarePass.cc
+++ b/src/LensFlarePass.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#include "gz/rendering/LensFlarePass.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+LensFlarePass::LensFlarePass() = default;
+
+//////////////////////////////////////////////////
+LensFlarePass::~LensFlarePass() = default;

--- a/test/common_test/GaussianNoisePass_TEST.cc
+++ b/test/common_test/GaussianNoisePass_TEST.cc
@@ -46,6 +46,7 @@ TEST_F(GaussianNoisePassTest, GaussianNoise)
   EXPECT_DOUBLE_EQ(0u, noisePass->Mean());
   EXPECT_DOUBLE_EQ(0u, noisePass->StdDev());
   EXPECT_DOUBLE_EQ(0u, noisePass->Bias());
+  EXPECT_EQ(false, noisePass->WideAngleCameraAfterStitching());
 
   // mean
   double mean = 0.23;
@@ -69,4 +70,9 @@ TEST_F(GaussianNoisePassTest, GaussianNoise)
   // Note, tol relaxed to 4-sigma to fix flaky test
   EXPECT_LE(std::fabs(noisePass->Bias()), biasMean + biasStdDev*4);
   EXPECT_GE(std::fabs(noisePass->Bias()), biasMean - biasStdDev*4);
+
+  noisePass->SetWideAngleCameraAfterStitching(false);
+  EXPECT_EQ(false, noisePass->WideAngleCameraAfterStitching());
+  noisePass->SetWideAngleCameraAfterStitching(true);
+  EXPECT_EQ(true, noisePass->WideAngleCameraAfterStitching());
 }

--- a/test/common_test/LensFlarePass_TEST.cc
+++ b/test/common_test/LensFlarePass_TEST.cc
@@ -47,6 +47,7 @@ TEST_F(LensFlarePassTest, LensFlare)
   EXPECT_DOUBLE_EQ(1.0, lensFlarePass->Scale());
   EXPECT_EQ(10u, lensFlarePass->OcclusionSteps());
   EXPECT_EQ(math::Vector3d(1.0, 1.0, 1.0), lensFlarePass->Color());
+  EXPECT_EQ(true, lensFlarePass->WideAngleCameraAfterStitching());
 
   // scale
   const double scale = 0.23;
@@ -62,4 +63,9 @@ TEST_F(LensFlarePassTest, LensFlare)
   const math::Vector3d color = math::Vector3d(0.7, 0.4, 0.12);
   lensFlarePass->SetColor(color);
   EXPECT_EQ(color, lensFlarePass->Color());
+
+  lensFlarePass->SetWideAngleCameraAfterStitching(false);
+  EXPECT_EQ(false, lensFlarePass->WideAngleCameraAfterStitching());
+  lensFlarePass->SetWideAngleCameraAfterStitching(true);
+  EXPECT_EQ(true, lensFlarePass->WideAngleCameraAfterStitching());
 }

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -776,14 +776,32 @@ static void TestLensFlare(gz::rendering::RenderEngine *_engine,
 
     // If a significant number of pixels between Partial & No occlusion are
     // incomparable, then this test is meaningless and needs tweaking.
+    //
+    // The threshold value is arbitrary and chosen empirically
+    // If this value is exceded consider just raising it.
     if (!_wideAngleCamera)
     {
-      EXPECT_LE(uncomparablePixelCount, 5);
+      EXPECT_LE(uncomparablePixelCount, 1);
     }
     else
     {
-      EXPECT_LE(uncomparablePixelCount, 40);
+      if (_engine->Name() == "ogre")
+      {
+        EXPECT_LE(uncomparablePixelCount, 51);
+      }
+      else
+      {
+        EXPECT_LE(uncomparablePixelCount, 40);
+      }
     }
+
+    // Same test as before, but this time as a percentage of total pixels.
+    //
+    // While the threshold is again arbitrary; if this value is exceded,
+    // rather than raising the threshold, we should consider the test
+    // flawed and change it (i.e. the reference is too bright)
+    EXPECT_LE(uncomparablePixelCount,
+              (camera->ImageWidth() * camera->ImageHeight() * 1u) / 100u);
   }
 
   //
@@ -845,7 +863,7 @@ static void TestLensFlare(gz::rendering::RenderEngine *_engine,
 /////////////////////////////////////////////////
 TEST_F(RenderPassTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LensFlarePass))
 {
-  CHECK_SUPPORTED_ENGINE("ogre2");
+  CHECK_UNSUPPORTED_ENGINE("optix");
   CHECK_RENDERPASS_SUPPORTED();
 
   TestLensFlare(this->engine, false);
@@ -854,7 +872,7 @@ TEST_F(RenderPassTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LensFlarePass))
 /////////////////////////////////////////////////
 TEST_F(RenderPassTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LensFlareWideAnglePass))
 {
-  CHECK_SUPPORTED_ENGINE("ogre2");
+  CHECK_UNSUPPORTED_ENGINE("optix");
   CHECK_RENDERPASS_SUPPORTED();
 
   TestLensFlare(this->engine, true);

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -781,7 +781,7 @@ static void TestLensFlare(gz::rendering::RenderEngine *_engine,
     // If this value is exceded consider just raising it.
     if (!_wideAngleCamera)
     {
-      EXPECT_LE(uncomparablePixelCount, 1);
+      EXPECT_LE(uncomparablePixelCount, 2);
     }
     else
     {

--- a/test/integration/render_pass.cc
+++ b/test/integration/render_pass.cc
@@ -781,7 +781,7 @@ static void TestLensFlare(gz::rendering::RenderEngine *_engine,
     // If this value is exceded consider just raising it.
     if (!_wideAngleCamera)
     {
-      EXPECT_LE(uncomparablePixelCount, 2);
+      EXPECT_LE(uncomparablePixelCount, 5);
     }
     else
     {


### PR DESCRIPTION
# 🎉 New feature

Closes #730

## Summary

Previous PR #752 added LensFlarePass to ogre2.
This PR adds LensFlarePass to ogre1.

This includes LensFlarePass support for ogre1's WideAngleCamera.
WideAngleCamera had to be modified a little to support RenderPass at all.

In theory the gaussian filter pass should also work with WideAngleCamera but I did not test it.

It also implements OgreWideAngleCamera::Copy so that integration tests can function (Ogre2WideAngleCamera::Copy had already been implemented).

OgreRayQuery also had to be modified to support OgreWideAngleCamera; since LensFlares need ray queries for occlusion support.

Additionally I add `RemoveAllRenderPasses` since I noticed a lot of RenderPasses didn't get to properly deinitialize. Though it didn't seem like much harm was being done because currently all RenderPasses are very simple.

**IMPORTANT:** LensFlare occlusion in ogre1 is ridiculously slow on my HW. It may be due to a known OpenGL driver bug for my GPU (downloading vertex data from GPU back to CPU in Radeon RX 6800 XT), or it may be slow for everyone.

Frankly I didn't bother profiling too much: For offline simulations I suppose it's good enough; if this is a problem one can either use ogre2, or use ogre1 and temporarily disable occlusion (call `SetOcclusionSteps` to 0) while working in realtime with it.

If you need that fixed we can open a new ticket and I'll take a deeper look.

## Test it

See PR #752

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
