### PR TITLE
Fix wide angle camera visibility flags

### DIFF
--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -979,7 +979,9 @@ void Ogre2WideAngleCamera::CreateWideAngleTexture()
 //////////////////////////////////////////////////
 void Ogre2WideAngleCamera::Render()
 {
-  const uint32_t currVisibilityMask = this->VisibilityMask();
+  // make sure we do not alter the reserved visibility flags
+  const uint32_t currVisibilityMask = this->VisibilityMask() &
+    Ogre::VisibilityFlags::RESERVED_VISIBILITY_FLAGS;
   this->dataPtr->cubePassSceneDef->mVisibilityMask = currVisibilityMask;
 
   this->scene->StartRendering(this->dataPtr->ogreCamera);


### PR DESCRIPTION

# 🦟 Bug fix


## Summary
The default visibility flags conflicts with ogre's internal reserved flags which causes heightmaps to be not visible in the camera view. This PR fixes the visibility flags in the same way that's [done for a regular camera](https://github.com/gazebosim/gz-rendering/blob/b16a396d64f0c0a31dcb459b3acd6d719d057ea8/ogre2/src/Ogre2RenderTarget.cc#L65-L66).


See https://github.com/gazebosim/harmonic_demo/pull/7 for screenshot

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

