### PR TITLE
Minor cleanup of ogre/ogre2

### DIFF
--- a/ogre/src/OgreProjector.cc
+++ b/ogre/src/OgreProjector.cc
@@ -444,7 +444,7 @@ std::unordered_set<std::string> OgreProjectorListener::FindVisibleMaterials()
 /////////////////////////////////////////////////
 void OgreProjectorListener::AddDecalToVisibleMaterials()
 {
-  auto newVisibleMaterials = std::move(this->FindVisibleMaterials());
+  auto newVisibleMaterials = this->FindVisibleMaterials();
 
   this->AddDecalToMaterials(newVisibleMaterials);
 }
@@ -652,8 +652,7 @@ void OgreProjectorListener::SetVisibilityFlags(uint32_t _flags)
 /////////////////////////////////////////////////
 void OgreProjectorListener::UpdateVisibleMaterials()
 {
-  this->visibleMaterials =
-      std::move(this->FindVisibleMaterials());
+  this->visibleMaterials = this->FindVisibleMaterials();
 }
 
 /////////////////////////////////////////////////

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -843,5 +843,5 @@ OgreRenderEngine *OgreRenderEngine::Instance()
 }
 
 // Register this plugin
-GZ_ADD_PLUGIN(OgreRenderEnginePlugin,
+GZ_ADD_PLUGIN(rendering::OgreRenderEnginePlugin,
               rendering::RenderEnginePlugin)

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -128,8 +128,6 @@ void Ogre2RayQuery::SetFromCamera(const CameraPtr &_camera,
 //////////////////////////////////////////////////
 RayQueryResult Ogre2RayQuery::ClosestPoint(bool _forceSceneUpdate)
 {
-  RayQueryResult result;
-
   if (!this->dataPtr->camera ||
       !this->dataPtr->camera->Parent() ||
       std::this_thread::get_id() != this->dataPtr->threadId)

--- a/ogre2/src/terrain/Terra/src/Terra.cpp
+++ b/ogre2/src/terrain/Terra/src/Terra.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
 #include "Terra/TerraShadowMapper.h"
 #include "Terra/Hlms/OgreHlmsTerra.h"
+#include "Terra/Hlms/OgreHlmsTerraDatablock.h"
 
 #include "OgreImage2.h"
 


### PR DESCRIPTION
- Remove std::move for temporary returned from OgreProjectorListener::FindVisibleMaterials
- Fix namespace for OgreRenderEngine plugin registration
- Fix unused variable in ogre2/src/Ogre2RayQuery.cc
- Add missing header Terra/Hlms/OgreHlmsTerraDatablock.h in ogre2/src/terrain/Terra/src/Terra.cpp
