### PR TITLE
Skip particle passes in Ogre2GpuRays if there are no particles in the scene

### DIFF
--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -1032,7 +1032,8 @@ void Ogre2GpuRays::Setup1stPass()
   Ogre::CompositorNodeDef *nodeDef =
     ogreCompMgr->getNodeDefinitionNonConst("GpuRays1stPass");
   Ogre::CompositorTargetDef *target0 = nodeDef->getTargetPass(0);
-  Ogre::CompositorPassDefVec &colorPasses = target0->getCompositorPassesNonConst();
+  Ogre::CompositorPassDefVec &colorPasses =
+      target0->getCompositorPassesNonConst();
   assert(colorPasses.size() >= 1u);
   assert(colorPasses[0]->getType() == Ogre::PASS_SCENE);
   assert(dynamic_cast<Ogre::CompositorPassSceneDef *>(colorPasses[0]));

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -15,7 +15,6 @@
  *
 */
 
-#include <gz/common/Timer.hh>
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 
@@ -1113,7 +1112,8 @@ void Ogre2GpuRays::Setup1stPass()
           compoChannels,
           this->dataPtr->cubeCam[i],
           wsDefName,
-          false);
+          false, -1, 0, 0, Ogre::Vector4::ZERO, 0x00,
+          this->dataPtr->kGpuRaysExecutionMask);
 
     compoChannels.pop_back();
 
@@ -1262,8 +1262,6 @@ void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 //////////////////////////////////////////////////
 void Ogre2GpuRays::Render()
 {
-  common::Timer t;
-  t.Start();
   this->scene->StartRendering(this->dataPtr->ogreCamera);
 
   auto engine = Ogre2RenderEngine::Instance();
@@ -1283,8 +1281,6 @@ void Ogre2GpuRays::Render()
   hlmsCustomizations.minDistanceClip = -1;
 
   this->scene->FlushGpuCommandsAndStartNewFrame(6u, false);
-  t.Stop();
-  std::cerr << t.ElapsedTime().count() << std::endl;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <gz/common/Timer.hh>
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 
@@ -205,6 +206,16 @@ class GZ_RENDERING_OGRE2_HIDDEN gz::rendering::Ogre2GpuRaysPrivate
   /// \brief Max number of cameras used for creating the cubemap of depth
   /// textures for generating lidar data
   public: const unsigned int kCubeCameraCount = 6;
+
+  /// \brief Execution mask for this workspace
+  /// If particles exist in the scene, the execution mask of the particle
+  /// target will be updated to match the workspace's execution mask so that
+  /// these passes are executed, otherwise they will be skipped for performance
+  /// improvement.
+  public: const uint8_t kGpuRaysExecutionMask = 0xEF;
+
+  /// \brief Pointer to the particle target definition in the workspace
+  public: Ogre::CompositorTargetDef *particleTargetDef{nullptr};
 };
 
 using namespace gz;
@@ -621,6 +632,7 @@ void Ogre2GpuRays::Destroy()
       this->dataPtr->firstPassTextures[i] = nullptr;
     }
   }
+  this->dataPtr->particleTargetDef = nullptr;
 
   // remove 2nd pass texture, material, compositor
   if (this->dataPtr->secondPassTexture)
@@ -1021,12 +1033,17 @@ void Ogre2GpuRays::Setup1stPass()
   Ogre::CompositorNodeDef *nodeDef =
     ogreCompMgr->getNodeDefinitionNonConst("GpuRays1stPass");
   Ogre::CompositorTargetDef *target0 = nodeDef->getTargetPass(0);
-  Ogre::CompositorPassDefVec &passes = target0->getCompositorPassesNonConst();
-  assert(passes.size() >= 1u);
-  assert(passes[0]->getType() == Ogre::PASS_SCENE);
-  assert(dynamic_cast<Ogre::CompositorPassSceneDef *>(passes[0]));
+  Ogre::CompositorPassDefVec &colorPasses = target0->getCompositorPassesNonConst();
+  assert(colorPasses.size() >= 1u);
+  assert(colorPasses[0]->getType() == Ogre::PASS_SCENE);
+  assert(dynamic_cast<Ogre::CompositorPassSceneDef *>(colorPasses[0]));
   this->dataPtr->mainPassSceneDef =
-    static_cast<Ogre::CompositorPassSceneDef *>(passes[0]);
+    static_cast<Ogre::CompositorPassSceneDef *>(colorPasses[0]);
+
+  Ogre::CompositorTargetDef *target1 = nodeDef->getTargetPass(1);
+  this->dataPtr->particleTargetDef = target1;
+  GZ_ASSERT(this->dataPtr->particleTargetDef != nullptr,
+            "Unable to get particle target in Ogre2GpuRays");
 
   const std::string wsDefName = "GpuRays1stPassWorkspace";
   Ogre::CompositorWorkspaceDef *wsDef =
@@ -1245,6 +1262,8 @@ void Ogre2GpuRays::UpdateRenderTarget2ndPass()
 //////////////////////////////////////////////////
 void Ogre2GpuRays::Render()
 {
+  common::Timer t;
+  t.Start();
   this->scene->StartRendering(this->dataPtr->ogreCamera);
 
   auto engine = Ogre2RenderEngine::Instance();
@@ -1264,6 +1283,8 @@ void Ogre2GpuRays::Render()
   hlmsCustomizations.minDistanceClip = -1;
 
   this->scene->FlushGpuCommandsAndStartNewFrame(6u, false);
+  t.Stop();
+  std::cerr << t.ElapsedTime().count() << std::endl;
 }
 
 //////////////////////////////////////////////////
@@ -1271,6 +1292,27 @@ void Ogre2GpuRays::PreRender()
 {
   if (!this->dataPtr->cubeUVTexture)
     this->CreateGpuRaysTextures();
+
+  if (this->dataPtr->particleTargetDef)
+  {
+    bool hasParticles =
+        this->scene->OgreSceneManager()->getMovableObjectIterator(
+        Ogre::ParticleSystemFactory::FACTORY_TYPE_NAME).hasMoreElements();
+    Ogre::CompositorPassDefVec &particlePasses =
+        this->dataPtr->particleTargetDef->getCompositorPassesNonConst();
+    GZ_ASSERT(particlePasses.size() == 2u,
+        "Ogre2DepthCamera particle target should 2 passes");
+    GZ_ASSERT(particlePasses[0]->getType() == Ogre::PASS_CLEAR,
+        "Ogre2DepthCamera particle target should start with a clear pass");
+    GZ_ASSERT(particlePasses[1]->getType() == Ogre::PASS_SCENE,
+        "Ogre2DepthCamera particle target should end with a scene pass");
+    particlePasses[0]->mExecutionMask =
+      (hasParticles) ? ~this->dataPtr->kGpuRaysExecutionMask :
+                       this->dataPtr->kGpuRaysExecutionMask;
+    particlePasses[1]->mExecutionMask =
+      (hasParticles) ? this->dataPtr->kGpuRaysExecutionMask :
+                       ~this->dataPtr->kGpuRaysExecutionMask;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/media/materials/scripts/GpuRays.compositor
+++ b/ogre2/src/media/materials/scripts/GpuRays.compositor
@@ -45,6 +45,12 @@ compositor_node GpuRays1stPass
 
   target particleTextureRtv
   {
+    pass clear
+    {
+      execution_mask 0xEF
+      colour_value 0 0 0 1
+    }
+
     pass render_scene
     {
       load
@@ -58,6 +64,8 @@ compositor_node GpuRays1stPass
 
       enable_forwardplus no
       light_visibility_mask 0x0
+
+      execution_mask 0x00
 
       profiling_id "GpuRays1stPass Particle"
     }

--- a/ogre2/src/media/materials/scripts/GpuRays.compositor
+++ b/ogre2/src/media/materials/scripts/GpuRays.compositor
@@ -65,7 +65,7 @@ compositor_node GpuRays1stPass
       enable_forwardplus no
       light_visibility_mask 0x0
 
-      execution_mask 0x00
+      execution_mask 0x0
 
       profiling_id "GpuRays1stPass Particle"
     }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix


## Summary

Improve Ogre2GpuRays performance in the same way as done in #971 for `Ogre2DepthCamera`. Added execution mask to skip the particle passes when there are no particles in the scene

The time taken for a lidar (160 degrees FOV and 640 samples) to do a render update is shown below. The speedup is roughly ~1ms (30%). I also included the ogre1.x implementation for comparison. The ogre 1.x implementation is still faster (~5.5x) than the ogre2.x implementation

![lidar_camera_particle_profile](https://github.com/gazebosim/gz-rendering/assets/4000684/6fca7a59-6969-4408-aef8-1efe5f7b47d7)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
