### PR TITLE
Fix Metal shader compiler error in GpuRays (Lidar)

### DIFF
--- a/ogre2/src/media/Hlms/Terra/Metal/VertexShader_vs.metal
+++ b/ogre2/src/media/Hlms/Terra/Metal/VertexShader_vs.metal
@@ -17,7 +17,7 @@ struct PS_INPUT
 	@insertpiece( Terra_VStoPS_block )
 	float4 gl_Position [[position]];
 	@foreach( hlms_pso_clip_distances, n )
-		float gl_ClipDistance@n [[clip_distance]];
+		float gl_ClipDistance [[clip_distance]] [@value( hlms_pso_clip_distances )];
 	@end
 };
 


### PR DESCRIPTION
Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

No ticket filed for this bug report.

## Summary

Trying to use the heightmap in GpuRays (Lidar) in macOS / Metal will result in a shader compiler error.

This is a backport from PR #785 which includes this fix alongside the integration test that discovered this bug.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
