### PR TITLE
Fix RenderTarget::destroy not getting called in both ogre1 & ogre2

### DIFF
--- a/ogre/include/ignition/rendering/ogre/OgreCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreCamera.hh
@@ -137,6 +137,10 @@ namespace ignition
 
       protected: virtual void CreateRenderTexture();
 
+      /// \brief Destroy render texture created by CreateRenderTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyRenderTexture();
+
       protected: Ogre::Camera *ogreCamera = nullptr;
 
       protected: OgreSelectionBuffer *selectionBuffer = nullptr;

--- a/ogre/include/ignition/rendering/ogre/OgreDepthCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreDepthCamera.hh
@@ -77,6 +77,10 @@ namespace ignition
       /// \brief Create a texture which will hold the depth data
       public: virtual void CreateDepthTexture() override;
 
+      /// \brief Destroy render texture created by CreateDepthTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyDepthTexture();
+
       /// \brief Render the camera
       public: virtual void PostRender() override;
 
@@ -148,6 +152,10 @@ namespace ignition
 
       /// \brief Create point cloud texture. This stores xyz rgb data
       private: void CreatePointCloudTexture();
+
+      /// \brief Destroy render texture created by CreatePointCloudTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyPointCloudTexture();
 
       /// \brief Communicates that a frams was rendered
       protected: bool newData = false;

--- a/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
+++ b/ogre/include/ignition/rendering/ogre/OgreThermalCamera.hh
@@ -75,6 +75,10 @@ namespace ignition
       /// \brief Create a texture
       public: virtual void CreateRenderTexture();
 
+      /// \brief Destroy render texture created by CreateRenderTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyRenderTexture();
+
       /// \brief Render the camera
       public: virtual void PostRender() override;
 

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -50,6 +50,8 @@ void OgreCamera::Destroy()
   if (!this->ogreCamera)
     return;
 
+  this->DestroyRenderTexture();
+
   Ogre::SceneManager *ogreSceneManager;
   ogreSceneManager = this->scene->OgreSceneManager();
   if (ogreSceneManager == nullptr)
@@ -183,6 +185,7 @@ void OgreCamera::CreateCamera()
 //////////////////////////////////////////////////
 void OgreCamera::CreateRenderTexture()
 {
+  this->DestroyRenderTexture();
   RenderTexturePtr base = this->scene->CreateRenderTexture();
   this->renderTexture = std::dynamic_pointer_cast<OgreRenderTexture>(base);
   this->renderTexture->SetCamera(this->ogreCamera);
@@ -190,6 +193,16 @@ void OgreCamera::CreateRenderTexture()
   this->renderTexture->SetWidth(this->ImageWidth());
   this->renderTexture->SetHeight(this->ImageHeight());
   this->renderTexture->SetBackgroundColor(this->scene->BackgroundColor());
+}
+
+//////////////////////////////////////////////////
+void OgreCamera::DestroyRenderTexture()
+{
+  if (this->renderTexture)
+  {
+    dynamic_cast<OgreRenderTarget *>(this->renderTexture.get())->Destroy();
+    this->renderTexture.reset();
+  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -113,6 +113,9 @@ void OgreDepthCamera::Destroy()
   if (!this->ogreCamera || !this->scene->IsInitialized())
     return;
 
+  this->DestroyPointCloudTexture();
+  this->DestroyDepthTexture();
+
   Ogre::SceneManager *ogreSceneManager;
   ogreSceneManager = this->scene->OgreSceneManager();
   if (ogreSceneManager == nullptr)
@@ -223,6 +226,24 @@ void OgreDepthCamera::CreatePointCloudTexture()
   this->dataPtr->pcdTexture->PreRender();
 }
 
+//////////////////////////////////////////////////
+void OgreDepthCamera::DestroyPointCloudTexture()
+{
+  if (this->dataPtr->pcdTexture)
+  {
+    dynamic_cast<OgreRenderTexture *>(this->dataPtr->pcdTexture.get())
+      ->Destroy();
+    this->dataPtr->pcdTexture.reset();
+  }
+
+  if (this->dataPtr->colorTexture)
+  {
+    dynamic_cast<OgreRenderTexture *>(this->dataPtr->colorTexture.get())
+      ->Destroy();
+    this->dataPtr->colorTexture.reset();
+  }
+}
+
 /////////////////////////////////////////////////
 void OgreDepthCamera::CreateDepthTexture()
 {
@@ -251,6 +272,16 @@ void OgreDepthCamera::CreateDepthTexture()
   double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / ratio);
   this->ogreCamera->setAspectRatio(ratio);
   this->ogreCamera->setFOVy(Ogre::Radian(this->LimitFOV(vfov)));
+}
+
+//////////////////////////////////////////////////
+void OgreDepthCamera::DestroyDepthTexture()
+{
+  if (this->depthTexture)
+  {
+    dynamic_cast<OgreRenderTexture *>(this->depthTexture.get())->Destroy();
+    this->depthTexture.reset();
+  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -61,10 +61,8 @@ OgreRenderTarget::OgreRenderTarget()
 //////////////////////////////////////////////////
 OgreRenderTarget::~OgreRenderTarget()
 {
-  // TODO(anyone): clean up check null
-
-  OgreRTShaderSystem::Instance()->DetachViewport(this->ogreViewport,
-      this->scene);
+  IGN_ASSERT(this->ogreViewport == nullptr,
+             "OgreRenderTarget::Destroy not called!");
 }
 
 //////////////////////////////////////////////////
@@ -309,6 +307,8 @@ OgreRenderTexture::OgreRenderTexture()
 //////////////////////////////////////////////////
 OgreRenderTexture::~OgreRenderTexture()
 {
+  IGN_ASSERT(this->ogreTexture == nullptr,
+             "OgreRenderTexture::Destroy not called!");
 }
 
 //////////////////////////////////////////////////
@@ -339,6 +339,8 @@ void OgreRenderTexture::DestroyTarget()
   if (nullptr == this->ogreTexture)
     return;
 
+  this->materialApplicator.reset();
+
   OgreRTShaderSystem::Instance()->DetachViewport(this->ogreViewport,
       this->scene);
 
@@ -352,6 +354,7 @@ void OgreRenderTexture::DestroyTarget()
   engine->OgreRoot()->getRenderSystem()->_cleanupDepthBuffers(false);
 
   this->ogreTexture = nullptr;
+  this->ogreViewport = nullptr;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
+++ b/ogre2/include/ignition/rendering/ogre2/Ogre2Camera.hh
@@ -141,6 +141,10 @@ namespace ignition
       /// \brief Create a render texture for the camera for offscreen rendering
       protected: virtual void CreateRenderTexture();
 
+      /// \brief Destroy render texture created by CreateRenderTexture()
+      /// Note: It's not virtual.
+      protected: void DestroyRenderTexture();
+
       /// \brief Create and set selection buffer object
       /// TODO(anyone) to be implemented
       protected: virtual void SetSelectionBuffer();

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -58,6 +58,8 @@ void Ogre2Camera::Destroy()
   if (!this->ogreCamera || !this->Scene()->IsInitialized())
     return;
 
+  this->DestroyRenderTexture();
+
   Ogre::SceneManager *ogreSceneManager;
   ogreSceneManager = this->scene->OgreSceneManager();
   if (ogreSceneManager == nullptr)
@@ -190,6 +192,7 @@ void Ogre2Camera::CreateCamera()
 //////////////////////////////////////////////////
 void Ogre2Camera::CreateRenderTexture()
 {
+  this->DestroyRenderTexture();
   RenderTexturePtr base = this->scene->CreateRenderTexture();
   this->renderTexture = std::dynamic_pointer_cast<Ogre2RenderTexture>(base);
   this->renderTexture->SetCamera(this->ogreCamera);
@@ -200,6 +203,16 @@ void Ogre2Camera::CreateRenderTexture()
   this->renderTexture->SetVisibilityMask(this->visibilityMask);
 }
 
+
+//////////////////////////////////////////////////
+void Ogre2Camera::DestroyRenderTexture()
+{
+  if (this->renderTexture)
+  {
+    dynamic_cast<Ogre2RenderTarget *>(this->renderTexture.get())->Destroy();
+    this->renderTexture.reset();
+  }
+}
 //////////////////////////////////////////////////
 unsigned int Ogre2Camera::RenderTextureGLId() const
 {

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -117,11 +117,11 @@ Ogre2RenderTarget::Ogre2RenderTarget()
 //////////////////////////////////////////////////
 Ogre2RenderTarget::~Ogre2RenderTarget()
 {
-  if (this->dataPtr->rtListener)
-  {
-    delete this->dataPtr->rtListener;
-    this->dataPtr->rtListener = nullptr;
-  }
+  IGN_ASSERT(this->dataPtr->rtListener == nullptr &&
+               this->dataPtr->ogreTexture[0] == nullptr &&
+               this->dataPtr->ogreTexture[1] == nullptr &&
+               this->ogreCompositorWorkspace == nullptr,
+             "Ogre2RenderTarget::Destroy not called!");
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

No ticket was filed for this bug.

## Summary

During PR #775 I discovered this bug.

That PR will fix that bug in main, this is a backport for Fortress.

A tiny difference is that in `main` changes were done so that RenderPasses are destroyed cleanly, while in Fortress' backport I can't do that without breaking the ABI.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
