### PR TITLE
6 -> 7 

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -374,6 +374,9 @@ bool Ogre2RenderEngine::InitImpl()
   catch (...)
   {
     gzerr << "Failed to initialize render-engine" << std::endl;
+    gzerr << "Please see the troubleshooting page for possible fixes: "
+          << "https://gazebosim.org/docs/fortress/troubleshooting"
+          << std::endl;
     return false;
   }
 }
@@ -589,8 +592,20 @@ void Ogre2RenderEngine::LoadPlugins()
       // load the plugin
       try
       {
+#if HAVE_GLX
+        // Store the current GLX context in case OGRE plugin init changes it
+        const auto context = glXGetCurrentContext();
+        const auto display = glXGetCurrentDisplay();
+        const auto drawable = glXGetCurrentDrawable();
+#endif
+
         // Load the plugin into OGRE
         this->ogreRoot->loadPlugin(filename, piter->bOptional, nullptr);
+
+#if HAVE_GLX
+        // Restore GLX context
+        glXMakeCurrent(display, drawable, context);
+#endif
       }
       catch(Ogre::Exception &)
       {


### PR DESCRIPTION

# ➡️ Forward port

Port ign-rendering6 to gz-rendering7

Branch comparison: https://github.com/gazebosim/gz-rendering/compare/gz-rendering7...ign-gazebo6

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)

Diff is small because most of the changes are already in 7 because they were backported from 7 to 6.

