### PR TITLE
Backport Composite BaseVisual destroy fix to 6

### DIFF
--- a/include/ignition/rendering/base/BaseArrowVisual.hh
+++ b/include/ignition/rendering/base/BaseArrowVisual.hh
@@ -96,6 +96,7 @@ namespace ignition
           visual->Destroy();
         }
       }
+      T::Destroy();
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseAxisVisual.hh
+++ b/include/ignition/rendering/base/BaseAxisVisual.hh
@@ -83,6 +83,7 @@ namespace ignition
           arrow->Destroy();
         }
       }
+      T::Destroy();
     }
 
     //////////////////////////////////////////////////

--- a/include/ignition/rendering/base/BaseJointVisual.hh
+++ b/include/ignition/rendering/base/BaseJointVisual.hh
@@ -263,6 +263,8 @@ namespace ignition
       this->dirtyJointType = false;
       this->dirtyAxis = false;
       this->dirtyParentAxis = false;
+
+      T::Destroy();
     }
 
     /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #814 

## Summary

backport fix from #816 that ensures composite visuals are destroyed properly

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

