### PR TITLE
Fix calling GpuRays::Destroy more than once

### DIFF
--- a/ogre/src/OgreGpuRays.cc
+++ b/ogre/src/OgreGpuRays.cc
@@ -163,6 +163,9 @@ void OgreGpuRays::Init()
 //////////////////////////////////////////////////
 void OgreGpuRays::Destroy()
 {
+  if (!this->dataPtr->ogreCamera)
+    return;
+
   if (this->dataPtr->gpuRaysBuffer)
   {
     delete [] this->dataPtr->gpuRaysBuffer;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fixes gz-sensors' `INTEGRATION_dvl` test with ogre on Harmonic

The test has been failing (crashing) on homebrew CI which runs test with `ogre`. I was able to reproduce the crash and found that the issue is due to the ogre node being destroyed twice on the rendering side. Added a check to make sure we return from the `Destroy` function if camera is null (indicates resources have been removed already). The same check [exists](https://github.com/gazebosim/gz-rendering/blob/b32cbd37bbfbac9e4c3db3e66171044f4ab14754/ogre2/src/Ogre2GpuRays.cc#L588) in the ogre2 version.

To reproduce the test failure in Harmonic workspace:

```
RENDER_ENGINE_VALUES=ogre ./build/gz-sensors8/bin/INTEGRATION_dvl
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

