### PR TITLE
Fix repeatedly loading engine when calling sceneFromFirstEngine

### DIFF
--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -381,20 +381,17 @@ RenderEngine *RenderEngineManagerPrivate::Engine(EngineInfo _info,
     std::lock_guard<std::recursive_mutex> lock(this->enginesMutex);
     // Check to see if we need to load the engine
     auto engineIt = this->engines.find(libName);
-    bool loadEngine = engineIt == this->engines.end() ||
-                      !engineIt->second;
-
-    // Load the engine plugin
-    if (loadEngine && this->LoadEnginePlugin(libName, _path))
+    // Engine is already loaded
+    if (engineIt != this->engines.end() && engineIt->second)
+    {
+      engine = engineIt->second;
+    }
+    // Load the engine
+    else if (this->LoadEnginePlugin(libName, _path))
     {
       engineIt = this->engines.find(libName);
       if (engineIt != this->engines.end())
         engine = engineIt->second;
-    }
-    else if (engineIt->second)
-    {
-      // Engine is already loaded
-      engine = engineIt->second;
     }
   }
 


### PR DESCRIPTION


# 🦟 Bug fix

Fixes #959

## Summary

Added an better checks to make sure we return the engine if it was already previously loaded instead of loading the engine again.

To test:

```
gz sim -s -r -v3 --iterations 50 model_photo_shoot.sdf
```

and the following msg should now be only printed once:

```
[Msg] Loading plugin [gz-rendering-ogre2]
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
