### PR TITLE
Fix compilation on simple_demo_qml on Windows

### DIFF
--- a/examples/simple_demo_qml/GzRenderer.cc
+++ b/examples/simple_demo_qml/GzRenderer.cc
@@ -25,6 +25,8 @@
 
 #include <gz/common/Console.hh>
 
+#include <gz/math/Helpers.hh>
+
 #include <iostream>
 
 using namespace gz;
@@ -285,7 +287,7 @@ void GzRenderer::InitEngine()
 //////////////////////////////////////////////////
 void GzRenderer::UpdateCamera()
 {
-  double angle = this->cameraOffset / 2 * M_PI;
+  double angle = this->cameraOffset / 2 * GZ_PI;
   double x = sin(angle) * 3.0 + 3.0;
   double y = cos(angle) * 3.0;
   this->camera->SetLocalPosition(x, y, 0.0);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation of `simple_demo_qml` on Windows.

## Summary

This is not particularly useful as it is, as it crashes with error:

~~~
D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\examples\simple_demo_qml\build>pixi run simple_demo_qml.exe --help
[Msg] Loading plugin [gz-rendering-ogre2]
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): wglMakeCurrent failed: The pixel format is invalid.
 in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 624)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1285]  Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in Win32Window::create at D:\bld\ogre-next_1712610228408\work\RenderSystems\GL3Plus\src\windowing\win32\OgreWin32Window.cpp (line 230)
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1293] Unable to create the rendering window after [11] attempts.
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1191] Failed to create dummy render window.
[Err] [D:\src\pixi_gazebodistro\ionic_ws\src\gz-rendering\ogre2\src\Ogre2RenderEngine.cc:1192] Please see the troubleshooting page for possible fixes: https://gazebosim.org/docs/fortress/troubleshooting
~~~

However, as this it is the same crash of https://github.com/gazebosim/gz-sim/issues/2089, it is quite useful to debug that problem.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
