### PR TITLE
 Fix deleting ogre2 when created (and deleted) in a thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,9 @@ if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
   set(OpenGL_GL_PREFERENCE "GLVND")
 endif()
 
-gz_find_package(OpenGL
+gz_find_package(OpenGL REQUIRED
+  COMPONENTS OpenGL
+  OPTIONAL_COMPONENTS EGL
   REQUIRED_BY ogre ogre2
   PKGCONFIG gl)
 

--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -47,6 +47,14 @@ target_link_libraries(${ogre2_target}
     terra
     GzOGRE2::GzOGRE2)
 
+if (TARGET OpenGL::EGL)
+  target_link_libraries(${ogre2_target}
+  PRIVATE
+      OpenGL::EGL
+  )
+  add_definitions(-DHAVE_EGL=1)
+endif()
+
 set (versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
 set (unversioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_NO_VERSION_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})
 

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -50,6 +50,10 @@
 # include <GL/glxext.h>
 #endif
 
+#if HAVE_EGL
+  #include <EGL/egl.h>
+#endif
+
 class GZ_RENDERING_OGRE2_HIDDEN
     gz::rendering::Ogre2RenderEnginePrivate
 {
@@ -146,6 +150,12 @@ void Ogre2RenderEngine::Destroy()
 
   this->dataPtr->hlmsPbsTerraShadows.reset();
 
+  if (this->window)
+  {
+    this->window->destroy();
+    this->window = nullptr;
+  }
+
   if (this->ogreRoot)
   {
     // Clean up any textures that may still be in flight.
@@ -166,6 +176,7 @@ void Ogre2RenderEngine::Destroy()
     }
     catch (...)
     {
+      gzerr << "Error deleting ogre root " << std::endl;
     }
     this->ogreRoot = nullptr;
   }
@@ -192,6 +203,12 @@ void Ogre2RenderEngine::Destroy()
       this->dataPtr->dummyFBConfigs = nullptr;
     }
   }
+#endif
+
+#if HAVE_EGL
+  // release egl per-thread state otherwise this causes a crash on exit if
+  // ogre is created and deleted in a thread
+  eglReleaseThread();
 #endif
 }
 
@@ -391,6 +408,7 @@ void Ogre2RenderEngine::LoadAttempt()
   {
     this->CreateContext();
   }
+
   this->CreateRoot();
   this->CreateOverlay();
   this->LoadPlugins();
@@ -1043,7 +1061,7 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
 {
   Ogre::StringVector paramsVector;
   Ogre::NameValuePairList params;
-  window = nullptr;
+  this->window = nullptr;
 
   if (this->dataPtr->graphicsAPI == GraphicsAPI::VULKAN)
   {
@@ -1103,19 +1121,18 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
 #endif
 
   int attempts = 0;
-  while (window == nullptr && (attempts++) < 10)
+  while (this->window == nullptr && (attempts++) < 10)
   {
     try
     {
-      window = Ogre::Root::getSingleton().createRenderWindow(
+      this->window = Ogre::Root::getSingleton().createRenderWindow(
           stream.str(), _width, _height, false, &params);
-      this->RegisterHlms();
     }
     catch(const std::exception &_e)
     {
       gzerr << " Unable to create the rendering window: " << _e.what()
              << std::endl;
-      window = nullptr;
+      this->window = nullptr;
     }
   }
 
@@ -1126,12 +1143,14 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
     return std::string();
   }
 
-  if (window)
+  this->RegisterHlms();
+
+  if (this->window)
   {
-    window->_setVisible(true);
+    this->window->_setVisible(true);
 
     // Windows needs to reposition the render window to 0,0.
-    window->reposition(0, 0);
+    this->window->reposition(0, 0);
   }
   return stream.str();
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -9,10 +9,11 @@ set(tests
   lidar_visual
   render_pass
   scene
-  segmentation_camera 
-  shadows 
+  segmentation_camera
+  shadows
   sky
   thermal_camera
+  load_unload
   wide_angle_camera
 )
 

--- a/test/integration/load_unload.cc
+++ b/test/integration/load_unload.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include "CommonRenderingTest.hh"
+
+class LoadUnloadTest : public testing::Test
+{
+  public: void RenderThread()
+  {
+    gz::common::Console::SetVerbosity(4);
+
+    auto [envEngine, envBackend, envHeadless] = GetTestParams();
+
+    if (envEngine.empty())
+    {
+      GTEST_SKIP() << kEngineToTestEnv << " environment not set";
+    }
+
+    auto engineParams = GetEngineParams(envEngine, envBackend, envHeadless);
+    gz::rendering::RenderEngine *engine =
+        gz::rendering::engine(envEngine, engineParams);
+    if (!engine)
+    {
+      GTEST_SKIP() << "Engine '" << envEngine << "' could not be loaded" << std::endl;
+    }
+
+    gz::rendering::unloadEngine(envEngine);
+  }
+};
+
+/////////////////////////////////////////////////
+TEST_F(LoadUnloadTest, Thread)
+{
+  // verify that we can load and unload the render engine in a thread
+  std::thread renderThread = std::thread(&LoadUnloadTest::RenderThread, this);
+  EXPECT_TRUE(renderThread.joinable());
+  EXPECT_NO_THROW(renderThread.join());
+}
+
+

--- a/test/integration/load_unload.cc
+++ b/test/integration/load_unload.cc
@@ -21,6 +21,7 @@
 
 class LoadUnloadTest : public testing::Test
 {
+  /// \brief A thread that loads and unloads the render engine
   public: void RenderThread()
   {
     gz::common::Console::SetVerbosity(4);
@@ -37,7 +38,8 @@ class LoadUnloadTest : public testing::Test
         gz::rendering::engine(envEngine, engineParams);
     if (!engine)
     {
-      GTEST_SKIP() << "Engine '" << envEngine << "' could not be loaded" << std::endl;
+      GTEST_SKIP() << "Engine '" << envEngine << "' could not be loaded"
+                   << std::endl;
     }
 
     gz::rendering::unloadEngine(envEngine);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

I ran into a crash in gz-sim on exit after unloading the ogre2 render engine. It was found that it only happens if ogre-next is built with EGL support **and** the engine is created / deleted in a thread. The fix is to make sure EGL returns to its original state, specifically by calling `eglReleaseThread()` after deleting ogre root.

The fix this PR make EGL calls which requires including and linking against the EGL library, hence the extra cmake code. The proper fix may be to do this inside ogre.

To Test:

Run the `INTEGRATION_load_unload` test

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

