### PR TITLE
Workaround on warnings for Ubuntu Noble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,9 @@ set(GZ_RENDERING_ENGINE_INSTALL_DIR
 if(NOT MSVC)
   #--------------------------------------
   # Find CUDA
+  # Module is being removed in CMake and needs a non trivial
+  # migration https://cmake.org/cmake/help/latest/policy/CMP0146.html
+  cmake_policy(SET CMP0146 OLD)
   find_package(CUDA)
 
   #--------------------------------------

--- a/include/gz/rendering/Camera.hh
+++ b/include/gz/rendering/Camera.hh
@@ -28,6 +28,13 @@
 #include "gz/rendering/Sensor.hh"
 #include "gz/rendering/Scene.hh"
 
+// overloaded-virtuals warnings appeared on Ubuntu Noble
+// GCC-13. it is not easy to fix them without breaking ABI
+// ignore them to preserve current ABI.
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
 
 namespace gz
 {
@@ -369,4 +376,9 @@ namespace gz
     }
   }
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/include/gz/rendering/Object.hh
+++ b/include/gz/rendering/Object.hh
@@ -22,6 +22,14 @@
 #include "gz/rendering/RenderTypes.hh"
 #include "gz/rendering/Export.hh"
 
+// overloaded-virtuals warnings appeared on Ubuntu Noble
+// GCC-13. it is not easy to fix them without breaking ABI
+// ignore them to preserve current ABI.
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
 namespace gz
 {
   namespace rendering
@@ -69,4 +77,9 @@ namespace gz
     }
   }
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/include/gz/rendering/Visual.hh
+++ b/include/gz/rendering/Visual.hh
@@ -22,6 +22,14 @@
 #include "gz/rendering/config.hh"
 #include "gz/rendering/Node.hh"
 
+// overloaded-virtuals warnings appeared on Ubuntu Noble
+// GCC-13. it is not easy to fix them without breaking ABI
+// ignore them to preserve current ABI.
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
 namespace gz
 {
   namespace rendering
@@ -206,4 +214,9 @@ namespace gz
     }
   }
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
+
 #endif

--- a/include/gz/rendering/base/BaseRenderTarget.hh
+++ b/include/gz/rendering/base/BaseRenderTarget.hh
@@ -25,6 +25,14 @@
 #include "gz/rendering/Scene.hh"
 #include "gz/rendering/base/BaseRenderTypes.hh"
 
+// overloaded-virtuals warnings appeared on Ubuntu Noble
+// GCC-13. it is not easy to fix them without breaking ABI
+// ignore them to preserve current ABI.
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
+
 namespace gz
 {
   namespace rendering
@@ -406,4 +414,9 @@ namespace gz
     }
   }
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+# pragma GCC diagnostic pop
+#endif
+
 #endif


### PR DESCRIPTION
- **Add pragma ignores for Woverloaded-virtual**
- **Ignore the warning on FindCUDA removal**

# 🦟 Bug fix

## Summary

The support for Ubuntu Noble needs a couple of tweaks for new warnings.

 * GCC warnings coming from #991. To preserve the ABI in gz-rendering8 I'm adding pragmas to ignore the warnings and keep the ABI as it is currently.
 * CMake is complaining about the use of `FindCUDA` module, which is being removed. The transition was not trivial to me and the Optix component probably does not worth too much effort at this point so I'm just silencing the warning by now.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.