### PR TITLE
Use std::vector instead of std::map in BaseStorage

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -12,6 +12,14 @@ release will remove the deprecated code.
     + Deprecated: `HAVE_OGRE`, `HAVE_OGRE2` `HAVE_OPTIX`
     + Replacement: `GZ_RENDERING_HAVE_OGRE`, `GZ_RENDERING_HAVE_OGRE2` `GZ_RENDERING_HAVE_OPTIX`
 
+### Modifications
+1. The BaseStore internal data structure has changed from an std::map to an
+   std::vector for performance consideration. This means iterators returned by
+   BaseStore APIs such as `IterByIndex` may now be different from before since
+   the order of objects stored in maps and vectors are different. The iterators
+   returned may also change or become invalid when objects are added or removed
+   from the store.
+
 ## Gazebo Rendering 6.x to 7.x
 
 ### Deprecations

--- a/include/gz/rendering/base/BaseStorage.hh
+++ b/include/gz/rendering/base/BaseStorage.hh
@@ -165,21 +165,61 @@ namespace gz
       /// \returns Iterator to end
       public: virtual UIter End();
 
+      /// \brief Get a const iterator to the object by pointer.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _object Object pointer
+      /// \return Const iterator to the object
       protected: virtual ConstUIter ConstIter(ConstTPtr _object) const;
 
+      /// \brief Get a const iterator to the object by id.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _id Object id
+      /// \return Const iterator to the object
       protected: virtual ConstUIter ConstIterById(unsigned int _id) const;
 
+      /// \brief Get a const iterator to the object by name.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _name Object name
+      /// \return Const iterator to the object
       protected: virtual ConstUIter ConstIterByName(
                      const std::string &_name) const;
 
+      /// \brief Get a const iterator to the object by index.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _index Object index
+      /// \return Const iterator to the object
       protected: virtual ConstUIter ConstIterByIndex(unsigned int _index) const;
 
+      /// \brief Get an iterator to the object by pointer.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _object Object pointer
+      /// \return Iterator to the object
       protected: virtual UIter Iter(ConstTPtr _object);
 
+      /// \brief Get an iterator to the object by id.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _id Object id
+      /// \return Iterator to the object
       protected: virtual UIter IterById(unsigned int _id);
 
+      /// \brief Get an iterator to the object by name.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _name Object name
+      /// \return Iterator to the object
       protected: virtual UIter IterByName(const std::string &_name);
 
+      /// \brief Get an iterator to the object by index.
+      /// Note that the iterator may change or become invalid when objects are
+      /// added to / removed from the store.
+      /// \param[in] _index Object index
+      /// \return Iterator to the object
       protected: virtual UIter IterByIndex(unsigned int _index);
 
       protected: virtual bool AddImpl(UPtr _object);

--- a/include/gz/rendering/base/BaseStorage.hh
+++ b/include/gz/rendering/base/BaseStorage.hh
@@ -94,7 +94,8 @@ namespace gz
 
       typedef std::shared_ptr<U> UPtr;
 
-      typedef std::map<std::string, UPtr> UStore;
+      typedef std::map<std::string, int> UStoreMap;
+      typedef std::vector<UPtr> UStore;
 
       typedef typename UStore::iterator UIter;
 
@@ -192,6 +193,7 @@ namespace gz
       protected: virtual UIter RemoveConstness(ConstUIter _iter);
 
       protected: UStore store;
+      protected: UStoreMap storeMap;
     };
 
     //////////////////////////////////////////////////
@@ -689,6 +691,7 @@ namespace gz
     void BaseStore<T, U>::RemoveAll()
     {
       this->store.clear();
+      this->storeMap.clear();
     }
 
     //////////////////////////////////////////////////
@@ -741,7 +744,7 @@ namespace gz
     BaseStore<T, U>::DerivedById(unsigned int _id) const
     {
       auto iter = this->ConstIterById(_id);
-      return (this->IsValidIter(iter)) ? iter->second : nullptr;
+      return (this->IsValidIter(iter)) ? *iter : nullptr;
     }
 
     //////////////////////////////////////////////////
@@ -750,7 +753,7 @@ namespace gz
     BaseStore<T, U>::DerivedByName(const std::string &_name) const
     {
       auto iter = this->ConstIterByName(_name);
-      return (this->IsValidIter(iter)) ? iter->second : nullptr;
+      return (this->IsValidIter(iter)) ? *iter : nullptr;
     }
 
     //////////////////////////////////////////////////
@@ -759,7 +762,7 @@ namespace gz
     BaseStore<T, U>::DerivedByIndex(unsigned int _index) const
     {
       auto iter = this->ConstIterByIndex(_index);
-      return (this->IsValidIter(iter)) ? iter->second : nullptr;
+      return (this->IsValidIter(iter)) ? *iter : nullptr;
     }
 
     //////////////////////////////////////////////////
@@ -821,7 +824,7 @@ namespace gz
 
       for (auto iter = begin; iter != end; ++iter)
       {
-        if (iter->second == _object)
+        if (*iter == _object)
         {
           return iter;
         }
@@ -840,7 +843,7 @@ namespace gz
 
       for (auto iter = begin; iter != end; ++iter)
       {
-        if (iter->second->Id() == _id)
+        if ((*iter)->Id() == _id)
         {
           return iter;
         }
@@ -854,7 +857,12 @@ namespace gz
     typename BaseStore<T, U>::ConstUIter
     BaseStore<T, U>::ConstIterByName(const std::string &_name) const
     {
-      return this->store.find(_name);
+      auto idx = this->storeMap.find(_name);
+      if (idx == this->storeMap.end())
+      {
+        return this->store.end();
+      }
+      return ConstIterByIndex(idx->second);
     }
 
     //////////////////////////////////////////////////
@@ -929,7 +937,8 @@ namespace gz
         return false;
       }
 
-      this->store[name] = _object;
+      this->storeMap[name] = this->store.size();
+      this->store.emplace_back(_object);
       return true;
     }
 
@@ -943,7 +952,20 @@ namespace gz
         return nullptr;
       }
 
-      UPtr result = _iter->second;
+
+      auto idx = std::distance(this->store.begin(), _iter);
+      std::string nameToErase;
+      for (auto &[name, objIdx] : this->storeMap)
+      {
+        if (objIdx == idx)
+          nameToErase = name;
+
+        if (objIdx >= idx)
+          objIdx--;
+      }
+      this->storeMap.erase(nameToErase);
+
+      UPtr result = *_iter;
       this->store.erase(_iter);
       return result;
     }

--- a/include/gz/rendering/base/BaseVisual.hh
+++ b/include/gz/rendering/base/BaseVisual.hh
@@ -281,8 +281,7 @@ namespace gz
       }
       for (auto it = children_->Begin(); it != children_->End(); ++it)
       {
-        NodePtr child = it->second;
-        VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+        VisualPtr visual = std::dynamic_pointer_cast<Visual>(*it);
         if (visual) visual->SetMaterial(_material, false);
       }
     }
@@ -341,7 +340,7 @@ namespace gz
       }
       for (auto it = children_->Begin(); it != children_->End(); ++it)
       {
-        it->second->PreRender();
+        (*it)->PreRender();
       }
     }
 
@@ -416,8 +415,7 @@ namespace gz
       }
       for (auto it = childNodes->Begin(); it != childNodes->End(); ++it)
       {
-        NodePtr child = it->second;
-        VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+        VisualPtr visual = std::dynamic_pointer_cast<Visual>(*it);
         if (visual)
         {
           gz::math::AxisAlignedBox aabb = visual->LocalBoundingBox();
@@ -445,8 +443,7 @@ namespace gz
       }
       for (auto it = childNodes->Begin(); it != childNodes->End(); ++it)
       {
-        NodePtr child = it->second;
-        VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+        VisualPtr visual = std::dynamic_pointer_cast<Visual>(*it);
         if (visual)
           box.Merge(visual->BoundingBox());
       }
@@ -484,8 +481,7 @@ namespace gz
       }
       for (auto it = childNodes->Begin(); it != childNodes->End(); ++it)
       {
-        NodePtr child = it->second;
-        VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+        VisualPtr visual = std::dynamic_pointer_cast<Visual>(*it);
         if (visual)
           visual->SetVisibilityFlags(_flags);
       }
@@ -548,8 +544,7 @@ namespace gz
       }
       for (auto it = children_->Begin(); it != children_->End(); ++it)
       {
-        NodePtr child = it->second;
-        VisualPtr visual = std::dynamic_pointer_cast<Visual>(child);
+        VisualPtr visual = std::dynamic_pointer_cast<Visual>(*it);
         // recursively delete all cloned visuals if the child cannot be
         // retrieved, or if cloning the child visual failed
         if (!visual || !visual->Clone("", result))

--- a/ogre/src/OgreVisual.cc
+++ b/ogre/src/OgreVisual.cc
@@ -288,8 +288,7 @@ void OgreVisual::BoundsHelper(gz::math::AxisAlignedBox &_box,
 
   for (auto it = childNodes->Begin(); it != childNodes->End(); ++it)
   {
-    NodePtr child = it->second;
-    OgreVisualPtr visual = std::dynamic_pointer_cast<OgreVisual>(child);
+    OgreVisualPtr visual = std::dynamic_pointer_cast<OgreVisual>(*it);
     if (visual)
       visual->BoundsHelper(_box, _local, _pose);
   }

--- a/ogre2/src/Ogre2Visual.cc
+++ b/ogre2/src/Ogre2Visual.cc
@@ -301,8 +301,7 @@ void Ogre2Visual::BoundsHelper(gz::math::AxisAlignedBox &_box,
 
   for (auto it = childNodes->Begin(); it != childNodes->End(); ++it)
   {
-    NodePtr child = it->second;
-    Ogre2VisualPtr visual = std::dynamic_pointer_cast<Ogre2Visual>(child);
+    Ogre2VisualPtr visual = std::dynamic_pointer_cast<Ogre2Visual>(*it);
     if (visual)
       visual->BoundsHelper(_box, _local, _pose);
   }

--- a/test/common_test/Scene_TEST.cc
+++ b/test/common_test/Scene_TEST.cc
@@ -333,7 +333,7 @@ TEST_F(SceneTest, DestroyNodes)
   EXPECT_EQ(4u, scene->VisualCount());
 
   // Destroy a child visual by index
-  scene->DestroyVisualByIndex(0u);
+  scene->DestroyVisualByIndex(1u);
   EXPECT_FALSE(parent->HasChild(child02));
   EXPECT_FALSE(scene->HasVisual(child02));
   EXPECT_EQ(2u, parent->ChildCount());


### PR DESCRIPTION
# 🎉 New feature

## Summary

Most of the time the `store` std::map inside BaseStorage is iterated over, which is not as efficient as a std::vector.
 
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.