### PR TITLE
 Do not overwrite reserved visibility flags in ogre2 (Garden)

### DIFF
--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -390,6 +390,12 @@ void Ogre2Camera::SetFarClipPlane(const double _far)
 //////////////////////////////////////////////////
 void Ogre2Camera::SetVisibilityMask(uint32_t _mask)
 {
+  if (_mask & ~Ogre::VisibilityFlags::RESERVED_VISIBILITY_FLAGS)
+  {
+    gzerr << "Ogre2Camera::SetVisibilityMask: Mask bits " << std::hex
+          << ~Ogre::VisibilityFlags::RESERVED_VISIBILITY_FLAGS << std::dec
+          << " are set but will be ignored by ogre2 backend." << std::endl;
+  }
   BaseSensor::SetVisibilityMask(_mask);
   if (this->renderTexture)
     this->renderTexture->SetVisibilityMask(_mask);

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -711,7 +711,7 @@ void Ogre2DepthCamera::CreateDepthTexture()
             static_cast<Ogre::CompositorPassSceneDef *>(
             colorTargetDef->addPass(Ogre::PASS_SCENE));
         passScene->mShadowNode = this->dataPtr->kShadowNodeName;
-        passScene->mVisibilityMask = GZ_VISIBILITY_ALL;
+        passScene->setVisibilityMask(GZ_VISIBILITY_ALL);
         passScene->mIncludeOverlays = false;
         passScene->mFirstRQ = 0u;
         passScene->mLastRQ = 2u;
@@ -748,7 +748,8 @@ void Ogre2DepthCamera::CreateDepthTexture()
         Ogre::CompositorPassSceneDef *passScene =
             static_cast<Ogre::CompositorPassSceneDef *>(
             colorTargetDef->addPass(Ogre::PASS_SCENE));
-        passScene->mVisibilityMask = GZ_VISIBILITY_ALL;
+        passScene->setVisibilityMask(
+          GZ_VISIBILITY_ALL & Ogre::VisibilityFlags::RESERVED_VISIBILITY_FLAGS);
         // todo(anyone) PbsMaterialsShadowNode is hardcoded.
         // Although this may be just fine
         passScene->mShadowNode = this->dataPtr->kShadowNodeName;
@@ -770,8 +771,8 @@ void Ogre2DepthCamera::CreateDepthTexture()
         this->FarClipPlane(),
         this->FarClipPlane()));
       // depth texute does not contain particles
-      passScene->mVisibilityMask = GZ_VISIBILITY_ALL
-          & ~Ogre2ParticleEmitter::kParticleVisibilityFlags;
+      passScene->setVisibilityMask(
+        GZ_VISIBILITY_ALL & ~Ogre2ParticleEmitter::kParticleVisibilityFlags);
     }
 
     Ogre::CompositorTargetDef *particleTargetDef =
@@ -784,8 +785,8 @@ void Ogre2DepthCamera::CreateDepthTexture()
           particleTargetDef->addPass(Ogre::PASS_SCENE));
       passScene->setAllLoadActions(Ogre::LoadAction::Clear);
       passScene->setAllClearColours(Ogre::ColourValue::Black);
-      passScene->mVisibilityMask =
-          Ogre2ParticleEmitter::kParticleVisibilityFlags;
+      passScene->setVisibilityMask(
+        Ogre2ParticleEmitter::kParticleVisibilityFlags);
     }
 
     // rt0 target - converts depth to xyz

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -748,8 +748,7 @@ void Ogre2DepthCamera::CreateDepthTexture()
         Ogre::CompositorPassSceneDef *passScene =
             static_cast<Ogre::CompositorPassSceneDef *>(
             colorTargetDef->addPass(Ogre::PASS_SCENE));
-        passScene->setVisibilityMask(
-          GZ_VISIBILITY_ALL & Ogre::VisibilityFlags::RESERVED_VISIBILITY_FLAGS);
+        passScene->setVisibilityMask(GZ_VISIBILITY_ALL);
         // todo(anyone) PbsMaterialsShadowNode is hardcoded.
         // Although this may be just fine
         passScene->mShadowNode = this->dataPtr->kShadowNodeName;

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1196,12 +1196,8 @@ void Ogre2GpuRays::UpdateRenderTarget1stPass()
   Ogre::vector<Ogre::TextureGpu *>::type swappedTargets;
   swappedTargets.reserve(2u);
 
-  // set visibility mask and '&' it with GZ_VISIBILITY_ALL (0x0FFFFFFF)
-  // to make sure the fist 4 bits are 0 otherwise lidar will not be able
-  // to detect heightmaps
-  this->dataPtr->mainPassSceneDef->mVisibilityMask =
-      (this->VisibilityMask() & GZ_VISIBILITY_ALL)
-      & ~Ogre2ParticleEmitter::kParticleVisibilityFlags;
+  this->dataPtr->mainPassSceneDef->setVisibilityMask(
+    this->VisibilityMask() & ~Ogre2ParticleEmitter::kParticleVisibilityFlags);
 
   // update the compositors
   for (auto i : this->dataPtr->cubeFaceIdx)

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -59,8 +59,8 @@ class Ogre2RenderTargetCompositorListener :
       Ogre::Viewport *vp = scenePass->getCamera()->getLastViewport();
       if (vp == nullptr) return;
       // make sure we do not alter the reserved visibility flags
-      uint32_t f = this->ogreRenderTarget->VisibilityMask() |
-          ~Ogre::VisibilityFlags::RESERVED_VISIBILITY_FLAGS;
+      uint32_t f = this->ogreRenderTarget->VisibilityMask() &
+                   Ogre::VisibilityFlags::RESERVED_VISIBILITY_FLAGS;
       // apply the new visibility mask
       uint32_t flags = f & vp->getVisibilityMask();
       vp->_setVisibilityMask(flags, vp->getLightVisibilityMask());

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -348,7 +348,7 @@ void Ogre2SelectionBuffer::CreateRTTBuffer()
         colorTargetDef->addPass(Ogre::PASS_SCENE));
     passScene->setAllLoadActions(Ogre::LoadAction::Clear);
     passScene->setAllClearColours(Ogre::ColourValue::Black);
-    passScene->mVisibilityMask = GZ_VISIBILITY_SELECTABLE;
+    passScene->setVisibilityMask(GZ_VISIBILITY_SELECTABLE);
   }
 
   Ogre::CompositorTargetDef *targetDef = nodeDef->addTargetPass("rt");

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -1009,8 +1009,8 @@ void Ogre2ThermalCamera::CreateThermalTexture()
       passScene->setAllLoadActions(Ogre::LoadAction::Clear);
       passScene->setAllClearColours(Ogre::ColourValue(0, 0, 0));
       // thermal camera should not see particles
-      passScene->mVisibilityMask = GZ_VISIBILITY_ALL &
-          ~Ogre2ParticleEmitter::kParticleVisibilityFlags;
+      passScene->setVisibilityMask(
+        GZ_VISIBILITY_ALL & ~Ogre2ParticleEmitter::kParticleVisibilityFlags);
     }
 
     // rt_input target - converts to thermal


### PR DESCRIPTION
# 🦟 Bug fix

No particular ticket issued for this bug.

## Summary

This is the same as PR #783 but targeting Garden, which needs additional changes (Ogre2GpuRays) that could be easily missed when merging Fortress into Garden.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
