### PR TITLE
Remove inheritance from common::Singleton for all classes

### DIFF
--- a/ogre/include/gz/rendering/ogre/OgreRTShaderSystem.hh
+++ b/ogre/include/gz/rendering/ogre/OgreRTShaderSystem.hh
@@ -42,8 +42,7 @@ namespace gz
     ///
     /// This class allows Gazebo to generate per-pixel shaders for every
     /// material at run-time.
-    class GZ_RENDERING_OGRE_VISIBLE OgreRTShaderSystem :
-      public common::SingletonT<OgreRTShaderSystem>
+    class GZ_RENDERING_OGRE_VISIBLE OgreRTShaderSystem
     {
       /// \enum LightingModel
       /// \brief The type of lighting
@@ -169,7 +168,6 @@ namespace gz
       public: void Update();
 
       /// \brief Get a pointer to the Ogre RT shader system
-      /// \todo(anyone) Remove inheritance from Singleton base class
       /// \return a pointer to the Ogre RT shader system
       public: static OgreRTShaderSystem *Instance();
 

--- a/ogre/include/gz/rendering/ogre/OgreRenderEngine.hh
+++ b/ogre/include/gz/rendering/ogre/OgreRenderEngine.hh
@@ -66,8 +66,7 @@ namespace gz
     };
 
     class GZ_RENDERING_OGRE_VISIBLE OgreRenderEngine :
-      public virtual BaseRenderEngine,
-      public common::SingletonT<OgreRenderEngine>
+      public virtual BaseRenderEngine
     {
       /// \enum OgreRenderPathType
       /// \brief The type of rendering path used by the rendering engine.
@@ -114,7 +113,6 @@ namespace gz
       public: std::vector<unsigned int> FSAALevels() const;
 
       /// \brief Get a pointer to the render engine
-      /// \todo(anyone) Remove inheritance from Singleton base class
       /// \return a pointer to the render engine
       public: static OgreRenderEngine *Instance();
 

--- a/ogre/src/OgreRTShaderSystem.cc
+++ b/ogre/src/OgreRTShaderSystem.cc
@@ -756,5 +756,5 @@ bool OgreRTShaderSystem::IsInitialized() const
 //////////////////////////////////////////////////
 OgreRTShaderSystem *OgreRTShaderSystem::Instance()
 {
-  return SingletonT<OgreRTShaderSystem>::Instance();
+  return gz::common::SingletonT<OgreRTShaderSystem>::Instance();
 }

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -839,7 +839,7 @@ Ogre::OverlaySystem *OgreRenderEngine::OverlaySystem() const
 //////////////////////////////////////////////////
 OgreRenderEngine *OgreRenderEngine::Instance()
 {
-  return SingletonT<OgreRenderEngine>::Instance();
+  return gz::common::SingletonT<OgreRenderEngine>::Instance();
 }
 
 // Register this plugin

--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderEngine.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderEngine.hh
@@ -79,8 +79,7 @@ namespace gz
     /// underlying ogre2 render engine, loads its plugins, and creates
     /// resources needed for the engine to run
     class GZ_RENDERING_OGRE2_VISIBLE Ogre2RenderEngine :
-      public virtual BaseRenderEngine,
-      public common::SingletonT<Ogre2RenderEngine>
+      public virtual BaseRenderEngine
     {
       /// \brief Constructor
       private: Ogre2RenderEngine();
@@ -230,7 +229,6 @@ namespace gz
           *TerraWorkspaceListener() const;
 
       /// \brief Get a pointer to the render engine
-      /// \todo(anyone) Remove inheritance from Singleton base class
       /// \return a pointer to the render engine
       public: static Ogre2RenderEngine *Instance();
 

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1455,7 +1455,7 @@ Ogre::CompositorWorkspaceListener *Ogre2RenderEngine::TerraWorkspaceListener()
 //////////////////////////////////////////////////
 Ogre2RenderEngine *Ogre2RenderEngine::Instance()
 {
-  return SingletonT<Ogre2RenderEngine>::Instance();
+  return gz::common::SingletonT<Ogre2RenderEngine>::Instance();
 }
 
 // Register this plugin


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

Continuing the effort from #874, this PR removes inheritance from `common::Singleton` for all other classes.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

