### PR TITLE
Override SetProjectionMatrix and ProjectionMatrix functions in derived ogre2 camera classes.

### DIFF
--- a/ogre2/include/gz/rendering/ogre2/Ogre2BoundingBoxCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2BoundingBoxCamera.hh
@@ -67,6 +67,13 @@ namespace gz
       // Documentation inherited
       public: virtual void PostRender() override;
 
+      // Documentation inherited.
+      public: virtual math::Matrix4d ProjectionMatrix() const override;
+
+      // Documentation inherited.
+      public: virtual void SetProjectionMatrix(
+          const math::Matrix4d &_matrix) override;
+
       // Documentation inherited
       public: virtual const std::vector<BoundingBox> &BoundingBoxData() const
               override;

--- a/ogre2/include/gz/rendering/ogre2/Ogre2SegmentationCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2SegmentationCamera.hh
@@ -68,6 +68,13 @@ namespace gz
       // Documentation inherited
       public: virtual void PostRender() override;
 
+      // Documentation inherited.
+      public: virtual math::Matrix4d ProjectionMatrix() const override;
+
+      // Documentation inherited.
+      public: virtual void SetProjectionMatrix(
+          const math::Matrix4d &_matrix) override;
+
       // Documentation inherited
       public: virtual gz::common::ConnectionPtr
         ConnectNewSegmentationFrame(

--- a/ogre2/include/gz/rendering/ogre2/Ogre2ThermalCamera.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2ThermalCamera.hh
@@ -75,6 +75,13 @@ namespace gz
       /// \brief Render the camera
       public: virtual void PostRender() override;
 
+      // Documentation inherited.
+      public: virtual math::Matrix4d ProjectionMatrix() const override;
+
+      // Documentation inherited.
+      public: virtual void SetProjectionMatrix(
+          const math::Matrix4d &_matrix) override;
+
       /// \brief Connect to the new thermal image event
       /// \param[in] _subscriber Subscriber callback function
       /// \return Pointer to the new Connection. This must be kept in scope

--- a/ogre2/src/Ogre2BoundingBoxCamera.cc
+++ b/ogre2/src/Ogre2BoundingBoxCamera.cc
@@ -465,21 +465,6 @@ void Ogre2BoundingBoxCamera::PreRender()
   if (!this->dataPtr->ogreRenderTexture)
     this->CreateBoundingBoxTexture();
 
-  // todo(iche033) Override BaseCamera::SetProjectionMatrix() function in
-  // main / gz-rendering9 instead of checking and setting the custom
-  // projection matrix here
-  if (this->dataPtr->ogreCamera &&
-      this->projectionMatrix != gz::math::Matrix4d::Zero)
-  {
-    if (this->projectionMatrix !=
-        Ogre2Conversions::Convert(
-        this->dataPtr->ogreCamera->getProjectionMatrix()))
-    {
-      this->dataPtr->ogreCamera->setCustomProjectionMatrix(true,
-          Ogre2Conversions::Convert(this->projectionMatrix));
-    }
-  }
-
   this->dataPtr->outputBoxes.clear();
 }
 
@@ -1548,4 +1533,19 @@ void Ogre2BoundingBoxCamera::SetBoundingBoxType(BoundingBoxType _type)
 BoundingBoxType Ogre2BoundingBoxCamera::Type() const
 {
   return this->dataPtr->type;
+}
+
+/////////////////////////////////////////////////
+math::Matrix4d Ogre2BoundingBoxCamera::ProjectionMatrix() const
+{
+  return Ogre2Conversions::Convert(
+      this->dataPtr->ogreCamera->getProjectionMatrix());
+}
+
+/////////////////////////////////////////////////
+void Ogre2BoundingBoxCamera::SetProjectionMatrix(const math::Matrix4d &_matrix)
+{
+  BaseBoundingBoxCamera::SetProjectionMatrix(_matrix);
+  this->dataPtr->ogreCamera->setCustomProjectionMatrix(
+      true, Ogre2Conversions::Convert(this->projectionMatrix));
 }

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -1021,12 +1021,14 @@ void Ogre2DepthCamera::CreateWorkspaceInstance()
 }
 
 /////////////////////////////////////////////////
-math::Matrix4d Ogre2DepthCamera::ProjectionMatrix() const {
+math::Matrix4d Ogre2DepthCamera::ProjectionMatrix() const
+{
   return Ogre2Conversions::Convert(this->ogreCamera->getProjectionMatrix());
 }
 
 /////////////////////////////////////////////////
-void Ogre2DepthCamera::SetProjectionMatrix(const math::Matrix4d &_matrix) {
+void Ogre2DepthCamera::SetProjectionMatrix(const math::Matrix4d &_matrix)
+{
   BaseDepthCamera::SetProjectionMatrix(_matrix);
   this->ogreCamera->setCustomProjectionMatrix(
       true, Ogre2Conversions::Convert(this->projectionMatrix));
@@ -1068,20 +1070,6 @@ void Ogre2DepthCamera::PreRender()
 
   if (!this->dataPtr->ogreCompositorWorkspace)
     this->CreateWorkspaceInstance();
-
-  // todo(iche033) Override BaseCamera::SetProjectionMatrix() function in
-  // main / gz-rendering9 instead of checking and setting the custom
-  // projection matrix here
-  if (this->ogreCamera &&
-      this->projectionMatrix != gz::math::Matrix4d::Zero)
-  {
-    if (this->projectionMatrix !=
-        Ogre2Conversions::Convert(this->ogreCamera->getProjectionMatrix()))
-    {
-      this->ogreCamera->setCustomProjectionMatrix(true,
-          Ogre2Conversions::Convert(this->projectionMatrix));
-    }
-  }
 
   // Disable color target (set to clear pass) if there are no rgb point cloud
   // connections

--- a/ogre2/src/Ogre2SegmentationCamera.cc
+++ b/ogre2/src/Ogre2SegmentationCamera.cc
@@ -165,20 +165,6 @@ void Ogre2SegmentationCamera::PreRender()
 {
   if (!this->dataPtr->ogreSegmentationTexture)
     this->CreateSegmentationTexture();
-
-  // todo(iche033) Override BaseCamera::SetProjectionMatrix() function in
-  // main / gz-rendering9 instead of checking and setting the custom
-  // projection matrix here
-  if (this->ogreCamera &&
-      this->projectionMatrix != gz::math::Matrix4d::Zero)
-  {
-    if (this->projectionMatrix !=
-        Ogre2Conversions::Convert(this->ogreCamera->getProjectionMatrix()))
-    {
-      this->ogreCamera->setCustomProjectionMatrix(true,
-          Ogre2Conversions::Convert(this->projectionMatrix));
-    }
-  }
 }
 
 /////////////////////////////////////////////////
@@ -438,4 +424,18 @@ void Ogre2SegmentationCamera::LabelMapFromColoredBuffer(
 Ogre::Camera *Ogre2SegmentationCamera::OgreCamera() const
 {
   return this->ogreCamera;
+}
+
+/////////////////////////////////////////////////
+math::Matrix4d Ogre2SegmentationCamera::ProjectionMatrix() const
+{
+  return Ogre2Conversions::Convert(this->ogreCamera->getProjectionMatrix());
+}
+
+/////////////////////////////////////////////////
+void Ogre2SegmentationCamera::SetProjectionMatrix(const math::Matrix4d &_matrix)
+{
+  BaseSegmentationCamera::SetProjectionMatrix(_matrix);
+  this->ogreCamera->setCustomProjectionMatrix(
+      true, Ogre2Conversions::Convert(this->projectionMatrix));
 }

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -1131,20 +1131,6 @@ void Ogre2ThermalCamera::PreRender()
 {
   if (!this->dataPtr->ogreThermalTexture)
     this->CreateThermalTexture();
-
-  // todo(iche033) Override BaseCamera::SetProjectionMatrix() function in
-  // main / gz-rendering9 instead of checking and setting the custom
-  // projection matrix here
-  if (this->ogreCamera &&
-      this->projectionMatrix != gz::math::Matrix4d::Zero)
-  {
-    if (this->projectionMatrix !=
-        Ogre2Conversions::Convert(this->ogreCamera->getProjectionMatrix()))
-    {
-      this->ogreCamera->setCustomProjectionMatrix(true,
-          Ogre2Conversions::Convert(this->projectionMatrix));
-    }
-  }
 }
 
 //////////////////////////////////////////////////
@@ -1235,4 +1221,18 @@ RenderTargetPtr Ogre2ThermalCamera::RenderTarget() const
 Ogre::Camera *Ogre2ThermalCamera::OgreCamera() const
 {
   return this->ogreCamera;
+}
+
+/////////////////////////////////////////////////
+math::Matrix4d Ogre2ThermalCamera::ProjectionMatrix() const
+{
+  return Ogre2Conversions::Convert(this->ogreCamera->getProjectionMatrix());
+}
+
+/////////////////////////////////////////////////
+void Ogre2ThermalCamera::SetProjectionMatrix(const math::Matrix4d &_matrix)
+{
+  BaseThermalCamera::SetProjectionMatrix(_matrix);
+  this->ogreCamera->setCustomProjectionMatrix(
+      true, Ogre2Conversions::Convert(this->projectionMatrix));
 }


### PR DESCRIPTION


# 🦟 Bug fix



## Summary

Addresses todos in relevant ogre2 camera classes. The new`SetProjectionMatrix` and `ProjectionMatrix` functions overrides those in the BaseCamera class. The workaround in `PreRender` function is removed - that was done to avoid breaking ABI

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

