### PR TITLE
Fix missing cstdint header in latest gcc build

### DIFF
--- a/include/gz/rendering/GraphicsAPI.hh
+++ b/include/gz/rendering/GraphicsAPI.hh
@@ -18,6 +18,7 @@
 #define GZ_RENDERING_GRAPHICSAPI_HH_
 
 #include <string>
+#include <cstdint>
 #include "gz/rendering/config.hh"
 #include "gz/rendering/Export.hh"
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Same as gazebosim/gz-common#512, build fails on GCC 13.1.1 due to a missing `<cstdint>` header.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Adds missing `<cstdint>` to `GraphicsAPI.hh`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.