### PR TITLE
3.7.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-rendering3 VERSION 3.7.0)
+project(ignition-rendering3 VERSION 3.7.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition Rendering
 
+### Ignition Rendering 3.7.1 (2023-02-03)
+
+1. Remove fini to resolve segfaault at shutdown.
+    * [Pull request #813](https://github.com/gazebosim/gz-rendering/pull/813)
+
 ### Ignition Rendering 3.7.0 (2022-11-29)
 
 1. Migrate ignition to gazebo headers.


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 3.7.1 release.

Comparison to 3.7.0: https://github.com/gazebosim/gz-rendering/compare/ignition-rendering3_3.7.0...ign-rendering3

Needed by https://github.com/gazebosim/gz-sim/pull/1646

## Checklist
- [ ] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
