### PR TITLE
Add LookAt function to GizmoVisual class

### DIFF
--- a/include/gz/rendering/GizmoVisual.hh
+++ b/include/gz/rendering/GizmoVisual.hh
@@ -69,6 +69,21 @@ namespace gz
       /// mode
       /// \sa TransformAxis, TransformMode
       public: virtual VisualPtr ChildByAxis(unsigned int _axis) const = 0;
+
+      /// \brief Update the Gizmo visual's rotation visuals to face the specified
+      /// position.
+      /// \param[in] _pos Position to face. One typical position to face is
+      /// the eye (camera) position so that the rotation visuals are rendered
+      /// in a pose that is not behind the object the Gizmo visual is
+      /// attached to.
+      /// \param[in] _rot Rotation to be applied. For local space rotation,
+      /// set this to the rotation of the object that the Gizmo visual is
+      /// attached to so that the rotation visuals are rotated to match the
+      ///  object's rotation. For world space rotation, set this to identity
+      /// quarternion for rotation visuals to be rendered in a pose that the
+      /// rotation visuals are aligned with the world axes.
+      public: virtual void LookAt(const math::Vector3d &_pos,
+          const math::Quaterniond &_rot) = 0;
     };
     }
   }

--- a/include/gz/rendering/GizmoVisual.hh
+++ b/include/gz/rendering/GizmoVisual.hh
@@ -79,7 +79,7 @@ namespace gz
       /// \param[in] _rot Rotation to be applied. For local space rotation,
       /// set this to the rotation of the object that the Gizmo visual is
       /// attached to so that the rotation visuals are rotated to match the
-      ///  object's rotation. For world space rotation, set this to identity
+      /// object's rotation. For world space rotation, set this to identity
       /// quarternion for rotation visuals to be rendered in a pose that the
       /// rotation visuals are aligned with the world axes.
       public: virtual void LookAt(const math::Vector3d &_pos,

--- a/include/gz/rendering/GizmoVisual.hh
+++ b/include/gz/rendering/GizmoVisual.hh
@@ -70,8 +70,8 @@ namespace gz
       /// \sa TransformAxis, TransformMode
       public: virtual VisualPtr ChildByAxis(unsigned int _axis) const = 0;
 
-      /// \brief Update the Gizmo visual's rotation visuals to face the specified
-      /// position.
+      /// \brief Update the Gizmo visual's rotation visuals to face the
+      /// specified position.
       /// \param[in] _pos Position to face. One typical position to face is
       /// the eye (camera) position so that the rotation visuals are rendered
       /// in a pose that is not behind the object the Gizmo visual is

--- a/src/TransformController.cc
+++ b/src/TransformController.cc
@@ -131,40 +131,13 @@ void TransformController::Update()
   math::Quaterniond rot;
   if (this->dataPtr->mode == TransformMode::TM_ROTATION)
   {
-    math::Vector3d eye = this->dataPtr->camera->WorldPosition() - pos;
-    eye = eye.Normalize();
     math::Quaterniond nodeRot;
     if (this->dataPtr->space == TransformSpace::TS_LOCAL)
     {
       nodeRot = this->dataPtr->node->WorldRotation();
-      eye = nodeRot.RotateVectorReverse(eye);
     }
-    VisualPtr xVis = this->dataPtr->gizmoVisual->ChildByAxis(
-        TransformAxis::TA_ROTATION_X);
-    math::Vector3d xRot(atan2(-eye.Y(), eye.Z()), 0, 0);
-    math::Vector3d xRotOffset(0, -GZ_PI * 0.5, 0);
-    xVis->SetWorldRotation(nodeRot *
-        math::Quaterniond(xRot) * math::Quaterniond(xRotOffset));
-
-    VisualPtr yVis = this->dataPtr->gizmoVisual->ChildByAxis(
-        TransformAxis::TA_ROTATION_Y);
-    math::Vector3d yRot(0, atan2(eye.X(), eye.Z()), 0);
-    math::Vector3d yRotOffset(GZ_PI * 0.5, -GZ_PI * 0.5, 0);
-    yVis->SetWorldRotation(nodeRot *
-        math::Quaterniond(yRot) * math::Quaterniond(yRotOffset));
-
-    VisualPtr zVis = this->dataPtr->gizmoVisual->ChildByAxis(
-        TransformAxis::TA_ROTATION_Z);
-    math::Vector3d zRot(0, 0, atan2(eye.Y(), eye.X()));
-    zVis->SetWorldRotation(nodeRot * math::Quaterniond(zRot));
-
-    VisualPtr circleVis = this->dataPtr->gizmoVisual->ChildByAxis(
-        TransformAxis::TA_ROTATION_Z << 1);
-    math::Matrix4d lookAt;
-    lookAt = lookAt.LookAt(this->dataPtr->camera->WorldPosition(), pos);
-    math::Vector3d circleRotOffset(0, GZ_PI * 0.5, 0);
-    circleVis->SetWorldRotation(
-        lookAt.Rotation() * math::Quaterniond(circleRotOffset));
+    this->dataPtr->gizmoVisual->LookAt(this->dataPtr->camera->WorldPosition(),
+        nodeRot);
   }
   else
   {

--- a/test/common_test/GizmoVisual_TEST.cc
+++ b/test/common_test/GizmoVisual_TEST.cc
@@ -26,7 +26,7 @@
 using namespace gz;
 using namespace rendering;
 
-class GizmoVisualTest : public CommonRenderingTest 
+class GizmoVisualTest : public CommonRenderingTest
 {
 };
 
@@ -163,6 +163,60 @@ TEST_F(GizmoVisualTest, Material)
   EXPECT_EQ(xMat, xMat4);
   EXPECT_EQ(yMat, yMat4);
   EXPECT_EQ(zMat, zMat4);
+
+  // Clean up
+  engine->DestroyScene(scene);
+}
+
+/////////////////////////////////////////////////
+TEST_F(GizmoVisualTest, LookAt)
+{
+  ScenePtr scene = engine->CreateScene("scene");
+  // create visual
+  GizmoVisualPtr gizmo = scene->CreateGizmoVisual();
+  ASSERT_NE(nullptr, gizmo);
+
+  // set to rotation mode
+  gizmo->SetTransformMode(TransformMode::TM_ROTATION);
+  EXPECT_EQ(TransformMode::TM_ROTATION, gizmo->Mode());
+
+  VisualPtr xrot = gizmo->ChildByAxis(TransformAxis::TA_ROTATION_X);
+  ASSERT_NE(nullptr, xrot);
+  VisualPtr yrot = gizmo->ChildByAxis(TransformAxis::TA_ROTATION_Y);
+  ASSERT_NE(nullptr, yrot);
+  VisualPtr zrot = gizmo->ChildByAxis(TransformAxis::TA_ROTATION_Z);
+  ASSERT_NE(nullptr, zrot);
+
+  math::Vector3d pos = math::Vector3d::UnitX;
+  math::Quaterniond rot;
+  gizmo->LookAt(pos, rot);
+  auto newX = math::Quaterniond(math::Vector3d::UnitY, GZ_PI / 2);
+  auto newY = math::Quaterniond(math::Vector3d::UnitX, GZ_PI / 2);
+  auto newZ = math::Quaterniond::Identity;
+  EXPECT_EQ(newX.Euler().Abs(), xrot->WorldRotation().Euler().Abs());
+  EXPECT_EQ(newY.Euler().Abs(), yrot->WorldRotation().Euler().Abs());
+  EXPECT_EQ(newZ.Euler().Abs(), zrot->WorldRotation().Euler().Abs());
+
+  pos = math::Vector3d::UnitY;
+  gizmo->LookAt(pos, rot);
+  newX = math::Quaterniond(math::Vector3d::UnitZ, GZ_PI / 2) *
+         math::Quaterniond(math::Vector3d::UnitX, GZ_PI / 2);
+  newY = math::Quaterniond(math::Vector3d::UnitY, GZ_PI / 2) *
+         math::Quaterniond(math::Vector3d::UnitX, GZ_PI / 2);
+  newZ = math::Quaterniond(math::Vector3d::UnitZ, GZ_PI / 2);
+  EXPECT_EQ(newX.Euler().Abs(), xrot->WorldRotation().Euler().Abs());
+  EXPECT_EQ(newY.Euler().Abs(), yrot->WorldRotation().Euler().Abs());
+  EXPECT_EQ(newZ.Euler().Abs(), zrot->WorldRotation().Euler().Abs());
+
+  pos = math::Vector3d::UnitZ;
+  gizmo->LookAt(pos, rot);
+  newX = math::Quaterniond(math::Vector3d::UnitY, GZ_PI / 2);
+  newY = math::Quaterniond(math::Vector3d::UnitZ, GZ_PI / 2) *
+         math::Quaterniond(math::Vector3d::UnitY, GZ_PI / 2);
+  newZ = math::Quaterniond::Identity;
+  EXPECT_EQ(newX.Euler().Abs(), xrot->WorldRotation().Euler().Abs());
+  EXPECT_EQ(newY.Euler().Abs(), yrot->WorldRotation().Euler().Abs());
+  EXPECT_EQ(newZ.Euler().Abs(), zrot->WorldRotation().Euler().Abs());
 
   // Clean up
   engine->DestroyScene(scene);


### PR DESCRIPTION

# 🎉 New feature


## Summary
The LookAt function updates the rotation visuals in a GizmoVisual so that they always face the specified position. This is used by TransformController so that the rotation visuals (handles) are always positioned in front of the attached object w.r.t the camera so that they are easy to click on by the mouse.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

