### PR TITLE
Backport ogre2 lidar performance improvement changes

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -968,6 +968,8 @@ void Ogre2GpuRays::Setup1stPass()
       passScene->setVisibilityMask(
         this->VisibilityMask() &
         ~Ogre2ParticleEmitter::kParticleVisibilityFlags);
+      passScene->mEnableForwardPlus = false;
+      passScene->setLightVisibilityMask(0x0);
     }
 
     Ogre::CompositorTargetDef *particleTargetDef =
@@ -983,6 +985,8 @@ void Ogre2GpuRays::Setup1stPass()
       // set camera custom visibility mask when rendering particles
       passScene->mVisibilityMask =
           Ogre2ParticleEmitter::kParticleVisibilityFlags;
+      passScene->mEnableForwardPlus = false;
+      passScene->setLightVisibilityMask(0x0);
     }
 
     // rt_input target - converts depth to range


### PR DESCRIPTION
# ➡️ Backport

backport of #955

Note that from `gz-rendering7` onwards, the Ogre2GpuRays' compositor was ported to a script (as seen in #955) from C++. So the changes are not directly backported. Instead, this PR sets the ogre2 compositor parameters via C++ for `ign-rendering6` (fortress).

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)

