### PR TITLE
Fixes deleter passed to the std::shared_ptr<void>

### DIFF
--- a/src/ShaderParam.cc
+++ b/src/ShaderParam.cc
@@ -117,7 +117,7 @@ void ShaderParam::InitializeBuffer(uint32_t _count)
 {
   this->dataPtr->count = _count;
   this->dataPtr->buffer.reset(new float[_count],
-      std::default_delete<float[]>());
+      [](void *ptr) { delete [] static_cast<float*>(ptr); });
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# Bug fix

## Summary

Fixes deleter passed to the std::shared_ptr<void>: the c++ standard says that
the the  wrapped tye should be implicitely convertible to the type accepted by
the provided deleter. This is not the case for void* to float*.