### PR TITLE
Fix build fortress + jammy

### DIFF
--- a/include/gz/rendering/GraphicsAPI.hh
+++ b/include/gz/rendering/GraphicsAPI.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_RENDERING_GRAPHICSAPI_HH_
 #define IGNITION_RENDERING_GRAPHICSAPI_HH_
 
+#include <cstdint>
 #include <string>
 #include "ignition/rendering/config.hh"
 #include "ignition/rendering/Export.hh"


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

I was attempting to build Fortress on Jammy, and rand into:
```
 GraphicsAPI.hh:31:10: warning: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword
```
followed by:
```
GraphicsAPI.hh:31:55: error: found ‘:’ in nested-name-specifier, expected ‘::’
   31 |     enum class IGNITION_RENDERING_VISIBLE GraphicsAPI : uint16_t
```

The fix was to include the header file where uint16_t is defined.

I'm using gcc 13.2.0.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.