### PR TITLE
Minor fix to checking projector default visibility flags 

### DIFF
--- a/ogre2/src/Ogre2Projector.cc
+++ b/ogre2/src/Ogre2Projector.cc
@@ -163,9 +163,11 @@ void Ogre2Projector::UpdateCameraListener()
 {
   // if a custom visibility flag is set, we will need to use a listener
   // for toggling the visibility of the decal
-  if (this->VisibilityFlags() == GZ_VISIBILITY_ALL)
+  if ((this->VisibilityFlags() & GZ_VISIBILITY_ALL) == GZ_VISIBILITY_ALL)
   {
     this->dataPtr->decalNode->setVisible(true);
+    this->dataPtr->decalNode->getCreator()->setDecalsDiffuse(
+        this->dataPtr->decal->getDiffuseTexture());
 
     for (auto &ogreCamIt : this->dataPtr->camerasWithListener)
     {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fixed check to see if projector is using default or custom visibility flags. If it's using the default flags, we can skip all the extra computation added for visibility toggling. 

The check is not quite correct (so it's currently not skipping the extra computations). The default visibility flags (from SDF) is `0xFFFFFFFF` but the code is checking against `GZ_VISIBILITY_ALL` which is `0x0FFFFFFF`. So updated check to make sure the visibility flags contain all of `GZ_VISIBILITY_ALL` bits instead of exact equality comparison. 

This is more of a performance improvement and does not change projector behavior.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

