### PR TITLE
[backport fortress] Calculate camera intrinsics : Refactor

### DIFF
--- a/include/gz/rendering/Utils.hh
+++ b/include/gz/rendering/Utils.hh
@@ -97,6 +97,20 @@ namespace ignition
     ignition::math::AxisAlignedBox transformAxisAlignedBox(
         const ignition::math::AxisAlignedBox &_box,
         const ignition::math::Pose3d &_pose);
+
+    /// \brief Convert a given camera projection matrix
+    /// to an intrinsics matrix. Intrinsics matrix is different
+    /// from the matrix returned by Camera::ProjectionMatrix(),
+    /// which is used by OpenGL internally.
+    /// The matrix returned contains the camera calibrated values.
+    /// \param[in] _projectionMatrix Camera's projection matrix.
+    /// \param[in] _width Camera's image width.
+    /// \param[in] _height Camera's image height.
+    /// \return Camera's intrinsic matrix.
+    IGNITION_RENDERING_VISIBLE
+    ignition::math::Matrix3d projectionToCameraIntrinsic(
+        const ignition::math::Matrix4d &_projectionMatrix,
+        double _width, double _height);
     }
   }
 }

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -48,6 +48,9 @@ class CameraTest : public testing::Test,
 
   /// \brief Test setting visibility mask
   public: void VisibilityMask(const std::string &_renderEngine);
+
+  /// \brief Test setting intrinsic matrix
+  public: void IntrinsicMatrix(const std::string &_renderEngine);
 };
 
 /////////////////////////////////////////////////
@@ -367,48 +370,17 @@ void CameraTest::VisibilityMask(const std::string &_renderEngine)
 }
 
 /////////////////////////////////////////////////
-TEST_P(CameraTest, ViewProjectionMatrix)
+void CameraTest::IntrinsicMatrix(const std::string &_renderEngine)
 {
-  ViewProjectionMatrix(GetParam());
-}
+  // create and populate scene
+  RenderEngine *engine = rendering::engine(_renderEngine);
+  if (!engine)
+  {
+    igndbg << "Engine '" << _renderEngine
+              << "' is not supported" << std::endl;
+    return;
+  }
 
-/////////////////////////////////////////////////
-TEST_P(CameraTest, RenderTexture)
-{
-  RenderTexture(GetParam());
-}
-
-/////////////////////////////////////////////////
-TEST_P(CameraTest, TrackFollow)
-{
-  TrackFollow(GetParam());
-}
-
-/////////////////////////////////////////////////
-TEST_P(CameraTest, AddRemoveRenderPass)
-{
-  AddRemoveRenderPass(GetParam());
-}
-
-/////////////////////////////////////////////////
-TEST_P(CameraTest, VisibilityMask)
-{
-  VisibilityMask(GetParam());
-}
-
-INSTANTIATE_TEST_CASE_P(Camera, CameraTest,
-    RENDER_ENGINE_VALUES,
-    PrintToStringParam());
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-
-/////////////////////////////////////////////////
-TEST_F(CameraTest, IntrinsicMatrix)
-{
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);
 
@@ -471,4 +443,50 @@ TEST_F(CameraTest, IntrinsicMatrix)
 
   // Clean up
   engine->DestroyScene(scene);
+}
+
+/////////////////////////////////////////////////
+TEST_P(CameraTest, ViewProjectionMatrix)
+{
+  ViewProjectionMatrix(GetParam());
+}
+
+/////////////////////////////////////////////////
+TEST_P(CameraTest, RenderTexture)
+{
+  RenderTexture(GetParam());
+}
+
+/////////////////////////////////////////////////
+TEST_P(CameraTest, TrackFollow)
+{
+  TrackFollow(GetParam());
+}
+
+/////////////////////////////////////////////////
+TEST_P(CameraTest, AddRemoveRenderPass)
+{
+  AddRemoveRenderPass(GetParam());
+}
+
+/////////////////////////////////////////////////
+TEST_P(CameraTest, VisibilityMask)
+{
+  VisibilityMask(GetParam());
+}
+
+/////////////////////////////////////////////////
+TEST_F(CameraTest, IntrinsicMatrix)
+{
+  IntrinsicMatrix(GetParam());
+}
+
+INSTANTIATE_TEST_CASE_P(Camera, CameraTest,
+    RENDER_ENGINE_VALUES,
+    PrintToStringParam());
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -476,7 +476,7 @@ TEST_P(CameraTest, VisibilityMask)
 }
 
 /////////////////////////////////////////////////
-TEST_F(CameraTest, IntrinsicMatrix)
+TEST_P(CameraTest, IntrinsicMatrix)
 {
   IntrinsicMatrix(GetParam());
 }

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -164,6 +164,25 @@ float screenScalingFactor()
 }
 
 /////////////////////////////////////////////////
+ignition::math::Matrix3d projectionToCameraIntrinsic(
+    const gz::math::Matrix4d &_projectionMatrix,
+    double _width, double _height)
+{
+  // Extracting the intrinsic matrix :
+  // https://ogrecave.github.io/ogre/api/13/class_ogre_1_1_math.html
+  double fX = (_projectionMatrix(0, 0) * _width) / 2.0;
+  double fY = (_projectionMatrix(1, 1) * _height) / 2.0;
+  double cX = (-1.0 * _width *
+               (_projectionMatrix(0, 2) - 1.0)) / 2.0;
+  double cY = _height + (_height *
+               (_projectionMatrix(1, 2) - 1)) / 2.0;
+
+  return gz::math::Matrix3d(fX, 0, cX,
+                            0, fY, cY,
+                            0, 0, 1);
+}
+
+/////////////////////////////////////////////////
 ignition::math::AxisAlignedBox transformAxisAlignedBox(
     const ignition::math::AxisAlignedBox &_bbox,
     const ignition::math::Pose3d &_pose)


### PR DESCRIPTION
# 🎉 New feature

## Summary
[backport fortress] Calculate camera intrinsics : Refactor

Required in this PR https://github.com/gazebosim/gz-sensors/pull/383

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
