### PR TITLE
Backport #909: rpath fix for garden

### DIFF
--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -27,10 +27,14 @@ set_property(
 target_compile_definitions(${ogre2_target}
   PRIVATE OGRE_IGNORE_UNKNOWN_DEBUG)
 
+# Add OGRE2_LIBRARY_DIRS to INSTALL_RPATH
+# Append to a copy of CMAKE_INSTALL_RPATH since that is the default
+set(ogre2_target_install_rpath ${CMAKE_INSTALL_RPATH})
+list(APPEND ogre2_target_install_rpath ${OGRE2_LIBRARY_DIRS})
 set_property(
   TARGET ${ogre2_target}
   PROPERTY INSTALL_RPATH
-  ${OGRE2_LIBRARY_DIRS}
+  ${ogre2_target_install_rpath}
 )
 
 target_include_directories(${ogre2_target}


### PR DESCRIPTION
# 🦟 Bug fix

Backport #909 to garden

## Summary

Sets the ogre2 target INSTALL_RPATH to a copy of
CMAKE_INSTALL_RPATH with OGRE_LIBRARY_DIRS
appended, instead of just the latter path. This
helps with packaging on macOS.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Rebase-and-Merge**