### PR TITLE
Prepare release 6.6.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-rendering6 VERSION 6.6.2)
+project(ignition-rendering6 VERSION 6.6.3)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition Rendering
 
+### Ignition Rendering 6.6.3 (2024-01-19)
+
+1. Revert mesh viewer background color back to gray
+    * [Pull request #894](https://github.com/gazebosim/gz-rendering/pull/894)
+
 ### Ignition Rendering 6.6.2 (2023-10-03)
 
 1. Backport camera intrinsics calculation : Refactor


### PR DESCRIPTION
# 🎈 Release

Preparation for 6.6.3 release.

Comparison to 6.6.2: https://github.com/gazebosim/gz-rendering/compare/ignition-rendering6_6.6.2...jrivero_prepare_6_6_3

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to commit updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): https://github.com/gazebo-release/gz-rendering6-release/commit/30097478e36bb532d8c0cda213d96632b6f02bd5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
