### PR TITLE
Disable setting particle emitter color range

### DIFF
--- a/ogre2/src/Ogre2ParticleEmitter.cc
+++ b/ogre2/src/Ogre2ParticleEmitter.cc
@@ -296,6 +296,10 @@ void Ogre2ParticleEmitter::SetColorRange(
     const gz::math::Color &_colorStart,
     const gz::math::Color &_colorEnd)
 {
+  // see https://github.com/gazebosim/gz-rendering/issues/902
+  gzwarn << "ParticleEmitter SetColorRange is currently disabled." << std::endl;
+  return;
+
   // Color interpolator affector.
   if (!this->dataPtr->colorInterpolatorAffector)
   {

--- a/test/common_test/ParticleEmitter_TEST.cc
+++ b/test/common_test/ParticleEmitter_TEST.cc
@@ -29,7 +29,7 @@ using namespace gz;
 using namespace rendering;
 
 /// \brief The test fixture.
-class ParticleEmitterTest : public CommonRenderingTest 
+class ParticleEmitterTest : public CommonRenderingTest
 {
   /// \brief A directory under test/ with some textures.
   protected: const std::string TEST_MEDIA_PATH =
@@ -124,8 +124,10 @@ TEST_F(ParticleEmitterTest, ParticleEmitter)
   EXPECT_EQ(expectedMaterial,         particleEmitter->Material());
   EXPECT_DOUBLE_EQ(expectedMinVel,    particleEmitter->MinVelocity());
   EXPECT_DOUBLE_EQ(expectedMaxVel,    particleEmitter->MaxVelocity());
-  EXPECT_EQ(expectedColorStart,       particleEmitter->ColorStart());
-  EXPECT_EQ(expectedColorEnd,         particleEmitter->ColorEnd());
+  // ColorRange test is currently disabled, see
+  // https://github.com/gazebosim/gz-rendering/issues/902
+  // EXPECT_EQ(expectedColorStart,       particleEmitter->ColorStart());
+  // EXPECT_EQ(expectedColorEnd,         particleEmitter->ColorEnd());
   EXPECT_DOUBLE_EQ(expectedScaleRate, particleEmitter->ScaleRate());
   EXPECT_EQ(expectedColorRangeImage,  particleEmitter->ColorRangeImage());
   EXPECT_FLOAT_EQ(expectedScatterRatio,


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Related issue: #902 

## Summary

Setting the particle emitter color range causes particles to appear black instead of actually changing the color of the particles to the range specified. The problem is that is affecting particle emitters that have also a material set (via `SetMaterial`) - the material diffuse color is overriden and results in black particles.

This PR just disables that function for now, see more details in #902

Test with `gz sim -v 4 particle_emitter.sdf`. With these changes, you should now see that the particles on the left side of the scene appears red (the intended color specified in the `<material>` tag) instead of black with flickering red.

<img width="593" alt="particles_color" src="https://github.com/gazebosim/gz-rendering/assets/4000684/faa057a0-fc88-4550-81b1-018b707ebec2">


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

