### PR TITLE
Update ogre2 symbol visibility macro

### DIFF
--- a/ogre2/src/Ogre2GlobalIlluminationCiVct.cc
+++ b/ogre2/src/Ogre2GlobalIlluminationCiVct.cc
@@ -40,7 +40,7 @@ using namespace gz;
 using namespace rendering;
 
 /// \brief Private data for the Ogre2CiVctCascadePrivate class
-class DETAIL_GZ_RENDERING_OGRE2_HIDDEN gz::rendering::Ogre2CiVctCascadePrivate
+class GZ_RENDERING_OGRE2_HIDDEN gz::rendering::Ogre2CiVctCascadePrivate
 {
   // clang-format off
   /// \brief Pointer to cascade setting
@@ -49,7 +49,7 @@ class DETAIL_GZ_RENDERING_OGRE2_HIDDEN gz::rendering::Ogre2CiVctCascadePrivate
 };
 
 /// \brief Private data for the Ogre2GlobalIlluminationCiVct class
-class DETAIL_GZ_RENDERING_OGRE2_HIDDEN
+class GZ_RENDERING_OGRE2_HIDDEN
   gz::rendering::Ogre2GlobalIlluminationCiVctPrivate
 {
   // clang-format off


### PR DESCRIPTION
# 🦟 Bug fix

Updated to use `GZ_RENDERING_OGRE2_HIDDEN` as opposed to `DETAIL_GZ_RENDERING_OGRE2_HIDDEN`. 

We actually could just remove the use of these macros in cc files as they may not be necessary, especially in ionic when symbols are hidden by default.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

