### PR TITLE
Limit max camera node position values

### DIFF
--- a/ogre/src/OgreNode.cc
+++ b/ogre/src/OgreNode.cc
@@ -17,6 +17,7 @@
 
 #include <gz/common/Console.hh>
 
+#include "gz/rendering/ogre/OgreCamera.hh"
 #include "gz/rendering/ogre/OgreNode.hh"
 #include "gz/rendering/ogre/OgreConversions.hh"
 #include "gz/rendering/ogre/OgreIncludes.hh"
@@ -99,6 +100,16 @@ void OgreNode::SetRawLocalPosition(const math::Vector3d &_position)
   if (nullptr == this->ogreNode)
     return;
 
+  // ogre crashes in the shadow (PSSM) render pass with an
+  // Ogre::AxisAlignedBox::setExtents assertion error when the camera scene node
+  // position has large values. Added a workaround that places a max limit on
+  // the length of the position vector.
+  if (dynamic_cast<OgreCamera *>(this) && _position.Length() > 1e8)
+  {
+    ignerr << "Unable to set camera node position to a distance larger than "
+           << "1e8 from origin" << std::endl;
+    return;
+  }
   this->ogreNode->setPosition(OgreConversions::Convert(_position));
 }
 

--- a/ogre2/src/Ogre2Node.cc
+++ b/ogre2/src/Ogre2Node.cc
@@ -17,6 +17,7 @@
 
 #include <gz/common/Console.hh>
 
+#include "gz/rendering/ogre2/Ogre2Camera.hh"
 #include "gz/rendering/ogre2/Ogre2Node.hh"
 #include "gz/rendering/ogre2/Ogre2Conversions.hh"
 #include "gz/rendering/ogre2/Ogre2Scene.hh"
@@ -109,6 +110,16 @@ void Ogre2Node::SetRawLocalPosition(const math::Vector3d &_position)
   if (nullptr == this->ogreNode)
     return;
 
+  // ogre crashes in the compositor shadow pass with an
+  // Ogre::AxisAlignedBox::setExtents assertion error when the camera scene node
+  // position has large values. Added a workaround that places a max limit on
+  // the length of the position vector.
+  if (dynamic_cast<Ogre2Camera *>(this) && _position.Length() > 1e10)
+  {
+    ignerr << "Unable to set camera node position to a distance larger than "
+           << "1e10 from origin" << std::endl;
+    return;
+  }
   this->ogreNode->setPosition(Ogre2Conversions::Convert(_position));
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/710

## Summary

Currently rendering crashes with ogre assertion error when the camera position is a really large value. This PR places a limit on the max length of of the node position vector that can be set to prevent the crash. Note that the max limit is different between `ogre` and `ogre2` render engines

## To test:

launch gazebo and use view angle plugin to set the pose of the camera to a large number:

1. `ign gazebo -v 4 shapes.sdf`
2. Go to top right menu, open `View Angle` plugin
3. Scroll down to `Camera Pose` section and enter 100000000000 in the `X` field -> gazebo should no longer crash


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
