### PR TITLE
Fixed build on MSVC

### DIFF
--- a/include/gz/rendering/GlobalIlluminationBase.hh
+++ b/include/gz/rendering/GlobalIlluminationBase.hh
@@ -52,8 +52,11 @@ namespace gz
         STATIC_VISUALS = 1u << 1u
       };
 
+      /// \brief Constructor
+      public: GlobalIlluminationBase();
+
       /// \brief Destructor
-      public: virtual ~GlobalIlluminationBase() { }
+      public: virtual ~GlobalIlluminationBase();
 
       /// \brief Initialize the class
       protected: virtual void Init() = 0;

--- a/include/gz/rendering/GlobalIlluminationCiVct.hh
+++ b/include/gz/rendering/GlobalIlluminationCiVct.hh
@@ -31,8 +31,11 @@ namespace gz
 
   class GZ_RENDERING_VISIBLE CiVctCascade
   {
+    /// \brief Constructor
+    public: CiVctCascade();
+
     /// \brief Destructor
-    public: virtual ~CiVctCascade() {}
+    public: virtual ~CiVctCascade();
 
     /// \brief Sets whether to correctly calculate GI occlusion caused
     /// by occluders against area lights. Consumes more VRAM.
@@ -149,8 +152,11 @@ namespace gz
               DVM_None
             };
 
+    /// \brief Constructor
+    public: GlobalIlluminationCiVct();
+
     /// \brief Destructor
-    public: virtual ~GlobalIlluminationCiVct() { }
+    public: virtual ~GlobalIlluminationCiVct();
 
     /// \brief Tells how many times AddCascade will be called.
     /// You can call it fewer times (i.e. some kb of RAM will be wasted)

--- a/include/gz/rendering/GlobalIlluminationVct.hh
+++ b/include/gz/rendering/GlobalIlluminationVct.hh
@@ -48,8 +48,11 @@ namespace gz
                 DVM_None
               };
 
+      /// \brief Constructor
+      public: GlobalIlluminationVct();
+
       /// \brief Destructor
-      public: virtual ~GlobalIlluminationVct() { }
+      public: virtual ~GlobalIlluminationVct();
 
       /// \brief Resolution of the 3D Voxel. Must be multiple of 2
       /// \remarks To avoid wasting RAM, make this function your first call

--- a/include/gz/rendering/NativeWindow.hh
+++ b/include/gz/rendering/NativeWindow.hh
@@ -38,8 +38,11 @@ namespace gz
     /// on OS and RenderSystem
     class GZ_RENDERING_VISIBLE NativeWindow
     {
+      /// \brief Constructor
+      public: NativeWindow();
+
       /// \brief Destructor
-      public: virtual ~NativeWindow() { }
+      public: virtual ~NativeWindow();
 
       /// \brief Tells the native window whether it's under focus
       /// \param[in] _focused True if we acquired focus. False if we lost it

--- a/include/gz/rendering/base/BaseNativeWindow.hh
+++ b/include/gz/rendering/base/BaseNativeWindow.hh
@@ -32,9 +32,9 @@ namespace gz
     class GZ_RENDERING_VISIBLE BaseNativeWindow :
       public virtual NativeWindow
     {
-      protected: BaseNativeWindow() {}
+      protected: BaseNativeWindow();
 
-      public: virtual ~BaseNativeWindow() {}
+      public: virtual ~BaseNativeWindow();
 
       // Documentation Inherited.
       public: virtual void NotifyFocused(bool /*_focused*/) override {}

--- a/ogre2/include/gz/rendering/ogre2/Ogre2GlobalIlluminationCiVct.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2GlobalIlluminationCiVct.hh
@@ -47,6 +47,8 @@ namespace gz
       /// \brief Constructor
       public: explicit Ogre2CiVctCascade();
 
+      public: ~Ogre2CiVctCascade() override;
+
       /// \brief Initializes the cascade
       /// \param[in] _cascade Cascade we control
       /// \param[in] _ref Reference to clone settings from (can be nullptr)

--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -9,6 +9,7 @@ if (MSVC)
   # warning is not important since those members do not need to be interfaced
   # with.
   set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/wd4251")
+  set_source_files_properties(${sources} ${gtest_sources} COMPILE_FLAGS "/D_SILENCE_STDEXT_HASH_DEPRECATION_WARNINGS")
 endif()
 
 set(engine_name "ogre2")

--- a/ogre2/src/Ogre2GlobalIlluminationCiVct.cc
+++ b/ogre2/src/Ogre2GlobalIlluminationCiVct.cc
@@ -213,6 +213,11 @@ Ogre2GlobalIlluminationCiVct::~Ogre2GlobalIlluminationCiVct()
 }
 
 //////////////////////////////////////////////////
+Ogre2CiVctCascade::~Ogre2CiVctCascade()
+{
+}
+
+//////////////////////////////////////////////////
 void Ogre2GlobalIlluminationCiVct::Init()
 {
   this->dataPtr->cascadedVoxelizer = new Ogre::VctCascadedVoxelizer();

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1343,7 +1343,7 @@ NativeWindowPtr Ogre2RenderEngine::CreateNativeWindow(
 #ifdef _WIN32
     params["externalGLContext"] =
       std::to_string((size_t)wglGetCurrentContext());
-#  elidef __APPLE__
+#elif defined(__APPLE__)
     params["externalGLContext"] =
       std::to_string((size_t)CGLGetCurrentContext());
 #else

--- a/src/GlobalIlluminationBase.cc
+++ b/src/GlobalIlluminationBase.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/GlobalIlluminationBase.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+GlobalIlluminationBase::GlobalIlluminationBase() = default;
+
+//////////////////////////////////////////////////
+GlobalIlluminationBase::~GlobalIlluminationBase() = default;
+

--- a/src/GlobalIlluminationCiVct.cc
+++ b/src/GlobalIlluminationCiVct.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/GlobalIlluminationCiVct.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+CiVctCascade::CiVctCascade() = default;
+
+//////////////////////////////////////////////////
+CiVctCascade::~CiVctCascade() = default;
+
+//////////////////////////////////////////////////
+GlobalIlluminationCiVct::GlobalIlluminationCiVct() = default;
+
+//////////////////////////////////////////////////
+GlobalIlluminationCiVct::~GlobalIlluminationCiVct() = default;
+

--- a/src/GlobalIlluminationVct.cc
+++ b/src/GlobalIlluminationVct.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/GlobalIlluminationVct.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+GlobalIlluminationVct::GlobalIlluminationVct() = default;
+
+//////////////////////////////////////////////////
+GlobalIlluminationVct::~GlobalIlluminationVct() = default;
+

--- a/src/NativeWindow.cc
+++ b/src/NativeWindow.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/NativeWindow.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+NativeWindow::NativeWindow() = default;
+
+//////////////////////////////////////////////////
+NativeWindow::~NativeWindow() = default;
+

--- a/src/base/BaseNativeWindow.cc
+++ b/src/base/BaseNativeWindow.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "gz/rendering/base/BaseNativeWindow.hh"
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+BaseNativeWindow::BaseNativeWindow() = default;
+
+//////////////////////////////////////////////////
+BaseNativeWindow::~BaseNativeWindow() = default;
+


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This was needed for the MSVC build to succeed. @darksylinc got obviously hit again by the poor MSVC linker that is not able to figure out it doesn't need to lookup defaulted constructors/destructors.

The CMake flag was needed to support building with VS2022. VS2019 shouldn't require it.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.