### PR TITLE
Add projection matrix set/get functions to Ogre Depth camera

### DIFF
--- a/ogre/include/gz/rendering/ogre/OgreDepthCamera.hh
+++ b/ogre/include/gz/rendering/ogre/OgreDepthCamera.hh
@@ -27,6 +27,8 @@
 #include <memory>
 #include <string>
 
+#include <gz/math/Matrix4.hh>
+
 #include "gz/rendering/RenderTypes.hh"
 #include "gz/rendering/base/BaseDepthCamera.hh"
 #include "gz/rendering/ogre/OgreConversions.hh"
@@ -82,6 +84,13 @@ namespace gz
       /// \brief Destroy render texture created by CreateDepthTexture()
       /// Note: It's not virtual.
       protected: void DestroyDepthTexture();
+
+      // Documentation inherited.
+      public: virtual math::Matrix4d ProjectionMatrix() const override;
+
+      // Documentation inherited.
+      public: virtual void SetProjectionMatrix(
+          const math::Matrix4d &_matrix) override;
 
       /// \brief Render the camera
       public: virtual void PostRender() override;

--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -23,7 +23,10 @@
   #include <windows.h>
 #endif
 #include <gz/math/Helpers.hh>
+#include <gz/math/Matrix4.hh>
+
 #include "gz/rendering/InstallationDirectories.hh"
+#include "gz/rendering/ogre/OgreConversions.hh"
 #include "gz/rendering/ogre/OgreDepthCamera.hh"
 #include "gz/rendering/ogre/OgreMaterial.hh"
 
@@ -310,6 +313,18 @@ void OgreDepthCamera::DestroyDepthTexture()
     dynamic_cast<OgreRenderTexture *>(this->depthTexture.get())->Destroy();
     this->depthTexture.reset();
   }
+}
+
+/////////////////////////////////////////////////
+math::Matrix4d OgreDepthCamera::ProjectionMatrix() const {
+  return OgreConversions::Convert(this->ogreCamera->getProjectionMatrix());
+}
+
+/////////////////////////////////////////////////
+void OgreDepthCamera::SetProjectionMatrix(const math::Matrix4d &_matrix) {
+  BaseDepthCamera::SetProjectionMatrix(_matrix);
+  this->ogreCamera->setCustomProjectionMatrix(
+      true, OgreConversions::Convert(this->projectionMatrix));
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/include/gz/rendering/ogre2/Ogre2DepthCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2DepthCamera.hh
@@ -27,6 +27,8 @@
 #include <memory>
 #include <string>
 
+#include <gz/math/Matrix4.hh>
+
 #include "gz/rendering/base/BaseDepthCamera.hh"
 #include "gz/rendering/ogre2/Ogre2ObjectInterface.hh"
 #include "gz/rendering/ogre2/Ogre2Sensor.hh"
@@ -78,6 +80,13 @@ namespace gz
       /// \brief Creates an Ogre Workspace instance. Assumes the definition
       /// already and the depth texture have already been created
       private: void CreateWorkspaceInstance();
+
+      // Documentation inherited.
+      public: virtual math::Matrix4d ProjectionMatrix() const override;
+
+      // Documentation inherited.
+      public: virtual void SetProjectionMatrix(
+          const math::Matrix4d &_matrix) override;
 
       // Documentation inherited
       public: virtual void PreRender() override;

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -25,6 +25,7 @@
 
 #include <math.h>
 #include <gz/math/Helpers.hh>
+#include <gz/math/Matrix4.hh>
 
 #include "gz/rendering/RenderTypes.hh"
 #include "gz/rendering/ogre2/Ogre2Conversions.hh"
@@ -965,6 +966,18 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
       break;
     }
   }
+}
+
+/////////////////////////////////////////////////
+math::Matrix4d Ogre2DepthCamera::ProjectionMatrix() const {
+  return Ogre2Conversions::Convert(this->ogreCamera->getProjectionMatrix());
+}
+
+/////////////////////////////////////////////////
+void Ogre2DepthCamera::SetProjectionMatrix(const math::Matrix4d &_matrix) {
+  BaseDepthCamera::SetProjectionMatrix(_matrix);
+  this->ogreCamera->setCustomProjectionMatrix(
+      true, Ogre2Conversions::Convert(this->projectionMatrix));
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
This is required to properly set camera intrinsic parameters from SDF for depth and rgbd camera sensors.