### PR TITLE
 Fix memory corruption in Ogre2GpuRays (Garden)

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -602,6 +602,7 @@ void Ogre2GpuRays::Destroy()
 
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
+  auto textureGpuManager = ogreRoot->getRenderSystem()->getTextureGpuManager();
 
   Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
 
@@ -616,8 +617,7 @@ void Ogre2GpuRays::Destroy()
     }
     if (this->dataPtr->firstPassTextures[i])
     {
-      ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
-         this->dataPtr->firstPassTextures[i]);
+      textureGpuManager->destroyTexture(this->dataPtr->firstPassTextures[i]);
       this->dataPtr->firstPassTextures[i] = nullptr;
     }
   }
@@ -625,8 +625,7 @@ void Ogre2GpuRays::Destroy()
   // remove 2nd pass texture, material, compositor
   if (this->dataPtr->secondPassTexture)
   {
-    ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
-       this->dataPtr->secondPassTexture);
+    textureGpuManager->destroyTexture(this->dataPtr->secondPassTexture);
     this->dataPtr->secondPassTexture = nullptr;
   }
 
@@ -636,7 +635,6 @@ void Ogre2GpuRays::Destroy()
     this->dataPtr->ogreCompositorWorkspace2nd = nullptr;
   }
 
-  auto textureGpuManager = ogreRoot->getRenderSystem()->getTextureGpuManager();
   if (this->dataPtr->cubeUVTexture)
   {
     textureGpuManager->destroyTexture(this->dataPtr->cubeUVTexture);

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -602,6 +602,40 @@ void Ogre2GpuRays::Destroy()
 
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
+
+  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
+
+  // remove 1st pass textures, material, compositors
+  for (auto i : this->dataPtr->cubeFaceIdx)
+  {
+    if (this->dataPtr->ogreCompositorWorkspace1st[i])
+    {
+      ogreCompMgr->removeWorkspace(
+          this->dataPtr->ogreCompositorWorkspace1st[i]);
+      this->dataPtr->ogreCompositorWorkspace1st[i] = nullptr;
+    }
+    if (this->dataPtr->firstPassTextures[i])
+    {
+      ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
+         this->dataPtr->firstPassTextures[i]);
+      this->dataPtr->firstPassTextures[i] = nullptr;
+    }
+  }
+
+  // remove 2nd pass texture, material, compositor
+  if (this->dataPtr->secondPassTexture)
+  {
+    ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
+       this->dataPtr->secondPassTexture);
+    this->dataPtr->secondPassTexture = nullptr;
+  }
+
+  if (this->dataPtr->ogreCompositorWorkspace2nd)
+  {
+    ogreCompMgr->removeWorkspace(this->dataPtr->ogreCompositorWorkspace2nd);
+    this->dataPtr->ogreCompositorWorkspace2nd = nullptr;
+  }
+
   auto textureGpuManager = ogreRoot->getRenderSystem()->getTextureGpuManager();
   if (this->dataPtr->cubeUVTexture)
   {
@@ -627,39 +661,6 @@ void Ogre2GpuRays::Destroy()
   {
     textureGpuManager->destroyTexture(this->dataPtr->particleDepthTexture);
     this->dataPtr->particleDepthTexture = nullptr;
-  }
-
-  Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
-
-  // remove 1st pass textures, material, compositors
-  for (auto i : this->dataPtr->cubeFaceIdx)
-  {
-    if (this->dataPtr->firstPassTextures[i])
-    {
-      ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
-         this->dataPtr->firstPassTextures[i]);
-      this->dataPtr->firstPassTextures[i] = nullptr;
-    }
-    if (this->dataPtr->ogreCompositorWorkspace1st[i])
-    {
-      ogreCompMgr->removeWorkspace(
-          this->dataPtr->ogreCompositorWorkspace1st[i]);
-      this->dataPtr->ogreCompositorWorkspace1st[i] = nullptr;
-    }
-  }
-
-  // remove 2nd pass texture, material, compositor
-  if (this->dataPtr->secondPassTexture)
-  {
-    ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
-       this->dataPtr->secondPassTexture);
-    this->dataPtr->secondPassTexture = nullptr;
-  }
-
-  if (this->dataPtr->ogreCompositorWorkspace2nd)
-  {
-    ogreCompMgr->removeWorkspace(this->dataPtr->ogreCompositorWorkspace2nd);
-    this->dataPtr->ogreCompositorWorkspace2nd = nullptr;
   }
 
   if (this->scene)


### PR DESCRIPTION
# 🦟 Bug fix

No ticket was filed for this bug.

## Summary

Same as PR #787 

Garden flavour.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
