### PR TITLE
Fix gpu lidar memory leak [ogre2]

### DIFF
--- a/ogre2/src/Ogre2GzHlmsSharedPrivate.cc
+++ b/ogre2/src/Ogre2GzHlmsSharedPrivate.cc
@@ -80,7 +80,7 @@ namespace gz
         // gl_InstanceId / drawId will be reset to 0. We must create a new
         // buffer and bind that one
 
-        UnmapObjectDataBuffer();
+        this->UnmapObjectDataBuffer();
 
         if (_currConstBufferIdx >= this->perObjectDataBuffers.size())
         {
@@ -105,7 +105,7 @@ namespace gz
 
         this->lastMainConstBuffer = _constBuffers[_currConstBufferIdx];
 
-        BindObjectDataBuffer(_commandBuffer, _perObjectDataBufferSlot);
+        this->BindObjectDataBuffer(_commandBuffer, _perObjectDataBufferSlot);
       }
 
       const size_t offset = _instanceIdx * numFloatsPerObject;

--- a/ogre2/src/Ogre2GzHlmsSharedPrivate.cc
+++ b/ogre2/src/Ogre2GzHlmsSharedPrivate.cc
@@ -82,17 +82,20 @@ namespace gz
 
         this->UnmapObjectDataBuffer();
 
+        Ogre::ConstBufferPacked *constBuffer = nullptr;
         if (_currConstBufferIdx >= this->perObjectDataBuffers.size())
         {
           this->vaoManager = _vaoManager;
           const size_t bufferSize =
             std::min<size_t>(65536, _vaoManager->getConstBufferMaxSize());
-          Ogre::ConstBufferPacked *constBuffer = _vaoManager->createConstBuffer(
+          constBuffer = _vaoManager->createConstBuffer(
             bufferSize, Ogre::BT_DYNAMIC_PERSISTENT, nullptr, false);
           this->perObjectDataBuffers.push_back(constBuffer);
         }
-        Ogre::ConstBufferPacked *constBuffer =
-          this->perObjectDataBuffers[_currConstBufferIdx];
+        else
+        {
+          constBuffer = this->perObjectDataBuffers[_currConstBufferIdx];
+        }
 
         this->currPerObjectDataBuffer = constBuffer;
         this->currPerObjectDataPtr = reinterpret_cast<float *>(

--- a/ogre2/src/Ogre2GzHlmsSharedPrivate.hh
+++ b/ogre2/src/Ogre2GzHlmsSharedPrivate.hh
@@ -46,6 +46,9 @@ namespace gz
     /// \internal
     class GZ_RENDERING_OGRE2_HIDDEN Ogre2GzHlmsShared
     {
+      /// \brief Destructor
+      protected: ~Ogre2GzHlmsShared();
+
       /// \brief Binds currPerObjectDataBuffer to the right slot.
       /// Does nothing if it's nullptr
       /// \param[in] _commandBuffer Cmd buffer to bind to
@@ -105,6 +108,10 @@ namespace gz
       /// \brief The mapped contents of currPerObjectDataBuffer
       /// \internal
       protected: float *currPerObjectDataPtr = nullptr;
+
+      /// \brief Pointer to Ogre's VAO manager. Used here for destroying const
+      /// buffers.
+      private: Ogre::VaoManager *vaoManager = nullptr;
 
       /// \brief See GzOgreRenderingMode. Public variable.
       /// Modifying it takes change on the next render


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sensors/issues/197

## Summary

memory leak was due to internal buffers were being continuously created. Implemented the fix as suggested in https://github.com/gazebosim/gz-sensors/issues/197#issuecomment-1371438636 to prevent growing the buffers if not needed

To test:

Launch gz sim with `gpu_lidar_sensor.sdf` world:

```sh
gz sim -v 4 -r gpu_lidar_sensor.sdf
```

Subscribe to lidar data which will force lidar to start rendering

```sh
gz topic -e -t /lidar/points > /dev/null
```

Run `htop` or your favorite process / memory monitoring tool and see that the memory usage should now remain steady.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

