### PR TITLE
Update custom scene viewer tutorial

### DIFF
--- a/tutorials/13_custom_scene_viewer.md
+++ b/tutorials/13_custom_scene_viewer.md
@@ -1,14 +1,10 @@
 \page custom_scene_viewer Custom scene viewer
 
 This application allows us to view a number of pre constructed scenes.
-The initial render engine is Ogre.
 
 When the application starts you will see a blank window.
 When you click the `+` or `-` keys you can change the scene.
 By pressing the `Tab` button you will advance to the next render engine.
-
-You may see the render engine title in the window change to Optix if you have compiled your Gazebo Rendering library with OptiX (otherwise you can only use Ogre).
-The frame rate may also change based on your computer's capabilities.
 
 The following scenes have more primitive objects such as cones or cilinders. Again, you can see the scene with different render engines pressing `Tab`.
 Some of the scenes available include:


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Following up on https://github.com/gazebosim/gz-rendering/pull/893, this PR removes more references to optix in the custom scene viewer tutorial


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
