### PR TITLE
Mesh cleanup on destruction

### DIFF
--- a/ogre2/src/Ogre2Mesh.cc
+++ b/ogre2/src/Ogre2Mesh.cc
@@ -63,12 +63,13 @@ Ogre2Mesh::Ogre2Mesh()
 //////////////////////////////////////////////////
 Ogre2Mesh::~Ogre2Mesh()
 {
+  this->Destroy();
 }
 
 //////////////////////////////////////////////////
 void Ogre2Mesh::Destroy()
 {
-  if (!this->ogreItem)
+  if (!this->ogreItem || !this->Scene()->IsInitialized())
     return;
 
   // We need to override BaseMesh::Destroy for ogre2 implementation to control

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -71,7 +71,11 @@ void MeshTest::MeshSubMesh(const std::string &_renderEngine)
   // create the mesh using mesh descriptor
   MeshDescriptor descriptor("unit_box");
   MeshPtr mesh = scene->CreateMesh(descriptor);
-  ASSERT_TRUE(mesh!= nullptr);
+  ASSERT_NE(nullptr, mesh);
+
+  // make sure we can create the mesh again with same descriptor
+  mesh = scene->CreateMesh(descriptor);
+  ASSERT_NE(nullptr, mesh);
 
   // test mesh API
   EXPECT_EQ(mesh->SubMeshCount(), 1u);


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #805 

## Summary

The code snippet in #805 identified a case in which a mesh is not properly destroyed when it goes out of scope, see code and comment below

```cpp
        ignition::rendering::MeshPtr mesh_geom = scene.CreateMesh(descriptor);
        // the line below leaves the original `mesh_geom` dangling and we are not cleaning it up properly
        mesh_geom = scene.CreateMesh(descriptor);
```

This PR makes sure the `Destroy` function is called in the mesh destructor.

The mesh unit test is updated to cover the use case shown in #805

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

