### PR TITLE
Destroy sensor node on exit

### DIFF
--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -61,6 +61,14 @@ void OgreCamera::Destroy()
       this->ogreCamera = nullptr;
     }
   }
+
+  if (this->selectionBuffer)
+  {
+    delete this->selectionBuffer;
+    this->selectionBuffer = nullptr;
+  }
+
+  BaseCamera::Destroy();
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreGpuRays.cc
+++ b/ogre/src/OgreGpuRays.cc
@@ -163,6 +163,9 @@ void OgreGpuRays::Init()
 //////////////////////////////////////////////////
 void OgreGpuRays::Destroy()
 {
+  if (!this->dataPtr->ogreCamera)
+    return;
+
   if (this->dataPtr->gpuRaysBuffer)
   {
     delete [] this->dataPtr->gpuRaysBuffer;
@@ -235,6 +238,8 @@ void OgreGpuRays::Destroy()
 
   this->dataPtr->texIdx.clear();
   this->dataPtr->texCount = 0u;
+
+  BaseGpuRays::Destroy();
 }
 
 /////////////////////////////////////////////////

--- a/ogre/src/OgreSelectionBuffer.cc
+++ b/ogre/src/OgreSelectionBuffer.cc
@@ -124,7 +124,10 @@ void OgreSelectionBuffer::DeleteRTTBuffer()
     this->dataPtr->buffer = nullptr;
   }
   if (this->dataPtr->pixelBox)
+  {
     delete this->dataPtr->pixelBox;
+    this->dataPtr->pixelBox = nullptr;
+  }
 }
 
 /////////////////////////////////////////////////

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -344,6 +344,8 @@ void OgreThermalCamera::Destroy()
       this->ogreCamera = nullptr;
     }
   }
+
+  BaseThermalCamera::Destroy();
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -144,6 +144,9 @@ void OgreWideAngleCamera::PreRender()
 //////////////////////////////////////////////////
 void OgreWideAngleCamera::Destroy()
 {
+  if (!this->dataPtr->ogreCamera)
+    return;
+
   if (this->dataPtr->imageBuffer)
   {
     delete [] this->dataPtr->imageBuffer;
@@ -180,6 +183,13 @@ void OgreWideAngleCamera::Destroy()
     }
   }
 
+  if (this->dataPtr->ogreCamera)
+  {
+    this->scene->OgreSceneManager()->destroyCamera(
+        this->dataPtr->ogreCamera->getName());
+    this->dataPtr->ogreCamera = nullptr;
+  }
+
   if (this->dataPtr->envCubeMapTexture)
   {
     Ogre::TextureManager::getSingleton().remove(
@@ -200,6 +210,8 @@ void OgreWideAngleCamera::Destroy()
         this->dataPtr->compMat->getName());
     this->dataPtr->compMat.setNull();
   }
+
+  BaseWideAngleCamera::Destroy();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -71,6 +71,14 @@ void Ogre2Camera::Destroy()
     ogreSceneManager->destroyCamera(this->ogreCamera);
     this->ogreCamera = nullptr;
   }
+
+  if (this->selectionBuffer)
+  {
+    delete this->selectionBuffer;
+    this->selectionBuffer = nullptr;
+  }
+
+  BaseCamera::Destroy();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -358,6 +358,8 @@ void Ogre2DepthCamera::Destroy()
       this->ogreCamera = nullptr;
     }
   }
+
+  BaseDepthCamera::Destroy();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -153,6 +153,8 @@ void Ogre2SegmentationCamera::Destroy()
   }
 
   this->dataPtr->materialSwitcher.reset();
+
+  BaseCamera::Destroy();
 }
 
 /////////////////////////////////////////////////

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -208,11 +208,19 @@ void Ogre2SelectionBuffer::DeleteRTTBuffer()
     this->dataPtr->ogreCompositorWorkspace = nullptr;
   }
 
-  auto engine = Ogre2RenderEngine::Instance();
-  auto ogreRoot = engine->OgreRoot();
-  ogreRoot->getRenderSystem()->getTextureGpuManager()->destroyTexture(
-    this->dataPtr->renderTexture);
-  this->dataPtr->renderTexture = nullptr;
+  if (this->dataPtr->renderTexture)
+  {
+    auto engine = Ogre2RenderEngine::Instance();
+    auto ogreRoot = engine->OgreRoot();
+    Ogre::TextureGpuManager *textureMgr =
+      ogreRoot->getRenderSystem()->getTextureGpuManager();
+    if (textureMgr->findTextureNoThrow(
+        this->dataPtr->renderTexture->getName()))
+    {
+      textureMgr->destroyTexture(this->dataPtr->renderTexture);
+      this->dataPtr->renderTexture = nullptr;
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -780,6 +780,8 @@ void Ogre2ThermalCamera::Destroy()
   }
 
   this->dataPtr->thermalMaterialSwitcher.reset();
+
+  BaseThermalCamera::Destroy();
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
Cleanup minor memory leaks when a sensor is destroyed:
* Adds a call to `Base*::Destroy` when a sensor is destroyed - this eventually calls `BaseNode::Destroy` which makes sure the `ogreNode` is [destroyed](https://github.com/gazebosim/gz-rendering/blob/4a1d9af9b08340955ba40e8e3cf680f5852473e8/ogre2/src/Ogre2Node.cc#L77`)
    * Note: some sensor classes already includes the call to `BaseNode::Destroy`, e.g. [Ogre2GpuRays](https://github.com/gazebosim/gz-rendering/blob/4a1d9af9b08340955ba40e8e3cf680f5852473e8/ogre2/src/Ogre2GpuRays.cc#L684). This PR adds the call to all other classes.
* Deletes the selection buffer in Camera sensor

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

