### PR TITLE
Prepare for 6.6.2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-rendering6 VERSION 6.6.1)
+project(ignition-rendering6 VERSION 6.6.2)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,14 @@
 ## Ignition Rendering
 
+### Ignition Rendering 6.6.2 (2023-10-03)
+
+1. Backport camera intrinsics calculation : Refactor
+    * [Pull request #905](https://github.com/gazebosim/gz-rendering/pull/905)
+    * [Pull request #929](https://github.com/gazebosim/gz-rendering/pull/929)
+
+1. Revert mesh viewer background color back to gray
+    * [Pull request #894](https://github.com/gazebosim/gz-rendering/pull/894)
+
 ### Ignition Rendering 6.6.1 (2023-09-01)
 
 1. Fixed light visual in OGRE


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.6.2 release.

Comparison to 6.6.1: https://github.com/gazebosim/gz-rendering/compare/ignition-rendering6_6.6.1...prepare_6.6.2

<!-- Add links to PRs that require this release (if needed) -->
Needed by https://github.com/gazebosim/gz-sensors/pull/383

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
