### PR TITLE
Restore missing Ogre2Heightmap::DestroyImpl implementation

### DIFF
--- a/ogre2/src/Ogre2Heightmap.cc
+++ b/ogre2/src/Ogre2Heightmap.cc
@@ -76,6 +76,13 @@ Ogre2Heightmap::Ogre2Heightmap(const HeightmapDescriptor &_desc)
 //////////////////////////////////////////////////
 Ogre2Heightmap::~Ogre2Heightmap()
 {
+  this->DestroyImpl();
+}
+
+//////////////////////////////////////////////////
+void Ogre2Heightmap::DestroyImpl()
+{
+  this->dataPtr->terra.reset();
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Added missing  `Ogre2Heightmap::DestroyImpl` implementation. The changes were added to `ign-rendering6` branch in https://github.com/gazebosim/gz-rendering/pull/670 but looks like they got lost in the 6->7 merge.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

