### PR TITLE
Cleanup config.hh.in and deprecate public HAVE_ macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (OGRE_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
   endif()
 
-  set(HAVE_OGRE TRUE)
+  set(GZ_RENDERING_HAVE_OGRE TRUE)
 endif()
 
 #--------------------------------------
@@ -119,7 +119,7 @@ if ("${OGRE2-PlanarReflections}" STREQUAL "OGRE2-PlanarReflections-NOTFOUND")
 endif()
 
 if (OGRE2_FOUND)
-  set(HAVE_OGRE2 TRUE)
+  set(GZ_RENDERING_HAVE_OGRE2 TRUE)
 endif()
 
 #--------------------------------------
@@ -142,7 +142,7 @@ if (UNIX AND NOT APPLE)
       gz_build_warning("Skipping component [ogre2]: Missing vulkan headers.\n")
       # Create a variable to indicate that we need to skip the component
       set(INTERNAL_SKIP_ogre2 true)
-      set(HAVE_OGRE2 FALSE)
+      set(GZ_RENDERING_HAVE_OGRE2 FALSE)
     else()
       message(STATUS "Looking for vulkan header (vulkan/vulkan_core.h) - found")
       set(GZ_RENDERING_HAVE_VULKAN TRUE)
@@ -169,7 +169,7 @@ if(NOT MSVC)
       PRIVATE_FOR optix)
 
   if (OptiX_FOUND AND CUDA_FOUND)
-    set(HAVE_OPTIX TRUE)
+    set(GZ_RENDERING_HAVE_OPTIX TRUE)
   endif()
 endif()
 
@@ -186,15 +186,15 @@ set(GZ_RENDERING_RESOURCE_PATH ${CMAKE_INSTALL_PREFIX}/${GZ_DATA_INSTALL_DIR})
 #============================================================================
 # Configure the build
 #============================================================================
-if (HAVE_OGRE)
+if (GZ_RENDERING_HAVE_OGRE)
   list(APPEND RENDERING_COMPONENTS ogre)
 endif()
 
-if (HAVE_OPTIX)
+if (GZ_RENDERING_HAVE_OPTIX)
   list(APPEND RENDERING_COMPONENTS optix)
 endif()
 
-if (HAVE_OGRE2)
+if (GZ_RENDERING_HAVE_OGRE2)
   list(APPEND RENDERING_COMPONENTS ogre2)
 endif()
 
@@ -204,7 +204,7 @@ configure_file("${PROJECT_SOURCE_DIR}/cppcheck.suppress.in"
 gz_configure_build(QUIT_IF_BUILD_ERRORS
     COMPONENTS ${RENDERING_COMPONENTS})
 
-if (HAVE_OGRE2)
+if (GZ_RENDERING_HAVE_OGRE2)
   # Must be done after gz_configure_build or else Terra
   # won't see GZ_ADD_fPIC_TO_LIBRARIES
   add_subdirectory(ogre2/src/terrain/Terra)

--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,13 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Rendering 7.x to 8.x
+
+### Deprecations
+1. The following `HAVE_` prefixed macros that are defined in config.hh are deprecated and will be removed in future versions.
+    + Deprecated: `HAVE_OGRE`, `HAVE_OGRE2` `HAVE_OPTIX`
+    + Replacement: `GZ_RENDERING_HAVE_OGRE`, `GZ_RENDERING_HAVE_OGRE2` `GZ_RENDERING_HAVE_OPTIX`
+
 ## Gazebo Rendering 6.x to 7.x
 
 ### Deprecations

--- a/include/gz/rendering/config.hh.in
+++ b/include/gz/rendering/config.hh.in
@@ -42,8 +42,14 @@
 #cmakedefine GZ_RENDERING_HAVE_VULKAN 1
 
 // \todo(anyone) remove on tock
+#ifndef HAVE_OGRE
 #define HAVE_OGRE GZ_RENDERING_HAVE_OGRE
+#endif
+#ifndef HAVE_OGRE2
 #define HAVE_OGRE2 GZ_RENDERING_HAVE_OGRE2
+#endif
+#ifndef HAVE_OPTIX
 #define HAVE_OPTIX GZ_RENDERING_HAVE_OPTIX
+#endif
 
 #endif

--- a/include/gz/rendering/config.hh.in
+++ b/include/gz/rendering/config.hh.in
@@ -36,11 +36,14 @@
 
 #define GZ_RENDERING_ENGINE_INSTALL_DIR "${GZ_RENDERING_ENGINE_INSTALL_DIR}"
 
-#cmakedefine HAVE_OGRE 1
-#cmakedefine HAVE_OGRE2 1
-#cmakedefine HAVE_OPTIX 1
-#cmakedefine HAVE_GAZEBO 1
-#cmakedefine INCLUDE_RTSHADER 1
+#cmakedefine GZ_RENDERING_HAVE_OGRE 1
+#cmakedefine GZ_RENDERING_HAVE_OGRE2 1
+#cmakedefine GZ_RENDERING_HAVE_OPTIX 1
 #cmakedefine GZ_RENDERING_HAVE_VULKAN 1
+
+// \todo(anyone) remove on tock
+#define HAVE_OGRE GZ_RENDERING_HAVE_OGRE
+#define HAVE_OGRE2 GZ_RENDERING_HAVE_OGRE2
+#define HAVE_OPTIX GZ_RENDERING_HAVE_OPTIX
 
 #endif

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -455,19 +455,19 @@ void RenderEngineManagerPrivate::RegisterDefaultEngines()
   std::string engineName;
 
   std::lock_guard<std::recursive_mutex> lock(this->enginesMutex);
-#if HAVE_OGRE
+#if GZ_RENDERING_HAVE_OGRE
   engineName = "ogre";
   this->defaultEngines[engineName] = libName + engineName;
   if (this->engines.find(libName + engineName) == this->engines.end())
     this->engines[libName + engineName] = nullptr;
 #endif
-#if HAVE_OGRE2
+#if GZ_RENDERING_HAVE_OGRE2
   engineName = "ogre2";
   this->defaultEngines[engineName] = libName + engineName;
   if (this->engines.find(libName + engineName) == this->engines.end())
     this->engines[libName + engineName] = nullptr;
 #endif
-#if HAVE_OPTIX
+#if GZ_RENDERING_HAVE_OPTIX
   engineName = "optix";
   this->defaultEngines[engineName] = libName + engineName;
   if (this->engines.find(libName + engineName) == this->engines.end())

--- a/test/common_test/RenderingIface_TEST.cc
+++ b/test/common_test/RenderingIface_TEST.cc
@@ -28,19 +28,19 @@
 using namespace gz;
 using namespace rendering;
 
-#if HAVE_OGRE
+#if GZ_RENDERING_HAVE_OGRE
 static bool kHaveOgre = true;
 #else
 static bool kHaveOgre = false;
 #endif
 
-#if HAVE_OGRE2
+#if GZ_RENDERING_HAVE_OGRE2
 static bool kHaveOgre2 = true;
 #else
 static bool kHaveOgre2 = false;
 #endif
 
-#if HAVE_OPTIX
+#if GZ_RENDERING_HAVE_OPTIX
 static bool kHaveOptix = true;
 #else
 static bool kHaveOptix = false;

--- a/test/gz_rendering_test.cmake
+++ b/test/gz_rendering_test.cmake
@@ -136,14 +136,14 @@ macro(gz_rendering_test)
     )
   endif()
 
-  if (HAVE_OGRE)
+  if (GZ_RENDERING_HAVE_OGRE)
     gz_configure_rendering_test(
       TARGET ${TEST_NAME}
       RENDER_ENGINE "ogre"
     )
   endif()
 
-  if (HAVE_OGRE2)
+  if (GZ_RENDERING_HAVE_OGRE2)
     if (APPLE)
       gz_configure_rendering_test(
         TARGET ${TEST_NAME}
@@ -165,7 +165,7 @@ macro(gz_rendering_test)
       # endif()
     endif()
   endif()
-  if (HAVE_OPTIX)
+  if (GZ_RENDERING_HAVE_OPTIX)
     gz_configure_rendering_test(
       TARGET ${TEST_NAME}
       RENDER_ENGINE "optix"


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Further addresses https://github.com/gazebosim/gz-rendering/pull/790#issuecomment-1350763951

The config.hh file with these `HAVE_` macros can be indirectly included and used by downstream projects and potentially collide with their own private macros so a `GZ_RENDERING_` prefix is added to these macros. 

I also removed macros that are not used

Not sure if there is an elegant way to print out a deprecation msg. I added deprecation notes in `Migration.md` guide


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
