### PR TITLE
Do not load optix engine in examples

### DIFF
--- a/examples/camera_tracking/Main.cc
+++ b/examples/camera_tracking/Main.cc
@@ -139,7 +139,6 @@ int main(int _argc, char** _argv)
   std::vector<NodePtr> nodes;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/custom_scene_viewer/ManualSceneDemo.cc
+++ b/examples/custom_scene_viewer/ManualSceneDemo.cc
@@ -223,7 +223,6 @@ int main(int _argc, char** _argv)
   sceneDemo->AddScene(SceneBuilderPtr(new ShadowSceneBuilder(5)));
 //! [add scenes]
   sceneDemo->AddCamera(ogreEngineName, params);
-  sceneDemo->AddCamera("optix");
   sceneDemo->Run();
   return 0;
 }

--- a/examples/gazebo_scene_viewer/GazeboDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboDemo.cc
@@ -103,7 +103,6 @@ int main(int _argc, char** _argv)
   std::vector<std::string> engineNames;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
+++ b/examples/gazebo_scene_viewer/GazeboWorldDemo.cc
@@ -103,7 +103,6 @@ int main(int _argc, char** _argv)
   std::vector<std::string> engineNames;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/mesh_viewer/Main.cc
+++ b/examples/mesh_viewer/Main.cc
@@ -153,7 +153,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/mouse_picking/Main.cc
+++ b/examples/mouse_picking/Main.cc
@@ -146,7 +146,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/projector/Main.cc
+++ b/examples/projector/Main.cc
@@ -188,7 +188,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/render_pass/Main.cc
+++ b/examples/render_pass/Main.cc
@@ -209,7 +209,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/simple_demo/Main.cc
+++ b/examples/simple_demo/Main.cc
@@ -229,7 +229,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/text_geom/Main.cc
+++ b/examples/text_geom/Main.cc
@@ -126,7 +126,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back("ogre");
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/transform_control/Main.cc
+++ b/examples/transform_control/Main.cc
@@ -132,7 +132,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/view_control/Main.cc
+++ b/examples/view_control/Main.cc
@@ -178,7 +178,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -259,7 +259,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(engine);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/wide_angle_camera/Main.cc
+++ b/examples/wide_angle_camera/Main.cc
@@ -173,7 +173,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/tutorials/17_render_pass_tutorial.md
+++ b/tutorials/17_render_pass_tutorial.md
@@ -24,7 +24,6 @@ You'll see:
 
 ```{.sh}
 [Msg] Loading plugin [gz-rendering8-ogre]
-Engine 'optix' is not supported
 ===============================
   TAB - Switch render engines
   ESC - Exit

--- a/tutorials/18_simple_demo_tutorial.md
+++ b/tutorials/18_simple_demo_tutorial.md
@@ -24,7 +24,6 @@ You'll see:
 
 ```{.sh}
 [Msg] Loading plugin [gz-rendering8-ogre]
-Engine 'optix' is not supported
 ===============================
   TAB - Switch render engines
   ESC - Exit

--- a/tutorials/19_text_geom_tutorial.md
+++ b/tutorials/19_text_geom_tutorial.md
@@ -24,7 +24,6 @@ You'll see:
 
 ```{.sh}
 [Msg] Loading plugin [gz-rendering8-ogre]
-Engine 'optix' is not supported
 ===============================
   TAB - Switch render engines
   ESC - Exit


### PR DESCRIPTION

# 🦟 Bug fix

## Summary
Many examples currently load optix by default (in addition to ogre / ogre2). If optix render engine support is not available (which is often the case), you'll get the error msgs:

```
[Err] [RenderEngineManager.cc:477] Failed to load plugin [optix] : couldn't find shared library.
Engine 'optix' is not supported
```

Given that optix support is not actively being developed, it's best not to load them in the examples. Users can still choose to use optix by passing it as an arg, e.g. `./simple_demo optix`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
