### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,6 @@ configure_file("${PROJECT_SOURCE_DIR}/cppcheck.suppress.in"
                ${PROJECT_BINARY_DIR}/cppcheck.suppress)
 
 gz_configure_build(QUIT_IF_BUILD_ERRORS
-    HIDE_SYMBOLS_BY_DEFAULT
     COMPONENTS ${RENDERING_COMPONENTS})
 
 if (GZ_RENDERING_HAVE_OGRE2)


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166