### PR TITLE
Fix debug builds of gz-rendering-ogre2 plugin

### DIFF
--- a/ogre2/src/CMakeLists.txt
+++ b/ogre2/src/CMakeLists.txt
@@ -65,7 +65,10 @@ if (TARGET OpenGL::EGL)
   add_definitions(-DHAVE_EGL=1)
 endif()
 
-target_compile_definitions(${ogre2_target} PRIVATE $<$<CONFIG:Debug>:DEBUG=1 _DEBUG=1>)
+# You might need to uncomment the following `target_compile_definitions`
+# if you've built Ogre from source in Debug mode
+# https://github.com/OGRECave/ogre-next/blob/003f51a0a90d1cf93fbea3c7302565b07c4f87b0/OgreMain/include/OgrePlatform.h#L350-L372
+# target_compile_definitions(${ogre2_target} PRIVATE $<$<CONFIG:Debug>:DEBUG=1 _DEBUG=1>)
 
 
 set (versioned ${CMAKE_SHARED_LIBRARY_PREFIX}${PROJECT_NAME_LOWER}-${engine_name}${CMAKE_SHARED_LIBRARY_SUFFIX})


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The ogre2 plugin fails to load in gz-sim when gz-rendering is built in Debug mode. The following error message is emitted:
```
Error while loading the library [....lib/gz-rendering-8/engine-plugins/libgz-rendering-ogre2.so]: ....lib/gz-rendering-8/engine-plugins/libgz-rendering-ogre2.so: undefined symbol: _ZThn1008_N4Ogre7HlmsPbs19_changeRenderSystemEPNS_12RenderSystemE
```

This is because we set `DEBUG=1` and `_DEBUG=1` on the ogre2 target which seem to change the ABI of the generated library. These defines should really be set if Ogre2 itself is built in debug mode, so this PR simply comments out the CMake command that adds those defines.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.