### PR TITLE
Update examples to use metal as default graphics API on mac

### DIFF
--- a/examples/actor_animation/Main.cc
+++ b/examples/actor_animation/Main.cc
@@ -188,7 +188,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/actor_animation/Main.cc
+++ b/examples/actor_animation/Main.cc
@@ -188,11 +188,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/boundingbox_camera/Main.cc
+++ b/examples/boundingbox_camera/Main.cc
@@ -217,10 +217,11 @@ void buildScene(ScenePtr _scene, BoundingBoxType _type)
 
 //////////////////////////////////////////////////
 std::vector<CameraPtr> createCameras(const std::string &_engineName,
+    const std::map<std::string, std::string>& _params,
     BoundingBoxType _type)
 {
   // create and populate scene
-  RenderEngine *engine = rendering::engine(_engineName);
+  RenderEngine *engine = rendering::engine(_engineName, _params);
   if (!engine)
   {
     gzwarn << "Engine '" << _engineName
@@ -271,6 +272,16 @@ int main(int _argc, char** _argv)
     }
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
+  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
+  if (_argc > 2)
+  {
+    graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
@@ -281,7 +292,14 @@ int main(int _argc, char** _argv)
   {
     try
     {
-      cameras = createCameras(engineName, bboxType);
+      std::map<std::string, std::string> params;
+      if (engineName.compare("ogre2") == 0
+          && graphicsApi == GraphicsAPI::METAL)
+      {
+        params["metal"] = "1";
+      }
+
+      cameras = createCameras(engineName, params, bboxType);
     }
     catch (...)
     {

--- a/examples/boundingbox_camera/Main.cc
+++ b/examples/boundingbox_camera/Main.cc
@@ -272,11 +272,7 @@ int main(int _argc, char** _argv)
     }
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/camera_tracking/Main.cc
+++ b/examples/camera_tracking/Main.cc
@@ -127,11 +127,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/camera_tracking/Main.cc
+++ b/examples/camera_tracking/Main.cc
@@ -127,7 +127,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -139,7 +143,6 @@ int main(int _argc, char** _argv)
   std::vector<NodePtr> nodes;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/custom_scene_viewer/ManualSceneDemo.cc
+++ b/examples/custom_scene_viewer/ManualSceneDemo.cc
@@ -192,11 +192,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/custom_scene_viewer/ManualSceneDemo.cc
+++ b/examples/custom_scene_viewer/ManualSceneDemo.cc
@@ -192,7 +192,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/custom_shaders_uniforms/Main.cc
+++ b/examples/custom_shaders_uniforms/Main.cc
@@ -167,11 +167,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/custom_shaders_uniforms/Main.cc
+++ b/examples/custom_shaders_uniforms/Main.cc
@@ -167,7 +167,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/depth_camera/Main.cc
+++ b/examples/depth_camera/Main.cc
@@ -154,11 +154,7 @@ int main(int _argc, char** _argv)
     engineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/depth_camera/Main.cc
+++ b/examples/depth_camera/Main.cc
@@ -115,7 +115,7 @@ void buildScene(ScenePtr _scene)
   camera->SetImageFormat(PixelFormat::PF_FLOAT32_RGBA);
   camera->SetNearClipPlane(0.15);
   camera->SetFarClipPlane(10.0);
-  camera->SetAntiAliasing(2);  
+  camera->SetAntiAliasing(2);
   camera->CreateDepthTexture();
 
   root->AddChild(camera);
@@ -154,7 +154,11 @@ int main(int _argc, char** _argv)
     engineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/heightmap/Main.cc
+++ b/examples/heightmap/Main.cc
@@ -324,7 +324,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2 && buildDemScene != 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/heightmap/Main.cc
+++ b/examples/heightmap/Main.cc
@@ -324,11 +324,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2 && buildDemScene != 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/lidar_visual/Main.cc
+++ b/examples/lidar_visual/Main.cc
@@ -272,7 +272,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/lidar_visual/Main.cc
+++ b/examples/lidar_visual/Main.cc
@@ -272,11 +272,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/mesh_viewer/Main.cc
+++ b/examples/mesh_viewer/Main.cc
@@ -142,11 +142,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/mesh_viewer/Main.cc
+++ b/examples/mesh_viewer/Main.cc
@@ -142,7 +142,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -153,7 +157,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/mouse_picking/Main.cc
+++ b/examples/mouse_picking/Main.cc
@@ -135,7 +135,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -146,7 +150,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/mouse_picking/Main.cc
+++ b/examples/mouse_picking/Main.cc
@@ -135,11 +135,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/ogre2_demo/Main.cc
+++ b/examples/ogre2_demo/Main.cc
@@ -317,7 +317,11 @@ int main(int _argc, char** _argv)
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/ogre2_demo/Main.cc
+++ b/examples/ogre2_demo/Main.cc
@@ -317,11 +317,7 @@ int main(int _argc, char** _argv)
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/particles_demo/Main.cc
+++ b/examples/particles_demo/Main.cc
@@ -168,7 +168,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/particles_demo/Main.cc
+++ b/examples/particles_demo/Main.cc
@@ -168,11 +168,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/projector/Main.cc
+++ b/examples/projector/Main.cc
@@ -180,11 +180,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/projector/Main.cc
+++ b/examples/projector/Main.cc
@@ -180,7 +180,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -191,7 +195,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/render_pass/Main.cc
+++ b/examples/render_pass/Main.cc
@@ -198,7 +198,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -209,7 +213,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/render_pass/Main.cc
+++ b/examples/render_pass/Main.cc
@@ -198,11 +198,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/segmentation_camera/Main.cc
+++ b/examples/segmentation_camera/Main.cc
@@ -150,11 +150,7 @@ int main(int _argc, char** _argv)
     engineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/segmentation_camera/Main.cc
+++ b/examples/segmentation_camera/Main.cc
@@ -150,7 +150,11 @@ int main(int _argc, char** _argv)
     engineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/simple_demo/Main.cc
+++ b/examples/simple_demo/Main.cc
@@ -218,11 +218,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/simple_demo/Main.cc
+++ b/examples/simple_demo/Main.cc
@@ -218,7 +218,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -229,7 +233,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/simple_demo_qml/ThreadRenderer.cpp
+++ b/examples/simple_demo_qml/ThreadRenderer.cpp
@@ -272,7 +272,6 @@ TextureNode::TextureNode(QQuickWindow *_window)
     , window(_window)
 {
     // Our texture node must have a texture, so use the default 0 texture.
-    // createTextureFromNativeObject()
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 # ifndef _WIN32
 #   pragma GCC diagnostic push
@@ -291,7 +290,6 @@ TextureNode::TextureNode(QQuickWindow *_window)
             0,
             QSize(1, 1));
 #endif
-
 
     this->setTexture(this->texture);
     this->setFiltering(QSGTexture::Linear);

--- a/examples/text_geom/Main.cc
+++ b/examples/text_geom/Main.cc
@@ -126,7 +126,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back("ogre");
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/thermal_camera/Main.cc
+++ b/examples/thermal_camera/Main.cc
@@ -138,11 +138,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/thermal_camera/Main.cc
+++ b/examples/thermal_camera/Main.cc
@@ -138,7 +138,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/transform_control/Main.cc
+++ b/examples/transform_control/Main.cc
@@ -121,11 +121,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/transform_control/Main.cc
+++ b/examples/transform_control/Main.cc
@@ -121,7 +121,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -132,7 +136,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/view_control/Main.cc
+++ b/examples/view_control/Main.cc
@@ -167,7 +167,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -178,7 +182,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
   for (auto engineName : engineNames)
   {
     try

--- a/examples/view_control/Main.cc
+++ b/examples/view_control/Main.cc
@@ -167,11 +167,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -248,11 +248,7 @@ int main(int _argc, char** _argv)
     engine = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/visualization_demo/Main.cc
+++ b/examples/visualization_demo/Main.cc
@@ -248,7 +248,11 @@ int main(int _argc, char** _argv)
     engine = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
@@ -259,7 +263,6 @@ int main(int _argc, char** _argv)
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(engine);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {

--- a/examples/waves/Main.cc
+++ b/examples/waves/Main.cc
@@ -164,7 +164,11 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
   GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/waves/Main.cc
+++ b/examples/waves/Main.cc
@@ -164,11 +164,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/examples/wide_angle_camera/Main.cc
+++ b/examples/wide_angle_camera/Main.cc
@@ -137,10 +137,11 @@ void buildScene(ScenePtr _scene)
 }
 
 //////////////////////////////////////////////////
-CameraPtr createCamera(const std::string &_engineName)
+CameraPtr createCamera(const std::string &_engineName,
+    const std::map<std::string, std::string>& _params)
 {
   // create and populate scene
-  RenderEngine *engine = rendering::engine(_engineName);
+  RenderEngine *engine = rendering::engine(_engineName, _params);
   if (!engine)
   {
     gzwarn << "Engine '" << _engineName
@@ -168,18 +169,34 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
+#ifdef __APPLE__
+  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
+#else
+  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
+#endif
+  if (_argc > 2)
+  {
+    graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));
+  }
+
   common::Console::SetVerbosity(4);
   std::vector<std::string> engineNames;
   std::vector<CameraPtr> cameras;
 
   engineNames.push_back(ogreEngineName);
-  engineNames.push_back("optix");
 
   for (auto engineName : engineNames)
   {
     try
     {
-      CameraPtr camera = createCamera(engineName);
+      std::map<std::string, std::string> params;
+      if (engineName.compare("ogre2") == 0
+          && graphicsApi == GraphicsAPI::METAL)
+      {
+        params["metal"] = "1";
+      }
+
+      CameraPtr camera = createCamera(engineName, params);
       if (camera)
       {
         cameras.push_back(camera);

--- a/examples/wide_angle_camera/Main.cc
+++ b/examples/wide_angle_camera/Main.cc
@@ -169,11 +169,7 @@ int main(int _argc, char** _argv)
     ogreEngineName = _argv[1];
   }
 
-#ifdef __APPLE__
-  GraphicsAPI graphicsApi = GraphicsAPI::METAL;
-#else
-  GraphicsAPI graphicsApi = GraphicsAPI::OPENGL;
-#endif
+  GraphicsAPI graphicsApi = defaultGraphicsAPI();
   if (_argc > 2)
   {
     graphicsApi = GraphicsAPIUtils::Set(std::string(_argv[2]));

--- a/include/gz/rendering/Utils.hh
+++ b/include/gz/rendering/Utils.hh
@@ -29,6 +29,7 @@
 #include "gz/rendering/Camera.hh"
 #include "gz/rendering/config.hh"
 #include "gz/rendering/Export.hh"
+#include "gz/rendering/GraphicsAPI.hh"
 #include "gz/rendering/RayQuery.hh"
 #include "gz/rendering/Image.hh"
 
@@ -120,6 +121,12 @@ namespace gz
     /// \return Image in bayer format
     GZ_RENDERING_VISIBLE
     Image convertRGBToBayer(const Image &_image, PixelFormat _bayerFormat);
+
+    /// \brief Convenience function to get the default graphics API based on
+    /// current platform
+    /// \return Graphics API, i.e. METAL, OPENGL, VULKAN
+    GZ_RENDERING_VISIBLE
+    GraphicsAPI defaultGraphicsAPI();
     }
   }
 }

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -1242,7 +1242,6 @@ void Ogre2Material::SetTextureMapDataImpl(const std::string& _name,
     // upload raw color image data to gpu texture
     Ogre::Image2 img;
     img.loadDynamicImage(&data[0], false, texture);
-    // img.save(_name, 1, 1);
     img.uploadTo(texture, 0, 0);
   }
 

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -1242,6 +1242,7 @@ void Ogre2Material::SetTextureMapDataImpl(const std::string& _name,
     // upload raw color image data to gpu texture
     Ogre::Image2 img;
     img.loadDynamicImage(&data[0], false, texture);
+    // img.save(_name, 1, 1);
     img.uploadTo(texture, 0, 0);
   }
 

--- a/src/Utils.cc
+++ b/src/Utils.cc
@@ -25,8 +25,9 @@
 #include "gz/math/Vector3.hh"
 
 #include "gz/rendering/Camera.hh"
-#include "gz/rendering/RayQuery.hh"
+#include "gz/rendering/GraphicsAPI.hh"
 #include "gz/rendering/PixelFormat.hh"
+#include "gz/rendering/RayQuery.hh"
 #include "gz/rendering/Utils.hh"
 
 
@@ -391,6 +392,16 @@ Image convertRGBToBayer(const Image &_image, PixelFormat _bayerFormat)
   }
 
   return destImage;
+}
+
+/////////////////////////////////////////////////
+GraphicsAPI defaultGraphicsAPI()
+{
+#ifdef __APPLE__
+  return GraphicsAPI::METAL;
+#else
+  return GraphicsAPI::OPENGL;
+#endif
 }
 
 }


### PR DESCRIPTION

# 🦟 Bug fix

https://github.com/gazebosim/gz-rendering/issues/914

## Summary
Use `metal` as default graphics API on macOs

A couple of other minor fixes:
* Fix `simple_demo_qml` deprecation warnings
* stop loading `optix` engine as one of the default engines 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

