### PR TITLE
Limit Global Illumination CI CVT method to vulkan backend

### DIFF
--- a/examples/global_illumination/Main.cc
+++ b/examples/global_illumination/Main.cc
@@ -351,7 +351,6 @@ int main(int _argc, char **_argv)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
   }
-  std::cerr << _argv[2] << std::endl;
 
   common::Console::SetVerbosity(4);
   std::vector<CameraPtr> cameras;

--- a/examples/global_illumination/Main.cc
+++ b/examples/global_illumination/Main.cc
@@ -249,53 +249,60 @@ void buildScene(ScenePtr _scene)
 
 #if GI_METHOD == 1
   auto gi = _scene->CreateGlobalIlluminationVct();
-  const uint32_t resolution[3]{ 128u, 128u, 32u };
-  const uint32_t octantCount[3]{ 4, 4, 2 };
-  gi->SetResolution(resolution);
-  gi->SetAnisotropic(true);
-  gi->SetHighQuality(false);
-  gi->SetThinWallCounter(1.0f);
-  gi->SetOctantCount(octantCount);
-  gi->SetAnisotropic(false);
-  gi->Build();
-  _scene->SetActiveGlobalIllumination(gi);
+  if (gi)
+  {
+    const uint32_t resolution[3]{ 128u, 128u, 32u };
+    const uint32_t octantCount[3]{ 4, 4, 2 };
+    gi->SetResolution(resolution);
+    gi->SetAnisotropic(true);
+    gi->SetHighQuality(false);
+    gi->SetThinWallCounter(1.0f);
+    gi->SetOctantCount(octantCount);
+    gi->SetAnisotropic(false);
+    gi->Build();
+    _scene->SetActiveGlobalIllumination(gi);
+  }
 #elif GI_METHOD == 2
   auto gi = _scene->CreateGlobalIlluminationCiVct();
 
-  gi->SetMaxCascades(3u);
+  if (gi)
+  {
+    gi->SetMaxCascades(3u);
 
-  CiVctCascadePtr cascade = gi->AddCascade(nullptr);
-  const uint32_t resolution[3]{ 128u, 128u, 128u };
-  const uint32_t octantCount[3]{ 4, 4, 2 };
-  cascade->SetAreaHalfSize(gz::math::Vector3d(5.0, 5.0, 5.0));
-  cascade->SetResolution(resolution);
-  cascade->SetCameraStepSize(gz::math::Vector3d(
-    1.0, 1.0, 1.0));  // Will be overriden by autoCalculateStepSizes
-  cascade->SetThinWallCounter(1.0f);
-  cascade->SetOctantCount(octantCount);
+    CiVctCascadePtr cascade = gi->AddCascade(nullptr);
+    const uint32_t resolution[3]{ 128u, 128u, 128u };
+    const uint32_t octantCount[3]{ 4, 4, 2 };
+    cascade->SetAreaHalfSize(gz::math::Vector3d(5.0, 5.0, 5.0));
+    cascade->SetResolution(resolution);
+    cascade->SetCameraStepSize(gz::math::Vector3d(
+      1.0, 1.0, 1.0));  // Will be overriden by autoCalculateStepSizes
+    cascade->SetThinWallCounter(1.0f);
+    cascade->SetOctantCount(octantCount);
 
-  cascade = gi->AddCascade(cascade.get());
-  cascade->SetAreaHalfSize(gz::math::Vector3d(10.0, 10.0, 10.0));
+    cascade = gi->AddCascade(cascade.get());
+    cascade->SetAreaHalfSize(gz::math::Vector3d(10.0, 10.0, 10.0));
 
-  cascade = gi->AddCascade(cascade.get());
-  cascade->SetAreaHalfSize(gz::math::Vector3d(20.0, 20.0, 20.0));
+    cascade = gi->AddCascade(cascade.get());
+    cascade->SetAreaHalfSize(gz::math::Vector3d(20.0, 20.0, 20.0));
 
-  gi->AutoCalculateStepSizes(gz::math::Vector3d(3.0, 3.0, 3.0));
+    gi->AutoCalculateStepSizes(gz::math::Vector3d(3.0, 3.0, 3.0));
 
-  gi->Bind(camera);
-  gi->SetHighQuality(false);
-  gi->Start(2u, true);
-  gi->Build();
-  _scene->SetActiveGlobalIllumination(gi);
+    gi->Bind(camera);
+    gi->SetHighQuality(false);
+    gi->Start(2u, true);
+    gi->Build();
+    _scene->SetActiveGlobalIllumination(gi);
+  }
 #endif
   g_gi = gi;
 }
 
 //////////////////////////////////////////////////
-CameraPtr createCamera(const std::string &_engineName)
+CameraPtr createCamera(const std::string &_engineName,
+    const std::map<std::string, std::string>& _params)
 {
   // create and populate scene
-  RenderEngine *engine = rendering::engine(_engineName);
+  RenderEngine *engine = rendering::engine(_engineName, _params);
   if (!engine)
   {
     std::cout << "Engine '" << _engineName << "' is not supported" << std::endl;
@@ -333,25 +340,39 @@ int main(int _argc, char **_argv)
     return -1;
   }
 
+  std::string engineName("ogre2");
+  if (_argc > 1)
+  {
+    engineName = _argv[1];
+  }
+
+  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+  if (_argc > 2)
+  {
+    graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
+  }
+  std::cerr << _argv[2] << std::endl;
+
   common::Console::SetVerbosity(4);
-  std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-  engineNames.push_back("ogre2");
-  for (auto engineName : engineNames)
+  std::map<std::string, std::string> params;
+  if (engineName.compare("ogre2") == 0
+      && graphicsApi == GraphicsAPI::VULKAN)
   {
-    try
+    params["vulkan"] = "1";
+  }
+  try
+  {
+    CameraPtr camera = createCamera(engineName, params);
+    if (camera)
     {
-      CameraPtr camera = createCamera(engineName);
-      if (camera)
-      {
-        cameras.push_back(camera);
-      }
+      cameras.push_back(camera);
     }
-    catch (...)
-    {
-      std::cerr << "Error starting up: " << engineName << std::endl;
-    }
+  }
+  catch (...)
+  {
+    std::cerr << "Error starting up: " << engineName << std::endl;
   }
   run(cameras);
 

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -17,6 +17,7 @@
 
 #include <gz/common/Console.hh>
 
+#include "gz/rendering/GraphicsAPI.hh"
 #include "gz/rendering/RenderTypes.hh"
 #include "gz/rendering/ogre2/Ogre2ArrowVisual.hh"
 #include "gz/rendering/ogre2/Ogre2AxisVisual.hh"
@@ -1369,6 +1370,13 @@ GlobalIlluminationVctPtr Ogre2Scene::CreateGlobalIlluminationVctImpl(
 GlobalIlluminationCiVctPtr Ogre2Scene::CreateGlobalIlluminationCiVctImpl(
   unsigned int _id, const std::string &_name)
 {
+  auto engine = Ogre2RenderEngine::Instance();
+  if (engine->GraphicsAPI() != GraphicsAPI::VULKAN)
+  {
+    gzerr << "Global Illumination CI VCT (ogre2) is currently "
+          << "only available with vulkan backend." << std::endl;
+    return nullptr;
+  }
   Ogre2GlobalIlluminationCiVctPtr gi(new Ogre2GlobalIlluminationCiVct);
   bool result = this->InitObject(gi, _id, _name);
 

--- a/test/common_test/GlobalIllumination_TEST.cc
+++ b/test/common_test/GlobalIllumination_TEST.cc
@@ -134,6 +134,12 @@ TEST_F(GlobalIlluminationTest, GlobalIlluminationCiVct)
 
   CHECK_SUPPORTED_ENGINE("ogre2");
 
+  if (engine->GraphicsAPI() != GraphicsAPI::VULKAN)
+  {
+    GTEST_SKIP() << "Global Illumination CI VCT method currently only works "
+                 << "with vulkan backend" << std::endl;
+  }
+
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

As observed in https://github.com/gazebosim/gz-rendering/pull/675#issuecomment-1363311005, Global Illumination (GI) CI CVT method current crashes when run with OpenGL. It is [recommended](https://github.com/gazebosim/gz-rendering/pull/675#issuecomment-1363412495) to run it with Vulkan backend.

This PR adds a check for backend api and only creates GI CI VCT if backend is vulkan

To test:

Make sure to build gz-rendering with vulkan support. You'll need to install `libvulkan-dev`

Go to the `examples/global_illumination` demo:

Change the [GI_METHOD](https://github.com/gazebosim/gz-rendering/blob/a6a94794b925b5fcd745b900eb3b434e3949ccaf/examples/global_illumination/GiConfig.hh#L17)  to a value other than `1` to force GI to use the CI VCT method. Then build and run:

```sh
# demo should run but print out an error message about GI CI VCT is only available with vulkan
./global_illumination

# demo should run with vulkan and GI should work
./global_illumination ogre2 vulkan
```

When GI is enabled, zoom in to the box and you should see reflections

![gi](https://user-images.githubusercontent.com/4000684/182988464-192c469d-5af1-42f2-a318-c39391d3f572.png)


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

