### PR TITLE
Fix requiring OpenGL on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,17 @@ if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
   set(OpenGL_GL_PREFERENCE "GLVND")
 endif()
 
-gz_find_package(OpenGL REQUIRED
-  COMPONENTS OpenGL
-  OPTIONAL_COMPONENTS EGL
-  REQUIRED_BY ogre ogre2
-  PKGCONFIG gl)
+if (APPLE)
+  gz_find_package(OpenGL
+    REQUIRED_BY ogre ogre2
+    PKGCONFIG gl)
+else()
+  gz_find_package(OpenGL REQUIRED
+    COMPONENTS OpenGL
+    OPTIONAL_COMPONENTS EGL
+    REQUIRED_BY ogre ogre2
+    PKGCONFIG gl)
+endif()
 
 if (OpenGL_FOUND)
   set(HAVE_OPENGL TRUE)


### PR DESCRIPTION
# 🦟 Bug fix

Related: https://github.com/osrf/homebrew-simulation/pull/2237#issuecomment-1518890616

## Summary
https://github.com/gazebosim/gz-rendering/pull/840 explicitly made OpenGL a required component but that broke pkg-config in homebrew. This PR reverts the change for macOS. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

