### PR TITLE
Fix simple_demo on Windows

### DIFF
--- a/examples/simple_demo/CMakeLists.txt
+++ b/examples/simple_demo/CMakeLists.txt
@@ -17,7 +17,9 @@ if (NOT APPLE)
   link_directories(${GLEW_LIBRARY_DIRS})
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+if(NOT MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
 
 add_executable(simple_demo Main.cc GlutWindow.cc)
 

--- a/examples/simple_demo/GlutWindow.cc
+++ b/examples/simple_demo/GlutWindow.cc
@@ -19,6 +19,13 @@
   #include <OpenGL/gl.h>
   #include <OpenGL/OpenGL.h>
   #include <GLUT/glut.h>
+#elif _WIN32
+  #define NOMINMAX
+  #include <windows.h>
+  #include <GL/glew.h>
+  #include <GL/glu.h>
+  #include <GL/glut.h>
+  #include "Wingdi.h"
 #else
   #include <GL/glew.h>
   #include <GL/gl.h>
@@ -57,6 +64,10 @@ bool g_initContext = false;
   CGLContextObj g_context;
   CGLContextObj g_glutContext;
 #elif _WIN32
+  HGLRC g_context = 0;
+  HDC g_display = 0;
+  HGLRC g_glutContext = 0;
+  HDC g_glutDisplay = 0;
 #else
   GLXContext g_context;
   Display *g_display;
@@ -73,7 +84,7 @@ double g_offset = 0.0;
 void updateCameras()
 
 {
-  double angle = g_offset / 2 * M_PI;
+  double angle = g_offset / 2 * GZ_PI;
   double x = sin(angle) * 3.0 + 3.0;
   double y = cos(angle) * 3.0;
   for (ir::CameraPtr camera : g_cameras)
@@ -91,6 +102,11 @@ void displayCB()
 #if __APPLE__
   CGLSetCurrentContext(g_context);
 #elif _WIN32
+  if (!wglMakeCurrent(g_display, g_context))
+  {
+    std::cerr << "Error calling wglMakeCurrent" << '\n';
+    exit(-1);
+  }
 #else
   if (g_display)
   {
@@ -103,6 +119,7 @@ void displayCB()
 #if __APPLE__
   CGLSetCurrentContext(g_glutContext);
 #elif _WIN32
+  wglMakeCurrent(g_glutDisplay, g_glutContext);
 #else
   glXMakeCurrent(g_glutDisplay, g_glutDrawable, g_glutContext);
 #endif
@@ -182,6 +199,8 @@ void run(std::vector<ir::CameraPtr> _cameras)
 #if __APPLE__
   g_context = CGLGetCurrentContext();
 #elif _WIN32
+  g_context = wglGetCurrentContext();
+  g_display = wglGetCurrentDC();
 #else
   g_context = glXGetCurrentContext();
   g_display = glXGetCurrentDisplay();
@@ -196,6 +215,8 @@ void run(std::vector<ir::CameraPtr> _cameras)
 #if __APPLE__
   g_glutContext = CGLGetCurrentContext();
 #elif _WIN32
+  g_glutContext = wglGetCurrentContext();
+  g_glutDisplay = wglGetCurrentDC();
 #else
   g_glutDisplay = glXGetCurrentDisplay();
   g_glutDrawable = glXGetCurrentDrawable();

--- a/examples/simple_demo/Main.cc
+++ b/examples/simple_demo/Main.cc
@@ -22,6 +22,8 @@
   #include <GL/glew.h>
   #include <GL/gl.h>
   #include <GL/glut.h>
+#else
+  #include <GL/glut.h>
 #endif
 
 #include <iostream>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation of simple_demo on Windows.

## Summary

I took the missing Windows logic from `wide_angle_camera` example. Differently from https://github.com/gazebosim/gz-rendering/pull/986, after this fix `simple_demo` works fine on Windows both with ogre and ogre2 plugins.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

