### PR TITLE
Limit eglReleaseThread call to GL render system

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -208,7 +208,9 @@ void Ogre2RenderEngine::Destroy()
 #if HAVE_EGL
   // release egl per-thread state otherwise this causes a crash on exit if
   // ogre is created and deleted in a thread
-  eglReleaseThread();
+  // Do this only if we are using GL
+  if (this->dataPtr->graphicsAPI == GraphicsAPI::OPENGL)
+    eglReleaseThread();
 #endif
 }
 

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -150,12 +150,6 @@ void Ogre2RenderEngine::Destroy()
 
   this->dataPtr->hlmsPbsTerraShadows.reset();
 
-  if (this->window)
-  {
-    this->window->destroy();
-    this->window = nullptr;
-  }
-
   if (this->ogreRoot)
   {
     // Clean up any textures that may still be in flight.

--- a/test/integration/load_unload.cc
+++ b/test/integration/load_unload.cc
@@ -16,6 +16,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <gz/utils/ExtraTestMacros.hh>
 
 #include "CommonRenderingTest.hh"
 

--- a/test/integration/load_unload.cc
+++ b/test/integration/load_unload.cc
@@ -47,7 +47,7 @@ class LoadUnloadTest : public testing::Test
 };
 
 /////////////////////////////////////////////////
-TEST_F(LoadUnloadTest, Thread)
+TEST_F(LoadUnloadTest, GZ_UTILS_TEST_DISABLED_ON_MAC(Thread))
 {
   // verify that we can load and unload the render engine in a thread
   std::thread renderThread = std::thread(&LoadUnloadTest::RenderThread, this);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Follow up to https://github.com/gazebosim/gz-rendering/pull/840. Fixes crash on macOS as mentioned in https://github.com/gazebosim/gz-rendering/pull/840#issuecomment-1500721820

This PR fixes the test failures by:
* Calling `eglReleaseThread` only when necessary
* Removing `window->destroy()`, this should be handled when ogre is deleted so we're just calling it twice.
* Disabling the `load_unload` test on mac - creating/deleting the render engine in a separate thread causes an issue on mac (but works on linux and win) - this needs to be further investigated. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

