### PR TITLE
Fix selecting semi-transparent visuals

### DIFF
--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -471,6 +471,9 @@ bool Ogre2SelectionBuffer::ExecuteQuery(const int _x, const int _y,
   unsigned int g = *rgba >> 16 & 0xFF;
   unsigned int b = *rgba >> 8 & 0xFF;
 
+  // todo(anyone) shaders may return nan values for semi-transparent objects
+  // if there are no objects in the background (behind the semi-transparent
+  // object)
   math::Vector3d point(pixel[0], pixel[1], pixel[2]);
 
   auto rot = Ogre2Conversions::Convert(
@@ -519,7 +522,6 @@ bool Ogre2SelectionBuffer::ExecuteQuery(const int _x, const int _y,
         }
       }
       return false;
-
     }
     else
     {

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -156,7 +156,7 @@ VisualPtr BaseScene::VisualAt(const CameraPtr &_camera,
     rayQuery->SetFromCamera(_camera, mousePos);
     RayQueryResult result = rayQuery->ClosestPoint();
 
-    if (result)
+    if (result.objectId > 0u)
     {
       visual = this->Visuals()->GetById(result.objectId);
     }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🦟 Bug fix

Another fix for https://github.com/gazebosim/gz-sim/issues/147, specifically the issue shown in the video in https://github.com/gazebosim/gz-sim/issues/147#issuecomment-1156973396

## Summary

The problem is that when clicking on semi-transparent visuals with nothing in the background, the ogre2 selection buffer returns `nan` point values. This causes entity selection to think that nothing is pressed by the mouse. Similarly when using the transform control tool, the user will not be able to click on the semi-transparent arrow visual if there is nothing in the background. For the entity selection and transform control functionality, we don't really need the point / distance results from the selection buffer ray query, so the workaround is to just make sure the visual object's ids is valid.

The issue with `nan` values returned the selection buffer for semi-transparent object still persist, and I added a todo note for this.

To test:

See video in https://github.com/gazebosim/gz-sim/issues/147#issuecomment-1156973396.

Alternatively:

1. launch gz-sim with shapes.sdf world

    ```
    gz sim -v 4 shapes.sdf
    ```

1. Right click the box and select `View` -> `Transparent`

1. Click on another model in the scene to unselect the box


1. Try positioning the camera so that there is nothing behind the semi-transparent box (i.e. no ground plane in the background) similar to the idea shown in the [video]( https://github.com/gazebosim/gz-sim/issues/147#issuecomment-1156973396). 

1. Use mouse to select the part of the box without background. Without this change, the box can not be selected.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
