### PR TITLE
Fix memory corruption in Ogre2GpuRays (Fortress)

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -407,29 +407,23 @@ void Ogre2GpuRays::Destroy()
 
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
-  if (this->dataPtr->cubeUVTexture)
-  {
-    ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
-      this->dataPtr->cubeUVTexture);
-    this->dataPtr->cubeUVTexture = nullptr;
-  }
 
   Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
 
   // remove 1st pass textures, material, compositors
   for (auto i : this->dataPtr->cubeFaceIdx)
   {
-    if (this->dataPtr->firstPassTextures[i])
-    {
-      ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
-         this->dataPtr->firstPassTextures[i]);
-      this->dataPtr->firstPassTextures[i] = nullptr;
-    }
     if (this->dataPtr->ogreCompositorWorkspace1st[i])
     {
       ogreCompMgr->removeWorkspace(
           this->dataPtr->ogreCompositorWorkspace1st[i]);
       this->dataPtr->ogreCompositorWorkspace1st[i] = nullptr;
+    }
+    if (this->dataPtr->firstPassTextures[i])
+    {
+      ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
+         this->dataPtr->firstPassTextures[i]);
+      this->dataPtr->firstPassTextures[i] = nullptr;
     }
   }
   if (this->dataPtr->matFirstPass)
@@ -471,6 +465,13 @@ void Ogre2GpuRays::Destroy()
     ogreCompMgr->removeNodeDefinition(
         this->dataPtr->ogreCompositorNodeDef2nd);
     this->dataPtr->ogreCompositorWorkspaceDef2nd.clear();
+  }
+
+  auto textureGpuManager = ogreRoot->getRenderSystem()->getTextureGpuManager();
+  if (this->dataPtr->cubeUVTexture)
+  {
+    textureGpuManager->destroyTexture(this->dataPtr->cubeUVTexture);
+    this->dataPtr->cubeUVTexture = nullptr;
   }
 
   if (this->scene)


### PR DESCRIPTION
Order of destruction was inverted

Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# 🦟 Bug fix

No ticket was filed for this bug.

## Summary

This bug was discovered thanks to CI and Valgrind in PR #785

This is a backport to Fortress.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
