### PR TITLE
Clean up internal resources on Destroy

### DIFF
--- a/ogre/src/OgreDistortionPass.cc
+++ b/ogre/src/OgreDistortionPass.cc
@@ -444,6 +444,21 @@ void OgreDistortionPass::Destroy()
     this->dataPtr->distortionInstance = nullptr;
     this->dataPtr->distortionCompositorListener.reset();
   }
+
+  if (!this->dataPtr->distortionMaterial.isNull())
+  {
+    Ogre::MaterialManager &matManager = Ogre::MaterialManager::getSingleton();
+    matManager.remove(this->dataPtr->distortionMaterial->getName());
+    this->dataPtr->distortionMaterial.setNull();
+  }
+
+  if (!this->dataPtr->distortionTexture.isNull())
+  {
+    auto &textureManager = Ogre::TextureManager::getSingleton();
+    textureManager.unload(this->dataPtr->distortionTexture->getName());
+    textureManager.remove(this->dataPtr->distortionTexture->getName());
+    this->dataPtr->distortionTexture.setNull();
+  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
@@ -79,7 +79,7 @@ namespace gz
             Ogre::CompositorWorkspace *_workspace) override;
 
       // Documentation inherited
-      public: void Destroy() override;
+      public: virtual void Destroy() override;
 
       /// \brief Check to see if the lens flare is occluded and return a scaling
       /// factor that is proportional to the lens flare's visibility

--- a/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
@@ -78,6 +78,9 @@ namespace gz
       public: void WorkspaceRemoved(
             Ogre::CompositorWorkspace *_workspace) override;
 
+      // Documentation inherited
+      public: void Destroy() override;
+
       /// \brief Check to see if the lens flare is occluded and return a scaling
       /// factor that is proportional to the lens flare's visibility
       /// \remark Ogre2LensFlarePass::PreRender must have been called first.

--- a/ogre2/src/Ogre2LensFlarePass.cc
+++ b/ogre2/src/Ogre2LensFlarePass.cc
@@ -126,6 +126,14 @@ Ogre2LensFlarePass::Ogre2LensFlarePass() :
 //////////////////////////////////////////////////
 Ogre2LensFlarePass::~Ogre2LensFlarePass()
 {
+  this->Destroy();
+}
+
+//////////////////////////////////////////////////
+void Ogre2LensFlarePass::Destroy()
+{
+  this->dataPtr->rayQuery.reset();
+  this->dataPtr->currentCamera.reset();
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -151,7 +151,12 @@ Ogre2Material::~Ogre2Material()
 void Ogre2Material::Destroy()
 {
   if (!this->Scene()->IsInitialized())
+  {
+    // just reset the ogre pointers and return.
+    this->dataPtr->ogreSolidColorMat.reset();
+    this->dataPtr->ogreSolidColorShader.reset();
     return;
+  }
 
   if (!this->ogreDatablock)
     return;

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -88,6 +88,9 @@ Ogre2RayQuery::Ogre2RayQuery()
 //////////////////////////////////////////////////
 Ogre2RayQuery::~Ogre2RayQuery()
 {
+  if (!this->Scene()->IsInitialized())
+    return;
+
   if (this->dataPtr->rayQuery)
   {
     Ogre2ScenePtr ogreScene =

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -144,6 +144,9 @@ Ogre2SelectionBuffer::Ogre2SelectionBuffer(const std::string &_cameraName,
 /////////////////////////////////////////////////
 Ogre2SelectionBuffer::~Ogre2SelectionBuffer()
 {
+  if (!this->dataPtr->scene || !this->dataPtr->scene->IsInitialized())
+    return;
+
   this->DeleteRTTBuffer();
 
   // remove selectionMaterial in destructor
@@ -157,7 +160,14 @@ Ogre2SelectionBuffer::~Ogre2SelectionBuffer()
   }
 
   // remove selection buffer camera
-  this->dataPtr->sceneMgr->destroyCamera(this->dataPtr->selectionCamera);
+  if (this->dataPtr->selectionCamera)
+  {
+    this->dataPtr->selectionCamera->removeListener(
+        this->dataPtr->materialSwitcher.get());
+    this->dataPtr->sceneMgr->destroyCamera(this->dataPtr->selectionCamera);
+    this->dataPtr->selectionCamera = nullptr;
+    this->dataPtr->materialSwitcher.reset();
+  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

Motivated by https://github.com/gazebosim/gz-sim/issues/2084. 

Went through and clean up resources and pointers when the objects destroyed. This is is to make sure that we don't hold on to any pointers after the engine is destroyed. 

More info:
We have ogre pointers as member variables in different rendering classes. The destructors are called when they go out of scope. If the engine is destroyed before the destructors are called, the destructor may be calling function from pointers that are no longer valid. So this PR tries to clear and reset all pointers when objects are destroyed (before the engine is unloaded).


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

