### PR TITLE
Parse correctly OGRE2_RESOURCE_PATH on Windows

### DIFF
--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -16,7 +16,13 @@ set(engine_name "ogre2")
 gz_add_component(${engine_name} SOURCES ${sources} GET_TARGET_NAME ogre2_target)
 
 set(OGRE2_RESOURCE_PATH_STR "${OGRE2_RESOURCE_PATH}")
-string(REPLACE ";" ":" OGRE2_RESOURCE_PATH_STR "${OGRE2_RESOURCE_PATH}")
+# On non-Windows, we need to convert the CMake list delimited (;) to the 
+# list delimiter used in list of paths in code (:)
+# On Windows, the list delimiter in code is already ;, not need to change it to :
+if(NOT WIN32)
+  string(REPLACE ";" ":" OGRE2_RESOURCE_PATH_STR "${OGRE2_RESOURCE_PATH}")
+endif()
+
 set_property(
   SOURCE Ogre2RenderEngine.cc
   PROPERTY COMPILE_DEFINITIONS

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -22,6 +22,8 @@
 #endif
 #include <gz/common/Console.hh>
 #include <gz/common/Filesystem.hh>
+#include <gz/common/StringUtils.hh>
+#include <gz/common/SystemPaths.hh>
 #include <gz/common/Util.hh>
 
 #include <gz/plugin/Register.hh>
@@ -118,14 +120,15 @@ Ogre2RenderEngine::Ogre2RenderEngine() :
   this->dummyWindowId = 0;
 
   std::string ogrePath = std::string(OGRE2_RESOURCE_PATH);
-  std::vector<std::string> paths = common::split(ogrePath, ":");
+  std::vector<std::string> paths = common::Split(ogrePath,
+      common::SystemPaths::Delimiter());
   for (const auto &path : paths)
     this->ogrePaths.push_back(path);
 
   const char *env = std::getenv("OGRE2_RESOURCE_PATH");
   if (env)
   {
-    paths = common::split(std::string(env), ":");
+    paths = common::Split(std::string(env), common::SystemPaths::Delimiter());
     for (const auto &path : paths)
       this->ogrePaths.push_back(path);
   }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes wrong handling of `OGRE2_RESOURCE_PATH` on Windows. 

## Summary

It was assume that the `OGRE2_RESOURCE_PATH` was a `:`-delimiter list of paths. However, on Windows `:` is the separator between the drive letter and the path, so `;` should be used instead. 

Everything was working fine as `C:\this\is\a\path` and `\this\is\a\path` are both valid paths if the active drive is `C:\`, but as soon as the current active directory was for example on `D:`, `OGRE2_RESOURCE_PATH` was not read correctly, see https://github.com/conda-forge/gz-sim-feedstock/issues/57 .

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

