### PR TITLE
Fix Ogre2DepthCamera on macOS (Fortress)

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -916,7 +916,7 @@ void Ogre2DepthCamera::CreateDepthTexture()
         this->ImageWidth(), this->ImageHeight());
       this->dataPtr->ogreDepthTexture[i]->setNumMipmaps(1u);
       this->dataPtr->ogreDepthTexture[i]->setPixelFormat(
-        Ogre::PFG_RGBA32_FLOAT);
+        Ogre::PFG_RGBA32_UINT);
 
       this->dataPtr->ogreDepthTexture[i]->scheduleTransitionTo(
         Ogre::GpuResidency::Resident);

--- a/ogre2/src/media/materials/programs/GLSL/depth_camera_final_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/depth_camera_final_fs.glsl
@@ -22,9 +22,9 @@ in block
   vec2 uv0;
 } inPs;
 
-uniform sampler2D inputTexture;
+uniform usampler2D inputTexture;
 
-out vec4 fragColor;
+out uvec4 fragColor;
 
 uniform float near;
 uniform float far;
@@ -37,14 +37,14 @@ void main()
 {
   float tolerance = 1e-6;
 
-  // Note: We use texelFetch because p.a contains an uint32 and sampling
+  // Note: We use PFG_RGBA32_UINT because p.a contains an uint32 and sampling
   // (even w/ point filtering) causes p.a to loss information (e.g.
   // values close to 0 get rounded to 0)
   //
-  // See https://github.com/ignitionrobotics/ign-rendering/issues/332
-  vec4 p = texelFetch(inputTexture, ivec2(inPs.uv0 *texResolution.xy), 0);
+  // See https://github.com/gazebosim/gz-rendering/issues/332
+  uvec4 p = texelFetch(inputTexture, ivec2(inPs.uv0 *texResolution.xy), 0);
 
-  vec3 point = p.xyz;
+  vec3 point = uintBitsToFloat(p.xyz);
 
   // Clamp again in case render passes changed depth values
   // to be outside of min/max range
@@ -73,5 +73,5 @@ void main()
     }
   }
 
-  fragColor = vec4(point, p.a);
+  fragColor = uvec4(floatBitsToUint(point), p.a);
 }

--- a/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/depth_camera_fs.glsl
@@ -28,7 +28,7 @@ uniform sampler2D colorTexture;
 uniform sampler2D particleTexture;
 uniform sampler2D particleDepthTexture;
 
-out vec4 fragColor;
+out uvec4 fragColor;
 
 uniform vec2 projectionParams;
 uniform float near;
@@ -43,13 +43,13 @@ uniform float particleScatterRatio;
 // rnd is a random number in the range of [0-1]
 uniform float rnd;
 
-float packFloat(vec4 color)
+uint packUnorm4x8Gz(vec4 color)
 {
-  int rgba = (int(round(color.x * 255.0)) << 24) +
-             (int(round(color.y * 255.0)) << 16) +
-             (int(round(color.z * 255.0)) << 8) +
-             int(round(color.w * 255.0));
-  return intBitsToFloat(rgba);
+  uint rgba = (uint(round(color.x * 255.0)) << 24u) +
+              (uint(round(color.y * 255.0)) << 16u) +
+              (uint(round(color.z * 255.0)) << 8u) +
+              uint(round(color.w * 255.0));
+  return rgba;
 }
 
 float toSRGB( float x )
@@ -193,6 +193,5 @@ void main()
   // gamma correct
   color = toSRGB(color);
 
-  float rgba = packFloat(color);
-  fragColor = vec4(point, rgba);
+  fragColor = uvec4(floatBitsToUint(point), packUnorm4x8Gz(color));
 }

--- a/ogre2/src/media/materials/programs/Metal/depth_camera_final_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/depth_camera_final_fs.metal
@@ -34,27 +34,24 @@ struct Params
   float4 texResolution;
 };
 
-fragment float4 main_metal
+fragment uint4 main_metal
 (
   PS_INPUT inPs [[stage_in]],
-  texture2d<float>  inputTexture [[texture(0)]],
-  sampler           inputSampler [[sampler(0)]],
+  texture2d<uint> inputTexture [[texture(0)]],
   constant Params &params [[buffer(PARAMETER_SLOT)]]
 )
 {
   float tolerance = 1e-6;
 
-  // Note: We use texelFetch because p.a contains an uint32 and sampling
+  // Note: We use PFG_RGBA32_UINT because p.a contains an uint32 and sampling
   // (even w/ point filtering) causes p.a to loss information (e.g.
   // values close to 0 get rounded to 0)
   //
   // See https://github.com/ignitionrobotics/ign-rendering/issues/332
   // Either: Metal equivalent of texelFetch
-  float4 p = inputTexture.read(uint2(inPs.uv0 * params.texResolution.xy), 0);
-  // Or: Use standard sampler
-  // float4 p = inputTexture.sample(inputSampler, inPs.uv0);
+  uint4 p = inputTexture.read(uint2(inPs.uv0 * params.texResolution.xy), 0);
 
-  float3 point = p.xyz;
+  float3 point = as_type<float3>(p.xyz);
 
   // Clamp again in case render passes changed depth values
   // to be outside of min/max range
@@ -83,6 +80,6 @@ fragment float4 main_metal
     }
   }
 
-  float4 fragColor(point, p.a);
+  uint4 fragColor(as_type<uint3>(point), p.a);
   return fragColor;
 }

--- a/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/depth_camera_fs.metal
@@ -42,13 +42,13 @@ struct Params
   float rnd;
 };
 
-float packFloat(float4 color)
+uint packUnorm4x8Gz(float4 color)
 {
-  int rgba = (int(round(color.x * 255.0)) << 24) +
-             (int(round(color.y * 255.0)) << 16) +
-             (int(round(color.z * 255.0)) << 8) +
-             int(round(color.w * 255.0));
-  return as_type<float>(rgba);
+  uint rgba = (uint(round(color.x * 255.0)) << 24u) +
+              (uint(round(color.y * 255.0)) << 16u) +
+              (uint(round(color.z * 255.0)) << 8u) +
+              uint(round(color.w * 255.0));
+  return rgba;
 }
 
 inline float toSRGB( float x )
@@ -89,7 +89,7 @@ float4 gaussrand(float2 co, float3 offsets, float mean, float stddev)
   return float4(Z, Z, Z, 0.0);
 }
 
-fragment float4 main_metal
+fragment uint4 main_metal
 (
   PS_INPUT inPs [[stage_in]],
   texture2d<float>  depthTexture [[texture(0)]],
@@ -204,7 +204,6 @@ fragment float4 main_metal
   // gamma correct
   color = toSRGB(color);
 
-  float rgba = packFloat(color);
-  float4 fragColor(point, rgba);
+  uint4 fragColor(as_type<uint3>(point), packUnorm4x8Gz(color));
   return fragColor;
 }

--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -260,10 +260,7 @@ void DepthCameraTest::DepthCameraBoxes(
       unsigned int ma = *mrgba >> 0 & 0xFF;
       EXPECT_EQ(0u, mr);
       EXPECT_EQ(0u, mg);
-#ifndef __APPLE__
-      // https://github.com/ignitionrobotics/ign-rendering/issues/332
       EXPECT_GT(mb, 0u);
-#endif
 
       // Far left and right points should be red (background color)
       float lc = pointCloudData[pcLeft + 3];
@@ -465,11 +462,8 @@ void DepthCameraTest::DepthCameraBoxes(
           unsigned int a = *rgba >> 0 & 0xFF;
           EXPECT_EQ(0u, r);
           EXPECT_EQ(0u, g);
-#ifndef __APPLE__
-          // https://github.com/ignitionrobotics/ign-rendering/issues/332
           EXPECT_GT(b, 0u);
           EXPECT_EQ(255u, a);
-#endif
         }
       }
     }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #332 (again) for macOS and possibly any OS/HW/Driver combination.
Fixes #369 

## Summary

For a very long time macOS (and possibly other OS/HW/Driver combination) would fail the tests because the shader code was doing (simplified, in C to convey the explanation):

```cpp
uint32_t valueToStore = r << 24 | g << 16 | b << 8 | a;
float output;
output = (float*)&valueToStore;
return output;
```

In ticket #332 I made a deep analysis and found out that given the wrong conditions, the bit pattern would result in either a denormal or a NaN in floating point; which risks being flushed to 0 (or set all types of NaN to the same type bit pattern of NaN).

Although the ticket was closed and tagged as "fixed", on some OS/HW/Driver combinations (e.g. macOS + Metal) this error would reappear.

This isn't just a mere test failure. This is an actual bug. Running DepthCamera in macOS could result in wrong readings.

This PR fixes the problem for good by using RGBA32_UINT instead of RGBA32_FLOAT; and having uints be reinterpreted to floats and back when needed; which is well-defined and much more stable as far as GPU shader compilers go.

The same fix is also part of PR #785 which targets Garden and includes other changes.

This PR is a backport specific for Fortress.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
