### PR TITLE
Add message to see troubleshooting page when render engine fails to initialize

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -343,6 +343,9 @@ bool Ogre2RenderEngine::InitImpl()
   catch (...)
   {
     ignerr << "Failed to initialize render-engine" << std::endl;
+    ignerr << "Please see the troubleshooting page for possible fixes:"
+           << "https://gazebosim.org/docs/fortress/troubleshooting"
+           << std::endl;
     return false;
   }
 }

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -343,7 +343,7 @@ bool Ogre2RenderEngine::InitImpl()
   catch (...)
   {
     ignerr << "Failed to initialize render-engine" << std::endl;
-    ignerr << "Please see the troubleshooting page for possible fixes:"
+    ignerr << "Please see the troubleshooting page for possible fixes: "
            << "https://gazebosim.org/docs/fortress/troubleshooting"
            << std::endl;
     return false;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Instructs the user to visit https://gazebosim.org/docs/fortress/troubleshooting when render engine fails to initialize. There is already some information on the page about issues creating the render window. I plan to add a little more info that page.

We'll need to update the url when merging forward.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

