### PR TITLE
OgreNext: Fix shaders compilation on d3d12 mesa driver (WSLg)

### DIFF
--- a/ogre2/src/media/2.0/scripts/materials/Common/GLSL/GaussianBlurBase_cs.glsl
+++ b/ogre2/src/media/2.0/scripts/materials/Common/GLSL/GaussianBlurBase_cs.glsl
@@ -1,5 +1,11 @@
 @property( syntax != glslvk )
-	#version 430
+	@property( GL3+ >= 430 )
+		#version 430
+	@else
+		#version 420
+		#extension GL_ARB_arrays_of_arrays: enable
+		#extension GL_ARB_compute_shader: enable
+	@end
 @else
 	#version 450
 @end

--- a/ogre2/src/media/2.0/scripts/materials/Terra/GLSL/TerraShadowGenerator.glsl
+++ b/ogre2/src/media/2.0/scripts/materials/Terra/GLSL/TerraShadowGenerator.glsl
@@ -1,5 +1,10 @@
 @property( syntax != glslvk )
-	#version 430
+	@property( GL3+ >= 430 )
+		#version 430
+	@else
+		#version 420
+		#extension GL_ARB_compute_shader: enable
+	@end
 	#define ogre_B0 binding = 0
 	#define ogre_B1 binding = 1
 @else

--- a/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -6,6 +6,10 @@
 		#version 430 core
 	@else
 		#version 330 core
+
+		@property( !hlms_readonly_is_tex )
+			#extension GL_ARB_shader_storage_buffer_object: require
+		@end
 	@end
 @end
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes part of https://github.com/gazebosim/gz-sim/issues/920 and of https://github.com/gazebosim/gz-rendering/issues/852 .

## Summary

Old GPUs and systems with incomplete GL implementations like WSLg would trigger shader compiler errors for several reasons:
* because C++ saw that GL_ARB_shader_storage_buffer_object was supported but we didn't request it in the shader.
* because C++ required the use of GLSL 4.30 (not supported by d3d12 as of 2023/05), even if GLSL 4.20 plus some extensions would also work fine.

This was tested on both mesa 22.2.5 and 23.1.0 .

The fix is actually from @darksylinc, see https://github.com/OGRECave/ogre-next/commit/5b6d444ece12a32ed8115c22650c2c79cb54c8e1 and https://github.com/OGRECave/ogre-next/commit/3d9d380683cdd3fb252d754c4e40d01dfa81a3aa for the original commits.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
