### PR TITLE
Disable Unit test that have segfaults on Mac (rendering3)

### DIFF
--- a/src/ArrowVisual_TEST.cc
+++ b/src/ArrowVisual_TEST.cc
@@ -43,6 +43,11 @@ class ArrowVisualTest : public testing::Test,
 /////////////////////////////////////////////////
 void ArrowVisualTest::ArrowVisual(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #35." << std::endl;
+  return;
+#endif
+
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/ArrowVisual_TEST.cc
+++ b/src/ArrowVisual_TEST.cc
@@ -44,7 +44,7 @@ class ArrowVisualTest : public testing::Test,
 void ArrowVisualTest::ArrowVisual(const std::string &_renderEngine)
 {
 #ifdef __APPLE__                                                                                                                                                                              
-  std::cerr << "Skipping test for apple, see issue #35." << std::endl;
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
   return;
 #endif
 

--- a/src/AxisVisual_TEST.cc
+++ b/src/AxisVisual_TEST.cc
@@ -43,6 +43,10 @@ class AxisVisualTest : public testing::Test,
 /////////////////////////////////////////////////
 void AxisVisualTest::AxisVisual(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -114,6 +114,10 @@ void CameraTest::ViewProjectionMatrix(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void CameraTest::RenderTexture(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
@@ -159,6 +163,10 @@ void CameraTest::RenderTexture(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void CameraTest::TrackFollow(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
@@ -231,6 +239,10 @@ void CameraTest::TrackFollow(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void CameraTest::AddRemoveRenderPass(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -49,6 +49,10 @@ class CameraTest : public testing::Test,
 /////////////////////////////////////////////////
 void CameraTest::ViewProjectionMatrix(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/Grid_TEST.cc
+++ b/src/Grid_TEST.cc
@@ -37,6 +37,10 @@ class GridTest : public testing::Test,
 /////////////////////////////////////////////////
 void GridTest::Grid(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   if (_renderEngine != "ogre" && _renderEngine != "ogre2")
   {
     igndbg << "Grid not supported yet in rendering engine: "

--- a/src/Light_TEST.cc
+++ b/src/Light_TEST.cc
@@ -39,6 +39,10 @@ class LightTest : public testing::Test,
 /////////////////////////////////////////////////
 void LightTest::Light(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/Marker_TEST.cc
+++ b/src/Marker_TEST.cc
@@ -37,6 +37,10 @@ class MarkerTest : public testing::Test,
 /////////////////////////////////////////////////
 void MarkerTest::Marker(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   if (_renderEngine == "optix")
   {
     igndbg << "Marker not supported yet in rendering engine: "

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -50,6 +50,10 @@ class MaterialTest : public testing::Test,
 /////////////////////////////////////////////////
 void MaterialTest::MaterialProperties(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -263,6 +263,10 @@ void MaterialTest::MaterialProperties(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void MaterialTest::Copy(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -50,6 +50,10 @@ class MeshTest : public testing::Test,
 /////////////////////////////////////////////////
 void MeshTest::MeshSubMesh(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -112,6 +116,10 @@ void MeshTest::MeshSubMesh(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void MeshTest::MeshSkeleton(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/MoveToHelper_TEST.cc
+++ b/src/MoveToHelper_TEST.cc
@@ -74,6 +74,10 @@ void MoveToHelperTest::checkIsCompleted(double timeout)
 
 void MoveToHelperTest::MoveTo(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -41,6 +41,10 @@ class NodeTest : public testing::Test,
 /////////////////////////////////////////////////
 void NodeTest::Pose(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/OrbitViewController_TEST.cc
+++ b/src/OrbitViewController_TEST.cc
@@ -46,6 +46,10 @@ class OrbitViewControllerTest : public testing::Test,
 /////////////////////////////////////////////////
 void OrbitViewControllerTest::OrbitViewControl(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/OrbitViewController_TEST.cc
+++ b/src/OrbitViewController_TEST.cc
@@ -95,6 +95,10 @@ void OrbitViewControllerTest::OrbitViewControl(const std::string &_renderEngine)
 void OrbitViewControllerTest::OrbitViewControlCameraConstructor(
   const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -131,6 +135,10 @@ void OrbitViewControllerTest::OrbitViewControlCameraConstructor(
 /////////////////////////////////////////////////
 void OrbitViewControllerTest::Control(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/RayQuery_TEST.cc
+++ b/src/RayQuery_TEST.cc
@@ -40,6 +40,10 @@ class RayQueryTest : public testing::Test,
 /////////////////////////////////////////////////
 void RayQueryTest::RayQuery(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   if (_renderEngine == "optix")
   {
     igndbg << "RayQuery not supported yet in rendering engine: "

--- a/src/RenderTarget_TEST.cc
+++ b/src/RenderTarget_TEST.cc
@@ -48,6 +48,10 @@ class RenderTargetTest : public testing::Test,
 /////////////////////////////////////////////////
 void RenderTargetTest::RenderTexture(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/RenderingIface_TEST.cc
+++ b/src/RenderingIface_TEST.cc
@@ -48,6 +48,10 @@ unsigned int defaultEnginesForTest()
 /////////////////////////////////////////////////
 TEST(RenderingIfaceTest, GetEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   common::Console::SetVerbosity(4);
 
   unsigned int count = defaultEnginesForTest();

--- a/src/Scene_TEST.cc
+++ b/src/Scene_TEST.cc
@@ -124,6 +124,10 @@ void SceneTest::Scene(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::Nodes(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -208,6 +212,10 @@ void SceneTest::Nodes(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::RemoveNodes(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -310,6 +318,10 @@ void SceneTest::RemoveNodes(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::DestroyNodes(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -533,6 +545,10 @@ void SceneTest::DestroyNodes(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::NodeCycle(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -599,6 +615,10 @@ void SceneTest::NodeCycle(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::Materials(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Scene_TEST.cc
+++ b/src/Scene_TEST.cc
@@ -54,6 +54,10 @@ class SceneTest : public testing::Test,
 /////////////////////////////////////////////////
 void SceneTest::Scene(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/ThermalCamera_TEST.cc
+++ b/src/ThermalCamera_TEST.cc
@@ -38,6 +38,10 @@ class ThermalCameraTest : public testing::Test,
 /////////////////////////////////////////////////
 void ThermalCameraTest::ThermalCamera(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/TransformController_TEST.cc
+++ b/src/TransformController_TEST.cc
@@ -49,6 +49,10 @@ class TransformControllerTest : public testing::Test,
 /////////////////////////////////////////////////
 void TransformControllerTest::TransformControl(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/TransformController_TEST.cc
+++ b/src/TransformController_TEST.cc
@@ -140,6 +140,10 @@ void TransformControllerTest::TransformControl(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void TransformControllerTest::WorldSpace(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -203,6 +207,10 @@ void TransformControllerTest::WorldSpace(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void TransformControllerTest::LocalSpace(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -317,6 +325,10 @@ void TransformControllerTest::LocalSpace(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void TransformControllerTest::Control2d(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -53,6 +53,10 @@ class VisualTest : public testing::Test,
 /////////////////////////////////////////////////
 void VisualTest::Material(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -142,6 +142,10 @@ TEST_P(VisualTest, Material)
 /////////////////////////////////////////////////
 void VisualTest::Children(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -211,6 +215,10 @@ TEST_P(VisualTest, Children)
 /////////////////////////////////////////////////
 void VisualTest::Scale(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -302,6 +310,10 @@ TEST_P(VisualTest, Scale)
 /////////////////////////////////////////////////
 void VisualTest::UserData(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -365,6 +377,10 @@ TEST_P(VisualTest, UserData)
 /////////////////////////////////////////////////
 void VisualTest::Geometry(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -12,6 +12,11 @@ set(tests
 
 if (APPLE)
   list(REMOVE_ITEM tests camera.cc)
+  list(REMOVE_ITEM tests depth_camera.cc)
+  list(REMOVE_ITEM tests render_pass.cc)
+  list(REMOVE_ITEM tests shadows.cc)
+  list(REMOVE_ITEM tests scene.cc)
+  list(REMOVE_ITEM tests thermal_camera.cc)
 endif()
 
 link_directories(${PROJECT_BINARY_DIR}/test)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -10,6 +10,10 @@ set(tests
   thermal_camera.cc
 )
 
+if (APPLE)
+  list(REMOVE_ITEM tests camera.cc)
+endif()
+
 link_directories(${PROJECT_BINARY_DIR}/test)
 
 # Test symbols having the right name on linux only


### PR DESCRIPTION
# 🦟 Bug fix

Disable tests from #847 

## Summary
This PR disables all tests that have segfaults in MacOS

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.