### PR TITLE
Wrong error log message

### DIFF
--- a/src/base/BaseRenderEngine.cc
+++ b/src/base/BaseRenderEngine.cc
@@ -224,7 +224,7 @@ ScenePtr BaseRenderEngine::CreateScene(unsigned int _id,
 
   if (this->HasSceneName(_name))
   {
-    ignerr << "Scene already exists with id: " << _id << std::endl;
+    ignerr << "Scene already exists with name: " << _name << std::endl;
     return nullptr;
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

No ticket submitted for this bug.

## Summary

A very silly Copy/Paste mistake: when a duplicate scene name is found, the error log will complain it has the same ID; instead of saying it has the same name.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
