### PR TITLE
Tweak max camera position limit

### DIFF
--- a/ogre2/src/Ogre2Node.cc
+++ b/ogre2/src/Ogre2Node.cc
@@ -114,10 +114,10 @@ void Ogre2Node::SetRawLocalPosition(const math::Vector3d &_position)
   // Ogre::AxisAlignedBox::setExtents assertion error when the camera scene node
   // position has large values. Added a workaround that places a max limit on
   // the length of the position vector.
-  if (dynamic_cast<Ogre2Camera *>(this) && _position.Length() > 1e10)
+  if (dynamic_cast<Ogre2Camera *>(this) && _position.Length() > 1e9)
   {
     ignerr << "Unable to set camera node position to a distance larger than "
-           << "1e10 from origin" << std::endl;
+           << "1e9 from origin" << std::endl;
     return;
   }
   this->ogreNode->setPosition(Ogre2Conversions::Convert(_position));
@@ -280,5 +280,3 @@ void Ogre2Node::SetLocalScaleImpl(const math::Vector3d &_scale)
 
   this->ogreNode->setScale(Ogre2Conversions::Convert(_scale));
 }
-
-


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Tweak the max camera position value that's set in https://github.com/gazebosim/gz-rendering/pull/824.

I've been testing https://github.com/gazebosim/gz-sim/pull/1807 (specifically addressing https://github.com/gazebosim/gz-sim/pull/1807#issuecomment-1428646045) and it seems like a camera pos length of 1e10 is still too large and crashes can still happen. With this change and the latest changes in https://github.com/gazebosim/gz-sim/pull/1807, I can no longer get gz-sim to crash.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

