### PR TITLE
Find python directly instead of using GzPython

### DIFF
--- a/test/gz_rendering_test.cmake
+++ b/test/gz_rendering_test.cmake
@@ -15,7 +15,7 @@
 #
 #################################################
 
-include(GzPython)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 # Determine Ubuntu version to enable/disable vulkan backend testing
 if (UNIX AND NOT APPLE)


### PR DESCRIPTION
# 🎉 New feature

Part of gazebosim/gz-cmake#350.

## Summary

I suggested in https://github.com/gazebosim/gz-cmake/issues/350#issuecomment-1907453341 that we find python directly so that `GzPython` can be deprecated, and this is a step towards that goal.

## Test it

Compile and run tests and verify that the `check_test_ran.py` script still runs.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
