### PR TITLE
Fix crash when wide angle camera FOV is > 180

### DIFF
--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -452,7 +452,11 @@ void OgreWideAngleCamera::CreateWideAngleTexture()
 
   double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / ratio);
   this->dataPtr->ogreCamera->setAspectRatio(ratio);
-  this->dataPtr->ogreCamera->setFOVy(Ogre::Radian(vfov));
+  // Setting the fov is likely not necessary for the ogreCamera but
+  // clamp to max fov supported by ogre to avoid issues with building the
+  // frustum
+  this->dataPtr->ogreCamera->setFOVy(Ogre::Radian(
+      Ogre::Real(std::clamp(vfov, 0.0, GZ_PI))));
 
   // create the env cameras and textures
   this->CreateEnvCameras();

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -1344,7 +1344,12 @@ void Ogre2WideAngleCamera::PrepareForFinalPass(Ogre::Pass *_pass)
   const double ratio = static_cast<double>(this->ImageWidth()) /
                        static_cast<double>(this->ImageHeight());
   const double vfov = 2.0 * atan(tan(this->HFOV().Radian() / 2.0) / ratio);
-  this->dataPtr->ogreCamera->setFOVy(Ogre::Radian(Ogre::Real(vfov)));
+
+  // Setting the fov is likely not necessary in the final pass but
+  // clamp to max fov supported by ogre to avoid issues with building the
+  // frustum
+  this->dataPtr->ogreCamera->setFOVy(Ogre::Radian(
+      Ogre::Real(std::clamp(vfov, 0.0, GZ_PI))));
 
   const float localHfov = static_cast<float>(this->HFOV().Radian());
 


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #988

## Summary

Limit ogre's FOV to 180 in the 2nd pass otherwise ogre crashes when building the frustum. This should be fine to do in the second pass since it is mainly for stitching images together and a correct camera FOV is likely not necessary.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
