### PR TITLE
ogre2: retain CMAKE_INSTALL_RPATH values

### DIFF
--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -28,10 +28,14 @@ set_property(
 target_compile_definitions(${ogre2_target}
   PRIVATE OGRE_IGNORE_UNKNOWN_DEBUG)
 
+# Add OGRE2_LIBRARY_DIRS to INSTALL_RPATH
+# Append to a copy of CMAKE_INSTALL_RPATH since that is the default
+set(ogre2_target_install_rpath ${CMAKE_INSTALL_RPATH})
+list(APPEND ogre2_target_install_rpath ${OGRE2_LIBRARY_DIRS})
 set_property(
   TARGET ${ogre2_target}
   PROPERTY INSTALL_RPATH
-  ${OGRE2_LIBRARY_DIRS}
+  ${ogre2_target_install_rpath}
 )
 
 target_include_directories(${ogre2_target}


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/osrf/homebrew-simulation/pull/2273

## Summary

I have been adding some RPATH configuration to our homebrew formulae to fix issues with binaries installed to subfolders of `lib` and `libexec` on ARM processors, for which homebrew is installed to `/opt/homebrew` instead of `/usr/local`. In https://github.com/osrf/homebrew-simulation/pull/2404 for example, an additional entry is added to `CMAKE_INSTALL_RPATH` to fix a `gz-plugin` standalone executable. The `CMAKE_INSTALL_RPATH` value provides a default value for the `INSTALL_RPATH` property of all targets. While testing these rpath fixes, but I ran into a problem with just the ogre2 library in gz-rendering not using the paths specified in `CMAKE_INSTALL_RPATH`. After looking at the gz-rendering source code, I see that the `INSTALL_RPATH` of the ogre2 target is set to a single path, which overrides the default values from `CMAKE_INSTALL_RPATH`.

This pull request sets the ogre2 target `INSTALL_RPATH` property to a copy of `CMAKE_INSTALL_RPATH` with `OGRE_LIBRARY_DIRS` appended, instead of just the latter path. This helps with packaging on macOS.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
