### PR TITLE
Add Cone as a primitive parametric shape.

### DIFF
--- a/include/gz/rendering/Marker.hh
+++ b/include/gz/rendering/Marker.hh
@@ -68,6 +68,9 @@ namespace gz
 
       /// \brief Capsule geometry
       MT_CAPSULE        = 11,
+
+      /// \brief Cone geometry
+      MT_CONE           = 12,
     };
 
     /// \class Marker Marker.hh gz/rendering/Marker

--- a/include/gz/rendering/ParticleEmitter.hh
+++ b/include/gz/rendering/ParticleEmitter.hh
@@ -87,7 +87,7 @@ namespace gz
       ///   - EM_POINT: The area is ignored.
       ///   - EM_BOX: The area is interpreted as width X height X depth.
       ///   - EM_CYLINDER: The area is interpreted as the bounding box of the
-      ///                  cilinder. The cylinder is oriented along the Z-axis.
+      ///                  cylinder. The cylinder is oriented along the Z-axis.
       ///   - EM_ELLIPSOID: The area is interpreted as the bounding box of an
       ///                   ellipsoid shaped area, i.e. a sphere or
       ///                   squashed-sphere area. The parameters are again

--- a/ogre/src/OgreMarker.cc
+++ b/ogre/src/OgreMarker.cc
@@ -107,6 +107,7 @@ Ogre::MovableObject *OgreMarker::OgreObject() const
       return nullptr;
     case MT_BOX:
     case MT_CAPSULE:
+    case MT_CONE:
     case MT_CYLINDER:
     case MT_SPHERE:
     {
@@ -184,6 +185,7 @@ void OgreMarker::SetMaterial(MaterialPtr _material, bool _unique)
       break;
     case MT_BOX:
     case MT_CAPSULE:
+    case MT_CONE:
     case MT_CYLINDER:
     case MT_SPHERE:
     {
@@ -256,6 +258,10 @@ void OgreMarker::SetType(MarkerType _markerType)
     case MT_CAPSULE:
       this->dataPtr->geom =
         std::dynamic_pointer_cast<OgreGeometry>(this->scene->CreateCapsule());
+      break;
+    case MT_CONE:
+      this->dataPtr->geom =
+        std::dynamic_pointer_cast<OgreGeometry>(this->scene->CreateCone());
       break;
     case MT_CYLINDER:
       this->dataPtr->geom =

--- a/ogre2/src/Ogre2Marker.cc
+++ b/ogre2/src/Ogre2Marker.cc
@@ -155,6 +155,7 @@ Ogre::MovableObject *Ogre2Marker::OgreObject() const
       return nullptr;
     case MT_BOX:
     case MT_CAPSULE:
+    case MT_CONE:
     case MT_CYLINDER:
     case MT_SPHERE:
     {
@@ -236,6 +237,7 @@ void Ogre2Marker::SetMaterial(MaterialPtr _material, bool _unique)
       break;
     case MT_BOX:
     case MT_CAPSULE:
+    case MT_CONE:
     case MT_CYLINDER:
     case MT_SPHERE:
     {
@@ -341,6 +343,10 @@ void Ogre2Marker::SetType(MarkerType _markerType)
     case MT_CAPSULE:
       isGeom = true;
       newGeom = this->scene->CreateCapsule();
+      break;
+    case MT_CONE:
+      isGeom = true;
+      newGeom = this->scene->CreateCone();
       break;
     case MT_CYLINDER:
       isGeom = true;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This helps add the missing cone geometry for primitive/basic parametric shapes:

![conetopple](https://github.com/gazebosim/gz-math/assets/10233412/5fd8f1a1-3a77-4e61-95d5-f053389cd908)
![cone](https://github.com/gazebosim/gz-math/assets/10233412/1c516775-7adb-4318-9c6a-0c09a746a3b0)

And is also valuable for visualizations of emitters/source that typically have conic-based spread as seen in this acoustic attack on an IMU by showing the affected area:

![drone_attack](https://github.com/gazebosim/gz-rendering/assets/10233412/7a6b0dfa-8ad6-42c1-83bc-8385ccc4c81a)

Associated PRs:

- https://github.com/gazebosim/gz-gui/pull/620
- https://github.com/gazebosim/gz-math/pull/593
- https://github.com/gazebosim/gz-msgs/pull/441
- https://github.com/gazebosim/gz-physics/pull/638
- https://github.com/gazebosim/gz-rendering/pull/1001
- https://github.com/gazebosim/gz-sim/pull/2404
- https://github.com/gazebosim/sdformat/pull/1415

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
