### PR TITLE
Set Projector emissive texture 

### DIFF
--- a/ogre2/src/Ogre2Projector.cc
+++ b/ogre2/src/Ogre2Projector.cc
@@ -168,6 +168,8 @@ void Ogre2Projector::UpdateCameraListener()
     this->dataPtr->decalNode->setVisible(true);
     this->dataPtr->decalNode->getCreator()->setDecalsDiffuse(
         this->dataPtr->decal->getDiffuseTexture());
+    this->dataPtr->decalNode->getCreator()->setDecalsEmissive(
+        this->dataPtr->decal->getEmissiveTexture());
 
     for (auto &ogreCamIt : this->dataPtr->camerasWithListener)
     {
@@ -276,6 +278,7 @@ void Ogre2Projector::CreateProjector()
       Ogre::GpuResidency::Resident);
 
   this->dataPtr->decal->setDiffuseTexture(this->dataPtr->textureDiff);
+  this->dataPtr->decal->setEmissiveTexture(this->dataPtr->textureDiff);
 
   // approximate frustum size
   common::Image image(this->textureName);
@@ -332,6 +335,8 @@ void Ogre2ProjectorCameraListener::cameraPreRenderScene(
     this->decalNode->setVisible(true);
     this->decalNode->getCreator()->setDecalsDiffuse(
         this->decal->getDiffuseTexture());
+    this->decalNode->getCreator()->setDecalsEmissive(
+        this->decal->getEmissiveTexture());
   }
 }
 


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #944

## Summary
Set projector emissive texture to be the same as the diffuse texture in ogre 2.x implementation for a more consistent result with the ogre 1.x implementation

Before (projected texture appears darker):
<img width="670" alt="projector_diffuse_only" src="https://github.com/gazebosim/gz-rendering/assets/4000684/bde1edaf-7efb-4d54-8ed8-7b4b385cb180">

After (projected texture is now brighter):
<img width="685" alt="projector_emissive" src="https://github.com/gazebosim/gz-rendering/assets/4000684/9a7f0616-8cae-4e37-a2e7-9170f0ee2445">

Here's the projector in the harmonic demo world. 
Previously I had to use a spot light to illuminate the projected texture because it was too dark. It shouldn't be necessary now with the emissive texture set.

![projector_harmonic_demo](https://github.com/gazebosim/gz-rendering/assets/4000684/629d36ed-3928-4eab-a432-a471d3c3e619)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
