### PR TITLE
Fix use of srgb format for texture maps (from glb meshes)

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -1229,8 +1229,10 @@ void Ogre2Material::SetTextureMapDataImpl(const std::string& _name,
   if (texture->getWidth() == 0)
   {
     auto data = _img->RGBAData();
-
-    texture->setPixelFormat(Ogre::PFG_RGBA8_UNORM_SRGB);
+    Ogre::PixelFormatGpu format = Ogre::PFG_RGBA8_UNORM;
+    if (this->ogreDatablock->suggestUsingSRGB(_type))
+      format = Ogre::PFG_RGBA8_UNORM_SRGB;
+    texture->setPixelFormat(format);
     texture->setTextureType(Ogre::TextureTypes::Type2D);
     texture->setNumMipmaps(1u);
     texture->setResolution(_img->Width(), _img->Height());


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Continuing efforts from https://github.com/gazebosim/gz-common/pull/532 for fixing rendering of glb meshes, this PR fixes the texture formats for textures coming from glb meshes. Previous behavior assumes all PBR textures are in sRGB format as the result the meshes are rendered darker than it should be. Only certain textures, (e.g. diffuse, emissive, and lightmap textures) should be in sRGB.

You can test with this [water_bottle.sdf](https://gist.github.com/iche033/822062dff94db236d2f568706958d39d) world.

Before this change:

![dark_water_bottle](https://github.com/gazebosim/gz-rendering/assets/4000684/93be4faf-6e8f-4362-a618-c0f3799aea6a)


After:

![water_bottle_srgb_fix](https://github.com/gazebosim/gz-rendering/assets/4000684/3009b48a-460b-4735-b364-32d34f0d55b6)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

