### PR TITLE
Revert mesh viewer background color back to gray

### DIFF
--- a/examples/mesh_viewer/Main.cc
+++ b/examples/mesh_viewer/Main.cc
@@ -45,7 +45,7 @@ void buildScene(ScenePtr _scene)
 {
   // initialize _scene
   _scene->SetAmbientLight(0.3, 0.3, 0.3);
-  _scene->SetBackgroundColor(0.0, 0.0, 0.3);
+  _scene->SetBackgroundColor(0.3, 0.3, 0.3);
   VisualPtr root = _scene->RootVisual();
 
   // create directional light


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Revert background color in the mesh viewer demo from blue back back to gray.

It was accidentally updated to blue in https://github.com/gazebosim/gz-rendering/pull/811 - probably I was testing something and forgot to revert the change. 

Gray color also matches what's shown in the tutorial screenshot:
https://gazebosim.org/api/rendering/8/mesh_viewer.html

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

