### PR TITLE
Skip particle passes in Ogre2DepthCamera if there are no particles in the scene

### DIFF
--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -1059,14 +1059,14 @@ void Ogre2DepthCamera::PreRender()
 
   // Disable color target (set to clear pass) if there are no rgb point cloud
   // connections
-  if (!this->dataPtr->colorTargetDef)
+  if (this->dataPtr->colorTargetDef)
   {
     Ogre::CompositorPassDefVec &colorPasses =
         this->dataPtr->colorTargetDef->getCompositorPassesNonConst();
     GZ_ASSERT(colorPasses.size() > 2u,
-              "Ogre2DepthCamera color target should contain more than 2 passes");
+        "Ogre2DepthCamera color target should contain more than 2 passes");
     GZ_ASSERT(colorPasses[0]->getType() == Ogre::PASS_CLEAR,
-              "Ogre2DepthCamera color target should start with a clear pass");
+        "Ogre2DepthCamera color target should start with a clear pass");
     colorPasses[0]->mExecutionMask =
       (this->dataPtr->newRgbPointCloud.ConnectionCount() > 0u) ?
       ~this->dataPtr->kDepthExecutionMask :this->dataPtr->kDepthExecutionMask;
@@ -1088,11 +1088,11 @@ void Ogre2DepthCamera::PreRender()
     Ogre::CompositorPassDefVec &particlePasses =
         this->dataPtr->particleTargetDef->getCompositorPassesNonConst();
     GZ_ASSERT(particlePasses.size() == 2u,
-              "Ogre2DepthCamera particle target should 2 passes");
+        "Ogre2DepthCamera particle target should 2 passes");
     GZ_ASSERT(particlePasses[0]->getType() == Ogre::PASS_CLEAR,
-              "Ogre2DepthCamera particle target should start with a clear pass");
+        "Ogre2DepthCamera particle target should start with a clear pass");
     GZ_ASSERT(particlePasses[1]->getType() == Ogre::PASS_SCENE,
-              "Ogre2DepthCamera particle target should end with a scene pass");
+        "Ogre2DepthCamera particle target should end with a scene pass");
     particlePasses[0]->mExecutionMask =
       (hasParticles) ? ~this->dataPtr->kDepthExecutionMask :
                        this->dataPtr->kDepthExecutionMask;

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -23,8 +23,6 @@
   #include <windows.h>
 #endif
 
-#include <gz/common/Timer.hh>
-
 #include <cstdint>
 #include <math.h>
 #include <gz/math/Helpers.hh>
@@ -1024,8 +1022,6 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
-  common::Timer t;
-  t.Start();
   // Our shaders rely on clamped values so enable it for this sensor
   //
   // TODO(anyone): Matias N. Goldberg (dark_sylinc) insists this is a hack
@@ -1049,9 +1045,6 @@ void Ogre2DepthCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
   this->ogreCamera->_setNeedsDepthClamp(bOldDepthClamp);
-
-  t.Stop();
-  std::cerr << t.ElapsedTime().count() << std::endl;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -23,6 +23,8 @@
   #include <windows.h>
 #endif
 
+#include <gz/common/Timer.hh>
+
 #include <cstdint>
 #include <math.h>
 #include <gz/math/Helpers.hh>
@@ -170,9 +172,11 @@ class gz::rendering::Ogre2DepthCameraPrivate
   /// improvement.
   public: const uint8_t kDepthExecutionMask = 0xEF;
 
-  /// \brief Pointer to the color target in the workspace
-  public: Ogre::CompositorTargetDef *colorTarget{nullptr};
+  /// \brief Pointer to the color target definition in the workspace
+  public: Ogre::CompositorTargetDef *colorTargetDef{nullptr};
 
+  /// \brief Pointer to the particle target definition in the workspace
+  public: Ogre::CompositorTargetDef *particleTargetDef{nullptr};
 };
 
 using namespace gz;
@@ -340,7 +344,8 @@ void Ogre2DepthCamera::Destroy()
   {
     ogreCompMgr->removeWorkspace(
         this->dataPtr->ogreCompositorWorkspace);
-    this->dataPtr->colorTarget = nullptr;
+    this->dataPtr->colorTargetDef = nullptr;
+    this->dataPtr->particleTargetDef = nullptr;
   }
 
   if (this->dataPtr->depthMaterial)
@@ -728,24 +733,24 @@ void Ogre2DepthCamera::CreateDepthTexture()
     rtvParticleTexture->depthAttachment.textureName = "particleDepthTexture";
 
     baseNodeDef->setNumTargetPass(4);
-    Ogre::CompositorTargetDef *colorTargetDef =
+    this->dataPtr->colorTargetDef =
         baseNodeDef->addTargetPass("colorTexture");
     if (validBackground)
-      colorTargetDef->setNumPasses(4);
+      this->dataPtr->colorTargetDef->setNumPasses(4);
     else
-      colorTargetDef->setNumPasses(3);
+      this->dataPtr->colorTargetDef->setNumPasses(3);
     {
       // clear pass
-      Ogre::CompositorPassSceneDef *passClear =
-          static_cast<Ogre::CompositorPassSceneDef *>(
-          colorTargetDef->addPass(Ogre::PASS_CLEAR));
+      Ogre::CompositorPassClearDef *passClear =
+          static_cast<Ogre::CompositorPassClearDef *>(
+          this->dataPtr->colorTargetDef->addPass(Ogre::PASS_CLEAR));
       passClear->mExecutionMask = this->dataPtr->kDepthExecutionMask;
 
       // scene pass - opaque
       {
         Ogre::CompositorPassSceneDef *passScene =
             static_cast<Ogre::CompositorPassSceneDef *>(
-            colorTargetDef->addPass(Ogre::PASS_SCENE));
+            this->dataPtr->colorTargetDef->addPass(Ogre::PASS_SCENE));
         passScene->mShadowNode = this->dataPtr->kShadowNodeName;
         passScene->setVisibilityMask(GZ_VISIBILITY_ALL);
         passScene->mIncludeOverlays = false;
@@ -773,7 +778,7 @@ void Ogre2DepthCamera::CreateDepthTexture()
         // quad pass
         Ogre::CompositorPassQuadDef *passQuad =
             static_cast<Ogre::CompositorPassQuadDef *>(
-            colorTargetDef->addPass(Ogre::PASS_QUAD));
+            this->dataPtr->colorTargetDef->addPass(Ogre::PASS_QUAD));
         passQuad->mMaterialName = this->dataPtr->kSkyboxMaterialName + "_"
             + this->Name();
         passQuad->mFrustumCorners =
@@ -785,7 +790,7 @@ void Ogre2DepthCamera::CreateDepthTexture()
       {
         Ogre::CompositorPassSceneDef *passScene =
             static_cast<Ogre::CompositorPassSceneDef *>(
-            colorTargetDef->addPass(Ogre::PASS_SCENE));
+            this->dataPtr->colorTargetDef->addPass(Ogre::PASS_SCENE));
         passScene->setVisibilityMask(GZ_VISIBILITY_ALL);
         // todo(anyone) PbsMaterialsShadowNode is hardcoded.
         // Although this may be just fine
@@ -815,20 +820,29 @@ void Ogre2DepthCamera::CreateDepthTexture()
       passScene->setLightVisibilityMask(0x0);
     }
 
-    Ogre::CompositorTargetDef *particleTargetDef =
+    // Ogre::CompositorTargetDef *particleTargetDef =
+    this->dataPtr->particleTargetDef =
         baseNodeDef->addTargetPass("particleTexture");
-    particleTargetDef->setNumPasses(1);
+    this->dataPtr->particleTargetDef->setNumPasses(2);
     {
+      // clear pass
+      Ogre::CompositorPassClearDef *passClear =
+          static_cast<Ogre::CompositorPassClearDef *>(
+          this->dataPtr->particleTargetDef->addPass(Ogre::PASS_CLEAR));
+      passClear->setAllClearColours(Ogre::ColourValue::Black);
+      passClear->mExecutionMask = this->dataPtr->kDepthExecutionMask;
+
       // scene pass
       Ogre::CompositorPassSceneDef *passScene =
           static_cast<Ogre::CompositorPassSceneDef *>(
-          particleTargetDef->addPass(Ogre::PASS_SCENE));
+          this->dataPtr->particleTargetDef->addPass(Ogre::PASS_SCENE));
       passScene->setAllLoadActions(Ogre::LoadAction::Clear);
       passScene->setAllClearColours(Ogre::ColourValue::Black);
       passScene->setVisibilityMask(
         Ogre2ParticleEmitter::kParticleVisibilityFlags);
       passScene->mEnableForwardPlus = false;
       passScene->setLightVisibilityMask(0x0);
+      passScene->mExecutionMask = ~this->dataPtr->kDepthExecutionMask;
     }
 
     // rt0 target - converts depth to xyz
@@ -1010,6 +1024,8 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::Render()
 {
+  common::Timer t;
+  t.Start();
   // Our shaders rely on clamped values so enable it for this sensor
   //
   // TODO(anyone): Matias N. Goldberg (dark_sylinc) insists this is a hack
@@ -1033,6 +1049,9 @@ void Ogre2DepthCamera::Render()
   this->scene->FlushGpuCommandsAndStartNewFrame(1u, false);
 
   this->ogreCamera->_setNeedsDepthClamp(bOldDepthClamp);
+
+  t.Stop();
+  std::cerr << t.ElapsedTime().count() << std::endl;
 }
 
 //////////////////////////////////////////////////
@@ -1044,32 +1063,49 @@ void Ogre2DepthCamera::PreRender()
   if (!this->dataPtr->ogreCompositorWorkspace)
     this->CreateWorkspaceInstance();
 
-  if (!this->dataPtr->colorTarget)
+
+  // Disable color target (set to clear pass) if there are no rgb point cloud
+  // connections
+  if (!this->dataPtr->colorTargetDef)
   {
-    auto engine = Ogre2RenderEngine::Instance();
-    auto ogreRoot = engine->OgreRoot();
-    Ogre::CompositorManager2 *ogreCompMgr = ogreRoot->getCompositorManager2();
-    Ogre::CompositorNodeDef *nodeDef =
-        ogreCompMgr->getNodeDefinitionNonConst(
-        this->dataPtr->ogreCompositorBaseNodeDef);
-    this->dataPtr->colorTarget = nodeDef->getTargetPass(0);
+    Ogre::CompositorPassDefVec &colorPasses =
+        this->dataPtr->colorTargetDef->getCompositorPassesNonConst();
+    GZ_ASSERT(colorPasses.size() > 2u,
+              "Ogre2DepthCamera color target should contain more than 2 passes");
+    GZ_ASSERT(colorPasses[0]->getType() == Ogre::PASS_CLEAR,
+              "Ogre2DepthCamera color target should start with a clear pass");
+    colorPasses[0]->mExecutionMask =
+      (this->dataPtr->newRgbPointCloud.ConnectionCount() > 0u) ?
+      ~this->dataPtr->kDepthExecutionMask :this->dataPtr->kDepthExecutionMask;
+    for (unsigned int i = 1; i < colorPasses.size(); ++i)
+    {
+      colorPasses[i]->mExecutionMask =
+          (this->dataPtr->newRgbPointCloud.ConnectionCount() > 0u) ?
+          this->dataPtr->kDepthExecutionMask :
+          ~this->dataPtr->kDepthExecutionMask;
+    }
   }
 
-  Ogre::CompositorPassDefVec &colorPasses =
-      this->dataPtr->colorTarget->getCompositorPassesNonConst();
-  GZ_ASSERT(colorPasses.size() > 2u,
-            "Ogre2DepthCamera color target should contain more than 2 passes");
-  GZ_ASSERT(colorPasses[0]->getType() == Ogre::PASS_CLEAR,
-            "Ogre2DepthCamera color target should start with a clear pass");
-  colorPasses[0]->mExecutionMask =
-    (this->dataPtr->newRgbPointCloud.ConnectionCount() > 0u) ?
-    ~this->dataPtr->kDepthExecutionMask :this->dataPtr->kDepthExecutionMask;
-  for (unsigned int i = 1; i < colorPasses.size(); ++i)
+  // Disable particle target (set to clear pass) if there are no particles
+  if (this->dataPtr->particleTargetDef)
   {
-    colorPasses[i]->mExecutionMask =
-        (this->dataPtr->newRgbPointCloud.ConnectionCount() > 0u) ?
-        this->dataPtr->kDepthExecutionMask :
-        ~this->dataPtr->kDepthExecutionMask;
+    bool hasParticles =
+        this->scene->OgreSceneManager()->getMovableObjectIterator(
+        Ogre::ParticleSystemFactory::FACTORY_TYPE_NAME).hasMoreElements();
+    Ogre::CompositorPassDefVec &particlePasses =
+        this->dataPtr->particleTargetDef->getCompositorPassesNonConst();
+    GZ_ASSERT(particlePasses.size() == 2u,
+              "Ogre2DepthCamera particle target should 2 passes");
+    GZ_ASSERT(particlePasses[0]->getType() == Ogre::PASS_CLEAR,
+              "Ogre2DepthCamera particle target should start with a clear pass");
+    GZ_ASSERT(particlePasses[1]->getType() == Ogre::PASS_SCENE,
+              "Ogre2DepthCamera particle target should end with a scene pass");
+    particlePasses[0]->mExecutionMask =
+      (hasParticles) ? ~this->dataPtr->kDepthExecutionMask :
+                       this->dataPtr->kDepthExecutionMask;
+    particlePasses[1]->mExecutionMask =
+      (hasParticles) ? this->dataPtr->kDepthExecutionMask :
+                       ~this->dataPtr->kDepthExecutionMask;
   }
 
   // update depth camera render passes


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Minor performance optimization to ogre2's depth camera implementation. Similar to https://github.com/gazebosim/gz-rendering/pull/965, I used execution mask to skip rendering the particle passes if there are no particles in the scene. This yields a small speed up, see the time it takes to do 1 render operation (for a 320x240 depth camera) before and after the changes in this PR:

![depth_camera_particle_profile](https://github.com/gazebosim/gz-rendering/assets/4000684/14dc69db-b007-4ae1-802f-e95dc345b004)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

