### PR TITLE
Remove RenderEngineManager's inheritance from Singleton base class

### DIFF
--- a/include/gz/rendering/RenderEngineManager.hh
+++ b/include/gz/rendering/RenderEngineManager.hh
@@ -43,8 +43,7 @@ namespace gz
     /// render-engines available at runtime. RenderEngine objects should not
     /// be access directly, but instead via the RenderEngineManager to maintain
     /// a flexible render-engine agnostic design.
-    class GZ_RENDERING_VISIBLE RenderEngineManager :
-      public virtual common::SingletonT<RenderEngineManager>
+    class GZ_RENDERING_VISIBLE RenderEngineManager
     {
       /// \brief Constructor
       public: RenderEngineManager();
@@ -136,7 +135,6 @@ namespace gz
       public: void SetPluginPaths(const std::list<std::string> &_paths);
 
       /// \brief Get a pointer to the render engine manager
-      /// \todo(anyone) Remove inheritance from Singleton base class
       /// \return a pointer to the render engine manager
       public: static RenderEngineManager *Instance();
 

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -386,7 +386,7 @@ void RenderEngineManager::SetPluginPaths(const std::list<std::string> &_paths)
 //////////////////////////////////////////////////
 RenderEngineManager *RenderEngineManager::Instance()
 {
-  return SingletonT<RenderEngineManager>::Instance();
+  return gz::common::SingletonT<RenderEngineManager>::Instance();
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Related PR: https://github.com/gazebosim/gz-rendering/pull/734.

Implements the ABI breaking change as mentioned in the todo note added in #734. 



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

