### PR TITLE
Address todo in Ogre2ParticleEmitter - override PreRender function

### DIFF
--- a/ogre2/include/gz/rendering/ogre2/Ogre2ParticleEmitter.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2ParticleEmitter.hh
@@ -86,15 +86,14 @@ namespace gz
       public: virtual void SetColorRangeImage(const std::string &_image)
           override;
 
+      // Documentation inherited.
+      public: virtual void PreRender() override;
+
       /// \brief Particle system visibility flags
       public: static const uint32_t kParticleVisibilityFlags;
 
       // Documentation inherited.
       protected: virtual void Init() override;
-
-      /// \brief Internal pre-render function added to avoid breaking ABI
-      /// compatibility
-      private: void PreRenderImpl();
 
       /// \brief Create the particle system
       private: void CreateParticleSystem();

--- a/ogre2/src/Ogre2ParticleEmitter.cc
+++ b/ogre2/src/Ogre2ParticleEmitter.cc
@@ -131,10 +131,8 @@ void Ogre2ParticleEmitter::SetType(
   this->type = _type;
 
   this->dataPtr->emitterDirty = true;
-  // todo(anyone) remove this call. We had to do this since we can't override
-  // PreRender() as it breaks ABI. We should rename PreRenderImpl to PreRender()
-  // in next release.
-  this->PreRenderImpl();
+  // Call PreRender to re-create the particle emitter
+  this->PreRender();
 }
 
 //////////////////////////////////////////////////
@@ -243,10 +241,6 @@ void Ogre2ParticleEmitter::SetParticleSize(
   this->particleSize = _size;
 
   this->dataPtr->emitterDirty = true;
-  // todo(anyone) remove this call. We had to do this since we can't override
-  // PreRender() as it breaks ABI. We should rename PreRenderImpl to PreRender()
-  // in next release.
-  this->PreRenderImpl();
 }
 
 //////////////////////////////////////////////////
@@ -434,12 +428,8 @@ void Ogre2ParticleEmitter::Init()
 }
 
 //////////////////////////////////////////////////
-void Ogre2ParticleEmitter::PreRenderImpl()
+void Ogre2ParticleEmitter::PreRender()
 {
-  // todo(anyone) rename this function to PreRender() so it overrides function
-  // from base class. Since this rename breaks ABI, we should rename this
-  // function in the next release
-
   // recreate the particle system if needed
   // currently this is needed when user changes type or particle size
   if (this->dataPtr->emitterDirty)


### PR DESCRIPTION

# 🦟 Bug fix


## Summary
Address todo note about an ABI breaking change in Ogre2ParticleEmitter class. 



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

