### PR TITLE
Fix crash when visualizing Lidars with points

### DIFF
--- a/ogre2/src/media/materials/programs/GLSL/point_vs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/point_vs.glsl
@@ -24,6 +24,7 @@ uniform float size;
 out gl_PerVertex
 {
   vec4 gl_Position;
+  float gl_PointSize;
 };
 
 void main()


### PR DESCRIPTION
# 🦟 Bug fix

Fixes: #970 

## Summary
The change is already in gz-rendering7.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
