### PR TITLE
Look for vulkan in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,16 @@ if (OpenGL_FOUND)
 endif()
 
 #--------------------------------------
+# Find Vulkan
+# ogre2 needs vulkan headers, e.g. vulkan/vulkan_core.h
+if (NOT APPLE)
+  gz_find_package(Vulkan
+    REQUIRED_BY ogre2
+    PRIVATE_FOR ogre2
+    PKGCONFIG vulkan)
+endif()
+
+#--------------------------------------
 # Find OGRE
 list(APPEND gz_ogre_components "RTShaderSystem" "Terrain" "Overlay" "Paging")
 


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

Make sure vulkan exists before building ogre2. This is needed by Jammy after https://github.com/gazebosim/gz-rendering/pull/706 introduced the `vulkan/vulkan_core.h` include header. Otherwise [build fails](https://build.osrfoundation.org/view/ign-harmonic/job/gz-rendering8-debbuilder/2/). 

We should only just need the vulkan headers and not the whole library. Alternative solution is to manually search for `vulkan_core.h` using `FIND_PATH` in cmake. I went with `gz_find_package` for simplicity as the headers are installed with the library when you do `apt install libvulkan-dev`

Note that the `libvulkan-dev` dependency has already been added to [packages-jammy.apt](https://github.com/gazebosim/gz-rendering/blob/main/.github/ci/packages-jammy.apt) and our Jammy CI script. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

