### PR TITLE
Fix float comparison warnings in test

### DIFF
--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -412,12 +412,12 @@ void CameraTest::IntrinsicMatrix(const std::string &_renderEngine)
   EXPECT_DOUBLE_EQ(cameraIntrinsics(1, 2), 120);
 
   // Verify rest of the intrinsics
-  EXPECT_EQ(cameraIntrinsics(0, 1), 0);
-  EXPECT_EQ(cameraIntrinsics(1, 0), 0);
-  EXPECT_EQ(cameraIntrinsics(0, 1), 0);
-  EXPECT_EQ(cameraIntrinsics(2, 0), 0);
-  EXPECT_EQ(cameraIntrinsics(2, 1), 0);
-  EXPECT_EQ(cameraIntrinsics(2, 2), 1);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(0, 1), 0);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(1, 0), 0);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(0, 1), 0);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(2, 0), 0);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(2, 1), 0);
+  EXPECT_DOUBLE_EQ(cameraIntrinsics(2, 2), 1);
 
   // Verify that changing camera size changes intrinsics
   height = 1000;


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Fix compile warnings:

```sh
warning: comparing floating-point with ‘==’ or ‘!=’ is unsafe [-Wfloat-equal]
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

