### PR TITLE
Fix gz-cmake declaration on package.xml (fix windows CI)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <build_depend>gz-cmake</build_depend>
+  <build_depend>gz-cmake3</build_depend>
 
   <depend>glut</depend>
   <depend>gz-common5</depend>


### PR DESCRIPTION
# 🦟 Bug fix

Fix #1004 

## Summary
The build dependency is broken declaring gz-cmake instead of gz-cmake3. This is probably making colcon to ignore the gz-cmake3 install directory thus there is not gz-cmake3 config file. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers