### PR TITLE
Handle null mesh pointers in examples

### DIFF
--- a/examples/actor_animation/Main.cc
+++ b/examples/actor_animation/Main.cc
@@ -69,6 +69,12 @@ void buildScene(ScenePtr _scene, std::vector<VisualPtr> &_visuals,
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
   //! [load mesh]
+  if (!descriptor.mesh)
+  {
+    gzerr << "Failed to load mesh: " << descriptor.meshName << std::endl;
+    // Do not launch example if actor mesh is not found.
+    return;
+  }
 
   // add bvh animation
   //! [add animation]

--- a/examples/boundingbox_camera/Main.cc
+++ b/examples/boundingbox_camera/Main.cc
@@ -53,18 +53,26 @@ VisualPtr createDuck(ScenePtr _scene,
   n_ducks++;
 
   // create a mesh
-  VisualPtr mesh = _scene->CreateVisual(
-    "duck" + std::to_string(n_ducks));
-  mesh->SetLocalPosition(_position);
-  mesh->SetLocalRotation(_rotation);
+  VisualPtr mesh;
   MeshDescriptor descriptor;
   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "duck.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  mesh->SetMaterial(_material);
-  mesh->SetUserData("label", 5);
+  if (descriptor.mesh)
+  {
+    mesh = _scene->CreateVisual(
+      "duck" + std::to_string(n_ducks));
+    mesh->SetLocalPosition(_position);
+    mesh->SetLocalRotation(_rotation);
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    mesh->SetMaterial(_material);
+    mesh->SetUserData("label", 5);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 
   return mesh;
 }
@@ -168,7 +176,8 @@ void buildScene(ScenePtr _scene, BoundingBoxType _type)
 
   // create a mesh
   auto duck = createDuck(_scene, math::Vector3d(5, 0, 0), skyBlue);
-  root->AddChild(duck);
+  if (duck)
+    root->AddChild(duck);
 
   // create a sphere1
   auto sphere1 = createSphere(_scene, math::Vector3d(3, -1.5, 0), green);

--- a/examples/depth_camera/Main.cc
+++ b/examples/depth_camera/Main.cc
@@ -57,17 +57,24 @@ void buildScene(ScenePtr _scene)
   root->AddChild(plane);
 
   // create a mesh
-  VisualPtr mesh = _scene->CreateVisual();
-  mesh->SetLocalPosition(3, 0, 0);
-  mesh->SetLocalRotation(1.5708, 0, 2.0);
   MeshDescriptor descriptor;
   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "duck.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  mesh->SetUserData("label", 5);
-  root->AddChild(mesh);
+  if (descriptor.mesh)
+  {
+    VisualPtr mesh = _scene->CreateVisual();
+    mesh->SetLocalPosition(3, 0, 0);
+    mesh->SetLocalRotation(1.5708, 0, 2.0);
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    mesh->SetUserData("label", 5);
+    root->AddChild(mesh);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 
   // create a box
   VisualPtr box = _scene->CreateVisual("box");

--- a/examples/global_illumination/Main.cc
+++ b/examples/global_illumination/Main.cc
@@ -70,18 +70,25 @@ void buildScene(ScenePtr _scene)
   matPBR->SetEnvironmentMap(environmentMap);
 
   // create mesh for PBR
-  VisualPtr meshPBR = _scene->CreateVisual("pump");
-  meshPBR->SetLocalPosition(2, 0.0, -0.3);
-  meshPBR->SetLocalRotation(0, 0, 0);
   MeshDescriptor descriptorPBR;
   descriptorPBR.meshName = common::joinPaths(RESOURCE_PATH, "pump.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptorPBR.mesh = meshManager->Load(descriptorPBR.meshName);
-  MeshPtr meshPBRGeom = _scene->CreateMesh(descriptorPBR);
-  meshPBRGeom->SetMaterial(matPBR);
-  meshPBR->AddGeometry(meshPBRGeom);
-  meshPBR->SetStatic(true);
-  root->AddChild(meshPBR);
+  if (descriptorPBR.mesh)
+  {
+    VisualPtr meshPBR = _scene->CreateVisual("pump");
+    meshPBR->SetLocalPosition(2, 0.0, -0.3);
+    meshPBR->SetLocalRotation(0, 0, 0);
+    MeshPtr meshPBRGeom = _scene->CreateMesh(descriptorPBR);
+    meshPBRGeom->SetMaterial(matPBR);
+    meshPBR->AddGeometry(meshPBRGeom);
+    meshPBR->SetStatic(true);
+    root->AddChild(meshPBR);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptorPBR.meshName << std::endl;
+  }
 
   // create green material
   MaterialPtr green = _scene->CreateMaterial();

--- a/examples/lux_core_engine/Main.cc
+++ b/examples/lux_core_engine/Main.cc
@@ -123,19 +123,25 @@ void buildScene(ScenePtr _scene)
   box2->SetMaterial(boxMaterial2);
 
   // Duck Scene
-  MaterialPtr matte = _scene->CreateMaterial();
-  matte->SetDiffuse(1.0, 0.0, 0.0);
-
-  VisualPtr mesh = _scene->CreateVisual();
   MeshDescriptor descriptor;
   descriptor.meshName = "media/duck.dae";
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  mesh->SetLocalRotation(GZ_PI / 2, 0, -GZ_PI / 4);
-  mesh->SetLocalPosition(-0.25, -1.25, 1.25);
-  mesh->SetMaterial(matte);
+  if (descriptor.mesh)
+  {
+    VisualPtr mesh = _scene->CreateVisual();
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    mesh->SetLocalRotation(GZ_PI / 2, 0, -GZ_PI / 4);
+    mesh->SetLocalPosition(-0.25, -1.25, 1.25);
+    MaterialPtr matte = _scene->CreateMaterial();
+    matte->SetDiffuse(1.0, 0.0, 0.0);
+    mesh->SetMaterial(matte);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/examples/mesh_viewer/Main.cc
+++ b/examples/mesh_viewer/Main.cc
@@ -56,27 +56,41 @@ void buildScene(ScenePtr _scene)
   root->AddChild(light0);
 
 //! [create a mesh]
-  VisualPtr mesh = _scene->CreateVisual();
-  mesh->SetLocalPosition(3, 0, 0);
-  mesh->SetLocalRotation(1.5708, 0, 2.0);
   MeshDescriptor descriptor;
   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "duck.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  root->AddChild(mesh);
+  if (descriptor.mesh)
+  {
+    VisualPtr mesh = _scene->CreateVisual();
+    mesh->SetLocalPosition(3, 0, 0);
+    mesh->SetLocalRotation(1.5708, 0, 2.0);
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    root->AddChild(mesh);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 //! [create a mesh]
 
   // create a pbr glb mesh
-  mesh = _scene->CreateVisual();
-  mesh->SetLocalPosition(3, 2, 0);
-  mesh->SetLocalRotation(0, 0, 0);
   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "AmbulanceStretcher.glb");
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  root->AddChild(mesh);
+  if (descriptor.mesh)
+  {
+    VisualPtr mesh = _scene->CreateVisual();
+    mesh->SetLocalPosition(3, 2, 0);
+    mesh->SetLocalRotation(0, 0, 0);
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    root->AddChild(mesh);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 
   // create gray material
   MaterialPtr gray = _scene->CreateMaterial();

--- a/examples/ogre2_demo/Main.cc
+++ b/examples/ogre2_demo/Main.cc
@@ -72,17 +72,24 @@ void buildScene(ScenePtr _scene)
   matPBR->SetEnvironmentMap(environmentMap);
 
   // create mesh for PBR
-  VisualPtr meshPBR = _scene->CreateVisual("pump");
-  meshPBR->SetLocalPosition(2, 0.0, -0.3);
-  meshPBR->SetLocalRotation(0, 0, 0);
   MeshDescriptor descriptorPBR;
   descriptorPBR.meshName = common::joinPaths(RESOURCE_PATH, "pump.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptorPBR.mesh = meshManager->Load(descriptorPBR.meshName);
-  MeshPtr meshPBRGeom = _scene->CreateMesh(descriptorPBR);
-  meshPBRGeom->SetMaterial(matPBR);
-  meshPBR->AddGeometry(meshPBRGeom);
-  root->AddChild(meshPBR);
+  if (descriptorPBR.mesh)
+  {
+    VisualPtr meshPBR = _scene->CreateVisual("pump");
+    meshPBR->SetLocalPosition(2, 0.0, -0.3);
+    meshPBR->SetLocalRotation(0, 0, 0);
+    MeshPtr meshPBRGeom = _scene->CreateMesh(descriptorPBR);
+    meshPBRGeom->SetMaterial(matPBR);
+    meshPBR->AddGeometry(meshPBRGeom);
+    root->AddChild(meshPBR);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptorPBR.meshName << std::endl;
+  }
 
   // create green material
   MaterialPtr green = _scene->CreateMaterial();

--- a/examples/particles_demo/Main.cc
+++ b/examples/particles_demo/Main.cc
@@ -56,16 +56,23 @@ void buildScene(ScenePtr _scene)
   root->AddChild(light0);
 
   //! [create a mesh]
-  VisualPtr mesh = _scene->CreateVisual();
-  mesh->SetLocalPosition(3, 0, 0);
-  mesh->SetLocalRotation(1.5708, 0, 2.0);
   MeshDescriptor descriptor;
   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "duck.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  root->AddChild(mesh);
+  if (descriptor.mesh)
+  {
+    VisualPtr mesh = _scene->CreateVisual();
+    mesh->SetLocalPosition(3, 0, 0);
+    mesh->SetLocalRotation(1.5708, 0, 2.0);
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    root->AddChild(mesh);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
   //! [create a mesh]
 
   // create gray material

--- a/examples/segmentation_camera/Main.cc
+++ b/examples/segmentation_camera/Main.cc
@@ -57,17 +57,24 @@ void buildScene(ScenePtr _scene)
   root->AddChild(plane);
 
   // create a mesh
-  VisualPtr mesh = _scene->CreateVisual();
-  mesh->SetLocalPosition(3, 0, 0);
-  mesh->SetLocalRotation(1.5708, 0, 2.0);
   MeshDescriptor descriptor;
   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "duck.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  mesh->SetUserData("label", 5);
-  root->AddChild(mesh);
+  if (descriptor.mesh)
+  {
+    VisualPtr mesh = _scene->CreateVisual();
+    mesh->SetLocalPosition(3, 0, 0);
+    mesh->SetLocalRotation(1.5708, 0, 2.0);
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    mesh->SetUserData("label", 5);
+    root->AddChild(mesh);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 
   // create a box
   VisualPtr box = _scene->CreateVisual("box");

--- a/examples/thermal_camera/Main.cc
+++ b/examples/thermal_camera/Main.cc
@@ -56,18 +56,25 @@ void buildScene(ScenePtr _scene)
   root->AddChild(plane);
 
   // create a mesh
-  VisualPtr mesh = _scene->CreateVisual();
-  mesh->SetLocalPosition(3, 0, 0);
-  mesh->SetLocalRotation(1.5708, 0, 2.0);
+  float temperature = 315.0;
   MeshDescriptor descriptor;
   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "duck.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
-  MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-  mesh->AddGeometry(meshGeom);
-  float temperature = 315.0;
-  mesh->SetUserData("temperature", temperature);
-  root->AddChild(mesh);
+  if (descriptor.mesh)
+  {
+    VisualPtr mesh = _scene->CreateVisual();
+    mesh->SetLocalPosition(3, 0, 0);
+    mesh->SetLocalRotation(1.5708, 0, 2.0);
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    mesh->AddGeometry(meshGeom);
+    mesh->SetUserData("temperature", temperature);
+    root->AddChild(mesh);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 
   // create a box
   VisualPtr box = _scene->CreateVisual("box");

--- a/examples/waves/Main.cc
+++ b/examples/waves/Main.cc
@@ -106,18 +106,25 @@ void buildScene(ScenePtr _scene,
   shader->SetVertexShader(vertexShaderPath);
   shader->SetFragmentShader(fragmentShaderPath);
 
-   // create waves visual
-   VisualPtr waves = _scene->CreateVisual("waves");
-   MeshDescriptor descriptor;
-   descriptor.meshName = common::joinPaths(RESOURCE_PATH, "mesh.dae");
-   common::MeshManager *meshManager = common::MeshManager::Instance();
-   descriptor.mesh = meshManager->Load(descriptor.meshName);
-   MeshPtr meshGeom = _scene->CreateMesh(descriptor);
-   waves->AddGeometry(meshGeom);
-   waves->SetLocalPosition(3, 0, 0);
-   waves->SetLocalScale(1, 1, 1);
-   waves->SetMaterial(shader);
-   root->AddChild(waves);
+  // create waves visual
+  MeshDescriptor descriptor;
+  descriptor.meshName = common::joinPaths(RESOURCE_PATH, "mesh.dae");
+  common::MeshManager *meshManager = common::MeshManager::Instance();
+  descriptor.mesh = meshManager->Load(descriptor.meshName);
+  if (descriptor.mesh)
+  {
+    VisualPtr waves = _scene->CreateVisual("waves");
+    MeshPtr meshGeom = _scene->CreateMesh(descriptor);
+    waves->AddGeometry(meshGeom);
+    waves->SetLocalPosition(3, 0, 0);
+    waves->SetLocalScale(1, 1, 1);
+    waves->SetMaterial(shader);
+    root->AddChild(waves);
+  }
+  else
+  {
+    gzerr << "Failed load mesh: " << descriptor.meshName << std::endl;
+  }
 
   // create camera
   CameraPtr camera = _scene->CreateCamera("camera");

--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -20,7 +20,6 @@
 
 #include <gz/common/Console.hh>
 #include <gz/common/Material.hh>
-#include <gz/common/MeshManager.hh>
 #include <gz/common/Skeleton.hh>
 #include <gz/common/SkeletonAnimation.hh>
 #include <gz/common/SubMesh.hh>

--- a/ogre2/src/Ogre2Marker.cc
+++ b/ogre2/src/Ogre2Marker.cc
@@ -27,9 +27,6 @@
 
 #include <gz/common/Console.hh>
 
-#include <gz/common/Mesh.hh>
-#include <gz/common/MeshManager.hh>
-
 #include "gz/rendering/ogre2/Ogre2Capsule.hh"
 #include "gz/rendering/ogre2/Ogre2Conversions.hh"
 #include "gz/rendering/ogre2/Ogre2DynamicRenderable.hh"

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -20,7 +20,6 @@
 
 #include <gz/common/Console.hh>
 #include <gz/common/Material.hh>
-#include <gz/common/MeshManager.hh>
 #include <gz/common/Skeleton.hh>
 #include <gz/common/SkeletonAnimation.hh>
 #include <gz/common/SubMesh.hh>

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -21,7 +21,6 @@
 
 #include <gz/common/Console.hh>
 #include <gz/common/Mesh.hh>
-#include <gz/common/MeshManager.hh>
 
 #include "gz/rendering/ArrowVisual.hh"
 #include "gz/rendering/AxisVisual.hh"

--- a/test/common_test/MeshDescriptor_TEST.cc
+++ b/test/common_test/MeshDescriptor_TEST.cc
@@ -29,7 +29,7 @@
 using namespace gz;
 using namespace rendering;
 
-class MeshDescriptorTest : public CommonRenderingTest 
+class MeshDescriptorTest : public CommonRenderingTest
 {
 };
 

--- a/test/common_test/Mesh_TEST.cc
+++ b/test/common_test/Mesh_TEST.cc
@@ -103,6 +103,7 @@ TEST_F(MeshTest, MeshSkeleton)
   descriptor.meshName = common::joinPaths(TEST_MEDIA_PATH, "walk.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
+  ASSERT_NE(nullptr, descriptor.mesh);
 
   MeshPtr mesh = scene->CreateMesh(descriptor);
   actorVisual->AddGeometry(mesh);
@@ -181,6 +182,7 @@ TEST_F(MeshTest, MeshSkeletonAnimation)
   descriptor.meshName = common::joinPaths(TEST_MEDIA_PATH, "walk.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
+  ASSERT_NE(nullptr, descriptor.mesh);
   MeshPtr mesh = scene->CreateMesh(descriptor);
 
   EXPECT_TRUE(mesh->HasSkeleton());

--- a/test/integration/waves.cc
+++ b/test/integration/waves.cc
@@ -119,6 +119,7 @@ TEST_F(WavesTest, Waves)
       TEST_MEDIA_PATH, "meshes", "mesh.dae");
   common::MeshManager *meshManager = common::MeshManager::Instance();
   descriptor.mesh = meshManager->Load(descriptor.meshName);
+  ASSERT_NE(nullptr, descriptor.mesh);
   MeshPtr meshGeom = scene->CreateMesh(descriptor);
   waves->AddGeometry(meshGeom);
   waves->SetLocalPosition(3, 0, 0);


### PR DESCRIPTION


# 🦟 Bug fix

## Summary
Add some sanity checks and for null pointers returned by `common::MeshManager::Load()`.

Also removed a few `MeshManager` headers that are not used.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

