### PR TITLE
Fix OGRE 2 with VirtualGL

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -539,8 +539,20 @@ void Ogre2RenderEngine::LoadPlugins()
       // load the plugin
       try
       {
+#if HAVE_GLX
+        // Store the current GLX context in case OGRE plugin init changes it
+        const auto context = glXGetCurrentContext();
+        const auto display = glXGetCurrentDisplay();
+        const auto drawable = glXGetCurrentDrawable();
+#endif
+
         // Load the plugin into OGRE
         this->ogreRoot->loadPlugin(filename);
+
+#if HAVE_GLX
+        // Restore GLX context
+        glXMakeCurrent(display, drawable, context);
+#endif
       }
       catch(Ogre::Exception &e)
       {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #526 and maybe https://github.com/gazebosim/gz-sim/issues/1746 .

## Summary
Restore GLX context after loading the OGRE plugin. It is possible the loading process changes the current GLX context.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.