### PR TITLE
Remove todo in gpu ray test

### DIFF
--- a/test/integration/gpu_rays.cc
+++ b/test/integration/gpu_rays.cc
@@ -1024,14 +1024,6 @@ TEST_F(GpuRaysTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
   delete [] scan;
   scan = nullptr;
 
-  // \todo(iche033) Implement Ogre2Heightmap::Destroy function in gz-rendering8
-  // this should not be needed once Ogre2Heightmap::Destroy is implemented.
-  if (engine->Name() == "ogre2")
-  {
-    vis->Destroy();
-    heightmap.reset();
-  }
-
   // Clean up
   engine->DestroyScene(scene);
 }


### PR DESCRIPTION

# 🦟 Bug fix


## Summary

Remove code as mentioned in the todo note now that the [OgreHeightmap::Destroy](https://github.com/gazebosim/gz-rendering/blob/93c278546da2152653f01187a910a1a0b97d7373/ogre2/include/gz/rendering/ogre2/Ogre2Heightmap.hh#L99) function is available. The test should not crash.

To run the test in your local colcon workspace:

```bash
GZ_ENGINE_TO_TEST=ogre2 ./build/gz-rendering8/bin/INTEGRATION_gpu_rays
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

