### PR TITLE
Fixed integer underflow in OgreDistortionPass

### DIFF
--- a/ogre/src/OgreDistortionPass.cc
+++ b/ogre/src/OgreDistortionPass.cc
@@ -236,8 +236,10 @@ void OgreDistortionPass::CreateRenderPass()
 
       // Make sure the distorted pixel is within the texture dimensions
       if (distortedCol >= 0 && distortedRow >= 0 &&
-          distortedCol < this->dataPtr->distortionTexWidth &&
-          distortedRow < this->dataPtr->distortionTexHeight)
+          static_cast<unsigned int>(distortedCol) <
+            this->dataPtr->distortionTexWidth &&
+          static_cast<unsigned int>(distortedRow) <
+            this->dataPtr->distortionTexHeight)
       {
         distortedIdx = distortedRow * this->dataPtr->distortionTexWidth +
           distortedCol;

--- a/ogre/src/OgreDistortionPass.cc
+++ b/ogre/src/OgreDistortionPass.cc
@@ -196,8 +196,8 @@ void OgreDistortionPass::CreateRenderPass()
       distortedLocation,
       newDistortedCoordinates,
       currDistortedCoordinates;
-  unsigned int distortedIdx,
-      distortedCol,
+  unsigned int distortedIdx;
+  int distortedCol,
       distortedRow;
   double normalizedColLocation, normalizedRowLocation;
 
@@ -223,9 +223,9 @@ void OgreDistortionPass::CreateRenderPass()
           focalLength);
 
       // compute the index in the distortion map
-      distortedCol = static_cast<unsigned int>(round(distortedLocation.X() *
+      distortedCol = static_cast<int>(round(distortedLocation.X() *
         this->dataPtr->distortionTexWidth));
-      distortedRow = static_cast<unsigned int>(round(distortedLocation.Y() *
+      distortedRow = static_cast<int>(round(distortedLocation.Y() *
         this->dataPtr->distortionTexHeight));
 
       // Note that the following makes sure that, for significant distortions,
@@ -235,7 +235,8 @@ void OgreDistortionPass::CreateRenderPass()
       // nonlegacy distortion modes.
 
       // Make sure the distorted pixel is within the texture dimensions
-      if (distortedCol < this->dataPtr->distortionTexWidth &&
+      if (distortedCol >= 0 && distortedRow >= 0 &&
+          distortedCol < this->dataPtr->distortionTexWidth &&
           distortedRow < this->dataPtr->distortionTexHeight)
       {
         distortedIdx = distortedRow * this->dataPtr->distortionTexWidth +


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

I've noticed the code is prone to underflow because the distorted pixel values can be negative. Practically, the underflow was not a problem because the 4e9 values coming from the underflow never matched the condition to be lower than texture width. But it is an underflow and it deserves to be fixed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.