### PR TITLE
Minor updates to  README file in the hello_world_plugin example

### DIFF
--- a/examples/hello_world_plugin/README.md
+++ b/examples/hello_world_plugin/README.md
@@ -36,7 +36,7 @@ Now you can run `gz sim` with the name of the resultant library file (without th
 or the file extension, i.e., libHelloWorldPlugin.so -> HelloWorldPlugin):
 
 ~~~
-gz sim -v 4 --render-engine HelloWorldPlugin empty.sdf
+gz sim --render-engine HelloWorldPlugin empty.sdf
 ~~~
 
 You should see a blank screen within the Gazebo GUI, as this mocked plugin provides no implementation

--- a/examples/hello_world_plugin/README.md
+++ b/examples/hello_world_plugin/README.md
@@ -36,8 +36,9 @@ Now you can run `gz sim` with the name of the resultant library file (without th
 or the file extension, i.e., libHelloWorldPlugin.so -> HelloWorldPlugin):
 
 ~~~
-gz sim --render-engine HelloWorldPlugin
+gz sim -v 4 --render-engine HelloWorldPlugin empty.sdf
 ~~~
 
 You should see a blank screen within the Gazebo GUI, as this mocked plugin provides no implementation
-for the scene.
+for the scene. The Gazebo Component Inspector should show that the Render Engine Gui Plugin and
+the Render Engine Server Plugin are now set to use the `HelloWorldPlugin`.


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

Updated instructions to launch gz sim with an empty world otherwise the quick start menu will pop up if no world is specified. 

Also added info on what to check when the gui comes up in order to verify that the plugin is successfully loaded.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

