### PR TITLE
6.6.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-rendering6 VERSION 6.5.2)
+project(ignition-rendering6 VERSION 6.6.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,33 @@
 ## Ignition Rendering
 
-### Ignition Rendering 6.6.0 (2023-01-19)
+### Ignition Rendering 6.6.0 (2023-02-02)
+
+1. Backport Composite BaseVisual destroy fix to 6
+    * [Pull request #818](https://github.com/gazebosim/ign-rendering/pull/818)
+
+1. Forward port 3 to 6.
+    * [Pull request #815](https://github.com/gazebosim/ign-rendering/pull/815)
+    * [Pull request #819](https://github.com/gazebosim/ign-rendering/pull/819)
+
+1. Remove fini to resolve segfault at shutdown
+    * [Pull request #813](https://github.com/gazebosim/ign-rendering/pull/813)
+
+1. Fix transparency over heightmap
+    * [Pull request #811](https://github.com/gazebosim/ign-rendering/pull/811)
+
+1. Fix duplicate PreRrender calls
+    * [Pull request #809](https://github.com/gazebosim/ign-rendering/pull/809)
+
+1. ign -> gz Migrate Ignition Headers : gz-rendering
+    * [Pull request #705](https://github.com/gazebosim/ign-rendering/pull/705)
+
+1. Improved coverage: MeshDescriptor, Mesh, MoveToHelper, OrbitViewController, PixelFormat and ShadersParams
+    * [Pull request #748](https://github.com/gazebosim/ign-rendering/pull/748)
+
+1. Suppress Windows warnings
+    * [Pull request #749](https://github.com/gazebosim/ign-rendering/pull/749)
+
+### Ignition Rendering 6.5.2 (2023-01-19)
 
 1. Mesh clean up in destructor
     * [Pull request #807](https://github.com/gazebosim/ign-rendering/pull/807)


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.6.0 release.

Comparison to 6.5.2: https://github.com/gazebosim/gz-rendering/compare/ignition-rendering6_6.5.2...prep_6.6.0

<!-- Add links to PRs that require this release (if needed) -->
Needed by
* https://github.com/gazebosim/gz-sensors/pull/313

I also fixed the changelog version from previous 6.5.2 release pointed out in https://github.com/gazebosim/gz-rendering/pull/808#discussion_r1086264362

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
