### PR TITLE
Fix setting normal map when not all submeshes have texcoords (ogre2)

### DIFF
--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -382,13 +382,22 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
 
       // two dimensional texture coordinates
       // add all texture coordinate sets
-      for (unsigned int k = 0u; k < subMesh.TexCoordSetCount(); ++k)
+      if (subMesh.TexCoordSetCount() == 0u)
       {
-        if (subMesh.TexCoordCountBySet(k) > 0)
-        {
           vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
-              Ogre::VES_TEXTURE_COORDINATES, k);
+              Ogre::VES_TEXTURE_COORDINATES, 0);
           currOffset += Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+      }
+      else
+      {
+        for (unsigned int k = 0u; k < subMesh.TexCoordSetCount(); ++k)
+        {
+          if (subMesh.TexCoordCountBySet(k) > 0)
+          {
+            vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
+                Ogre::VES_TEXTURE_COORDINATES, k);
+            currOffset += Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+          }
         }
       }
 
@@ -436,12 +445,20 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
         }
 
         // Add all texture coordinate sets
-        for (unsigned int k = 0u; k < subMesh.TexCoordSetCount(); ++k)
+        if (subMesh.TexCoordSetCount() == 0u)
         {
-          if (subMesh.TexCoordCountBySet(k) > 0u)
+          *vertices++ = 0;
+          *vertices++ = 0;
+        }
+        else
+        {
+          for (unsigned int k = 0u; k < subMesh.TexCoordSetCount(); ++k)
           {
-            *vertices++ = subMesh.TexCoordBySet(j, k).X();
-            *vertices++ = subMesh.TexCoordBySet(j, k).Y();
+            if (subMesh.TexCoordCountBySet(k) > 0u)
+            {
+              *vertices++ = subMesh.TexCoordBySet(j, k).X();
+              *vertices++ = subMesh.TexCoordBySet(j, k).Y();
+            }
           }
         }
       }

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -381,13 +381,18 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
       // TODO(anyone): specular colors
 
       // two dimensional texture coordinates
-      // add all texture coordinate sets
+      // If submesh does not have texcoord sets, add one default set.
+      // This is needed otherwise ogre2 will fail to generate tangents during
+      // Ogre::v2::Mesh::importV1() and throw an ogre exception if we try to
+      // apply normal maps to a submesh. Resulting object would then appear
+      // white without any PBR textures.
       if (subMesh.TexCoordSetCount() == 0u)
       {
-          vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
-              Ogre::VES_TEXTURE_COORDINATES, 0);
-          currOffset += Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+        vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
+            Ogre::VES_TEXTURE_COORDINATES, 0);
+        currOffset += Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
       }
+      // Add all texture coordinate sets
       else
       {
         for (unsigned int k = 0u; k < subMesh.TexCoordSetCount(); ++k)
@@ -396,7 +401,8 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
           {
             vertexDecl->addElement(0, currOffset, Ogre::VET_FLOAT2,
                 Ogre::VES_TEXTURE_COORDINATES, k);
-            currOffset += Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
+            currOffset +=
+                Ogre::v1::VertexElement::getTypeSize(Ogre::VET_FLOAT2);
           }
         }
       }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
   gpu_rays
   heightmap
   lidar_visual
+  mesh
   projector
   render_pass
   scene

--- a/test/integration/mesh.cc
+++ b/test/integration/mesh.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Open Source Robotics Foundation
+ * Copyright (C) 2024 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/mesh.cc
+++ b/test/integration/mesh.cc
@@ -82,9 +82,9 @@ TEST_F(MeshTest, NormalMapWithoutTexCoord)
   std::string textureMapName0 = "red_diffuse_map";
   auto textureMapData0 = std::make_shared<common::Image>();
   auto red = std::make_unique<unsigned char[]>(3);
-  red.get()[0] = 255;
-  red.get()[1] = 0;
-  red.get()[2] = 0;
+  red.get()[0] = 255u;
+  red.get()[1] = 0u;
+  red.get()[2] = 0u;
   textureMapData0->SetFromData(red.get(), 1, 1, common::Image::RGB_INT8);
   material0->SetTextureImage(textureMapName0, textureMapData0);
 
@@ -92,9 +92,9 @@ TEST_F(MeshTest, NormalMapWithoutTexCoord)
   std::string normalMapName = "normal_map";
   auto normalMapData = std::make_shared<common::Image>();
   auto normal = std::make_unique<unsigned char[]>(3);
-  normal.get()[0] = 127;
-  normal.get()[1] = 127;
-  normal.get()[2] = 255;
+  normal.get()[0] = 127u;
+  normal.get()[1] = 127u;
+  normal.get()[2] = 255u;
   normalMapData->SetFromData(normal.get(), 1, 1, common::Image::RGB_INT8);
 
   pbr.SetNormalMap(normalMapName, common::NormalMapSpace::TANGENT,
@@ -120,9 +120,9 @@ TEST_F(MeshTest, NormalMapWithoutTexCoord)
   std::string textureMapName1 = "green_diffuse_map";
   auto textureMapData1 = std::make_shared<common::Image>();
   auto green = std::make_unique<unsigned char[]>(3);
-  green.get()[0] = 0;
-  green.get()[1] = 255;
-  green.get()[2] = 0;
+  green.get()[0] = 0u;
+  green.get()[1] = 255u;
+  green.get()[2] = 0u;
   textureMapData1->SetFromData(green.get(), 1, 1, common::Image::RGB_INT8);
   material1->SetTextureImage(textureMapName1, textureMapData1);
   mesh.AddMaterial(material1);

--- a/test/integration/mesh.cc
+++ b/test/integration/mesh.cc
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <memory>
+
+#include "CommonRenderingTest.hh"
+
+#include <gz/common/Image.hh>
+#include <gz/common/Mesh.hh>
+#include <gz/common/MeshManager.hh>
+#include <gz/common/SubMesh.hh>
+
+#include "gz/rendering/Camera.hh"
+#include "gz/rendering/Image.hh"
+#include "gz/rendering/PixelFormat.hh"
+#include "gz/rendering/Scene.hh"
+
+using namespace gz;
+using namespace rendering;
+
+class MeshTest: public CommonRenderingTest
+{
+};
+
+/////////////////////////////////////////////////
+TEST_F(MeshTest, NormalMapWithoutTexCoord)
+{
+  // Create a mesh with 2 submeshes - one with red texture and the other with
+  // green texture. Add texcoords to the red submesh but not the green submesh.
+  // Verify that we can set normal map to the red submesh and the two
+  // submeshes should be rendered correctly
+
+  ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+  scene->SetAmbientLight(1.0, 1.0, 1.0);
+  scene->SetBackgroundColor(0.0, 0.0, 1.0);
+
+  VisualPtr root = scene->RootVisual();
+  ASSERT_NE(nullptr, root);
+
+  // create directional light
+  DirectionalLightPtr light0 = scene->CreateDirectionalLight();
+  light0->SetDirection(0.0, 0.0, -1);
+  light0->SetDiffuseColor(1.0, 1.0, 1.0);
+  light0->SetSpecularColor(1.0, 1.0, 1.0);
+  root->AddChild(light0);
+
+  common::Mesh mesh;
+  common::SubMesh subMesh0;
+  subMesh0.SetName("submesh0");
+  subMesh0.AddVertex(math::Vector3d(0, 0, 0));
+  subMesh0.AddVertex(math::Vector3d(1, 0, 0));
+  subMesh0.AddVertex(math::Vector3d(1, 1, 0));
+  subMesh0.AddNormal(math::Vector3d(0, 0, 1));
+  subMesh0.AddNormal(math::Vector3d(0, 0, 1));
+  subMesh0.AddNormal(math::Vector3d(0, 0, 1));
+  subMesh0.AddIndex(0);
+  subMesh0.AddIndex(1);
+  subMesh0.AddIndex(2);
+  subMesh0.AddTexCoordBySet(math::Vector2d(0, 0), 0);
+  subMesh0.AddTexCoordBySet(math::Vector2d(0, 1), 0);
+  subMesh0.AddTexCoordBySet(math::Vector2d(0, 0), 0);
+  common::MaterialPtr material0;
+  material0 = std::make_shared<common::Material>();
+  std::string textureMapName0 = "red_diffuse_map";
+  auto textureMapData0 = std::make_shared<common::Image>();
+  auto red = std::make_unique<unsigned char[]>(3);
+  red.get()[0] = 255;
+  red.get()[1] = 0;
+  red.get()[2] = 0;
+  textureMapData0->SetFromData(red.get(), 1, 1, common::Image::RGB_INT8);
+  material0->SetTextureImage(textureMapName0, textureMapData0);
+
+  common::Pbr pbr;
+  std::string normalMapName = "normal_map";
+  auto normalMapData = std::make_shared<common::Image>();
+  auto normal = std::make_unique<unsigned char[]>(3);
+  normal.get()[0] = 127;
+  normal.get()[1] = 127;
+  normal.get()[2] = 255;
+  normalMapData->SetFromData(normal.get(), 1, 1, common::Image::RGB_INT8);
+
+  pbr.SetNormalMap(normalMapName, common::NormalMapSpace::TANGENT,
+      normalMapData);
+  material0->SetPbrMaterial(pbr);
+  mesh.AddMaterial(material0);
+  subMesh0.SetMaterialIndex(0u);
+
+  common::SubMesh subMesh1;
+  subMesh1.SetName("submesh1");
+  subMesh1.AddVertex(math::Vector3d(0, 0, 0));
+  subMesh1.AddVertex(math::Vector3d(1, 1, 0));
+  subMesh1.AddVertex(math::Vector3d(0, 1, 0));
+  subMesh1.AddNormal(math::Vector3d(0, 0, 1));
+  subMesh1.AddNormal(math::Vector3d(0, 0, 1));
+  subMesh1.AddNormal(math::Vector3d(0, 0, 1));
+  subMesh1.AddIndex(0);
+  subMesh1.AddIndex(1);
+  subMesh1.AddIndex(2);
+
+  common::MaterialPtr material1;
+  material1 = std::make_shared<common::Material>();
+  std::string textureMapName1 = "green_diffuse_map";
+  auto textureMapData1 = std::make_shared<common::Image>();
+  auto green = std::make_unique<unsigned char[]>(3);
+  green.get()[0] = 0;
+  green.get()[1] = 255;
+  green.get()[2] = 0;
+  textureMapData1->SetFromData(green.get(), 1, 1, common::Image::RGB_INT8);
+  material1->SetTextureImage(textureMapName1, textureMapData1);
+  mesh.AddMaterial(material1);
+  subMesh1.SetMaterialIndex(1u);
+
+  mesh.AddSubMesh(subMesh0);
+  mesh.AddSubMesh(subMesh1);
+
+  MeshDescriptor descriptor;
+  descriptor.meshName = "test_mesh";
+  descriptor.mesh = &mesh;
+  MeshPtr meshGeom = scene->CreateMesh(descriptor);
+
+  VisualPtr visual = scene->CreateVisual("visual");
+  visual->AddGeometry(meshGeom);
+  root->AddChild(visual);
+
+  // create camera
+  CameraPtr camera = scene->CreateCamera();
+  ASSERT_NE(nullptr, camera);
+  camera->SetLocalPosition(0.5, 0.5, 0.5);
+  camera->SetLocalRotation(0, 1.57, 0);
+  camera->SetImageWidth(32);
+  camera->SetImageHeight(32);
+  root->AddChild(camera);
+
+  Image image = camera->CreateImage();
+  camera->Capture(image);
+
+  unsigned int height = camera->ImageHeight();
+  unsigned int width = camera->ImageWidth();
+  unsigned int channelCount = PixelUtil::ChannelCount(camera->ImageFormat());
+  unsigned int step = width * channelCount;
+  unsigned char *data = image.Data<unsigned char>();
+  for (unsigned int i = 0; i < height; ++i)
+  {
+    for (unsigned int j = 0; j < step; j += channelCount)
+    {
+      unsigned int idx = i * step + j;
+      unsigned int r = data[idx];
+      unsigned int g = data[idx + 1];
+      unsigned int b = data[idx + 2];
+
+      // color should be a shade of red (submesh0) or green (submesh1)
+      EXPECT_TRUE(r > 0u || g > 0u);
+      EXPECT_EQ(b, 0u);
+    }
+  }
+
+  // Clean up
+  engine->DestroyScene(scene);
+}


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

Setting normal map to a a submesh could fail in ogre2 if the mesh contains other submeshes that do not have texture coordinates set. Ogre2 will fail to generate tangents (needed for normal maps) and throw an exception:

```
03:59:05: OGRE EXCEPTION(5:ItemIdentityException): Cannot locate an appropriate 2D texture coordinate set for all the vertex data in this mesh to create tangents from.  in Mesh::suggestTangentVectorBuildParams at ./OgreMain/src/OgreMesh.cpp (line 1913)
```

The fix is to generate texcoords for all submeshes when importing the `common::SubMesh` into ogre even if the `common::SubMesh` does not have any texcoords. 

The alternative (ideal) fix is to update ogre to just skip generating tangents for those submeshes that do not have texcoords instead of throwing an exception.

Tested with the [AnisotropyBarnLamp.glb](https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/AnisotropyBarnLamp) model.

Before the fix, the whole metal part of the lamp mesh appears white. After the fix, the PBR textures are applied correctly:

<img width="388" alt="Screenshot 2024-02-29 at 7 54 07 PM" src="https://github.com/gazebosim/gz-rendering/assets/4000684/5c3daf5c-e635-419c-b07c-2515d527eedc">




The light bulb should be transparent so there's another bug somewhere else and that still needs to be fixed. For comparison, see the [result rendered by threejs](https://threejs.org/examples/webgl_loader_gltf_anisotropy.html)

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
