### PR TITLE
Fix unused variable warnings

### DIFF
--- a/include/gz/rendering/base/BaseGlobalIlluminationVct.hh
+++ b/include/gz/rendering/base/BaseGlobalIlluminationVct.hh
@@ -127,6 +127,7 @@ namespace gz
     void BaseGlobalIlluminationVct<T>::SetResolution(
       const uint32_t _resolution[3])
     {
+      (void)(_resolution);
     GZ_ASSERT(math::isPowerOfTwo(_resolution[0]),
           "Resolution must be power of 2");
     GZ_ASSERT(math::isPowerOfTwo(_resolution[1]),
@@ -148,6 +149,7 @@ namespace gz
     void BaseGlobalIlluminationVct<T>::SetOctantCount(
       const uint32_t _octants[3])
     {
+      (void)(_octants);
     GZ_ASSERT(_octants[0] > 0u, "Subdivision must be greater than 0");
     GZ_ASSERT(_octants[1] > 0u, "Subdivision must be greater than 0");
     GZ_ASSERT(_octants[2] > 0u, "Subdivision must be greater than 0");


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Warning started as of https://build.osrfoundation.org/view/gz-ionic/job/gz_rendering-ci-main-jammy-amd64/42/, likely because of https://github.com/gazebosim/gz-cmake/pull/418.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
