### PR TITLE
Add message to see troubleshooting page when render engine fails to create dummy window

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -913,6 +913,9 @@ void Ogre2RenderEngine::CreateRenderWindow()
   if (res.empty())
   {
     ignerr << "Failed to create dummy render window." << std::endl;
+    ignerr << "Please see the troubleshooting page for possible fixes: "
+           << "https://gazebosim.org/docs/fortress/troubleshooting"
+           << std::endl;
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The same message was added in https://github.com/gazebosim/gz-rendering/pull/793. The render engine can actual fail before that when it tries to create the dummy render window. So added another message when that fails.

Related PR: https://github.com/gazebosim/docs/pull/347

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

