### PR TITLE
Fix visibility decorator of Ogre2Projector

### DIFF
--- a/ogre2/include/gz/rendering/ogre2/Ogre2Projector.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Projector.hh
@@ -23,7 +23,7 @@
 #include "gz/rendering/config.hh"
 
 #include "gz/rendering/base/BaseProjector.hh"
-#include "gz/rendering/ogre/Export.hh"
+#include "gz/rendering/ogre2/Export.hh"
 #include "gz/rendering/ogre2/Ogre2Visual.hh"
 
 namespace gz
@@ -33,7 +33,7 @@ namespace gz
     inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
     /// \brief Ogre 2.x implementation of a Projector class.
-    class GZ_RENDERING_OGRE_VISIBLE Ogre2Projector :
+    class GZ_RENDERING_OGRE2_VISIBLE Ogre2Projector :
       public BaseProjector<Ogre2Visual>
     {
       /// \brief Constructor.


### PR DESCRIPTION


# 🦟 Bug fix

Fix visibility decorator of Ogre2Projector class.

## Summary

`Ogre2Projector` was decorated by `GZ_RENDERING_OGRE_VISIBLE` instead of `GZ_RENDERING_OGRE2_VISIBLE`, probably a copy&paste error.

I noticed this as by building `gz-rendering` with `SKIP_ogre`, the build was failing with:
~~~
In file included from /home/traversaro/gz-ws/src/gz-rendering/ogre2/src/Ogre2Projector.cc:30:
/home/traversaro/gz-ws/src/gz-rendering/ogre2/include/gz/rendering/ogre2/Ogre2Projector.hh:26:10: fatal error: gz/rendering/ogre/Export.hh: No such file or directory
   26 | #include "gz/rendering/ogre/Export.hh"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
~~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

