### PR TITLE
Update ogre2 ray query related functions to return Ogre::MovableObject instead of Ogre::Item

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,20 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Rendering 8.x to 9.x
+
+### Deprecations
+
+1. **Ogre2SelectionBuffer**
+    + Deprecated: `bool ExecuteQuery(const int _x, const int _y, Ogre::Item *&_item, math::Vector3d &_point)`
+    + Replacement: `bool ExecuteQuery(int _x, int _y, Ogre::MovableObject *&_obj, math::Vector3d &_point)`
+
+### Modifications
+
+1. **Ogre2SelectionBuffer**
+    + Removed: `Ogre::OgreItem *OnSelectionClick(const int _x, const int _y)`
+    + Replacement: `Ogre::MovableObject *OnSelectionClick(int _x, int _y)`
+
 ## Gazebo Rendering 7.x to 8.x
 
 ### Deprecations

--- a/ogre2/include/gz/rendering/ogre2/Ogre2SelectionBuffer.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2SelectionBuffer.hh
@@ -62,8 +62,8 @@ namespace gz
       /// \brief Handle on mouse click
       /// \param[in] _x X coordinate in pixels.
       /// \param[in] _y Y coordinate in pixels.
-      /// \return Returns the Ogre item at the coordinate.
-      public: Ogre::Item *OnSelectionClick(const int _x, const int _y);
+      /// \return Returns the Ogre movable object at the coordinate.
+      public: Ogre::MovableObject *OnSelectionClick(int _x, int _y);
 
       /// \brief Perform selection operation and get ogre item and
       /// point of intersection.
@@ -72,8 +72,18 @@ namespace gz
       /// \param[out] _item Ogre item at the coordinate.
       /// \param[out] _point 3D point of intersection with the ogre item's mesh.
       /// \return True if an ogre item is found, false otherwise
-      public: bool ExecuteQuery(const int _x, const int _y, Ogre::Item *&_item,
-          math::Vector3d &_point);
+      public: bool GZ_DEPRECATED(9) ExecuteQuery(const int _x, const int _y,
+          Ogre::Item *&_item, math::Vector3d &_point);
+
+      /// \brief Perform selection operation and get ogre item and
+      /// point of intersection.
+      /// \param[in] _x X coordinate in pixels.
+      /// \param[in] _y Y coordinate in pixels.
+      /// \param[out] _obj Ogre movable object at the coordinate.
+      /// \param[out] _point 3D point of intersection with the ogre object.
+      /// \return True if an ogre object is found, false otherwise
+      public: bool ExecuteQuery(int _x, int _y,
+          Ogre::MovableObject *&_obj, math::Vector3d &_point);
 
       /// \brief Set dimension of the selection buffer
       /// \param[in] _width X dimension in pixels.

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -321,19 +321,19 @@ VisualPtr Ogre2Camera::VisualAt(const math::Vector2i &_mousePos)
   math::Vector2i mousePos(
       static_cast<int>(std::rint(ratio * _mousePos.X())),
       static_cast<int>(std::rint(ratio * _mousePos.Y())));
-  Ogre::Item *ogreItem = this->selectionBuffer->OnSelectionClick(
+  Ogre::MovableObject *ogreObj = this->selectionBuffer->OnSelectionClick(
       mousePos.X(), mousePos.Y());
 
-  if (ogreItem)
+  if (ogreObj)
   {
-    if (!ogreItem->getUserObjectBindings().getUserAny().isEmpty() &&
-        ogreItem->getUserObjectBindings().getUserAny().getType() ==
+    if (!ogreObj->getUserObjectBindings().getUserAny().isEmpty() &&
+        ogreObj->getUserObjectBindings().getUserAny().getType() ==
         typeid(unsigned int))
     {
       try
       {
         result = this->scene->VisualById(Ogre::any_cast<unsigned int>(
-              ogreItem->getUserObjectBindings().getUserAny()));
+              ogreObj->getUserObjectBindings().getUserAny()));
       }
       catch(Ogre::Exception &e)
       {

--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -247,10 +247,10 @@ RayQueryResult Ogre2RayQuery::ClosestPointBySelectionBuffer()
     this->dataPtr->camera->ImageWidth(), this->dataPtr->camera->ImageHeight());
 
   RayQueryResult result;
-  Ogre::Item *ogreItem = nullptr;
+  Ogre::MovableObject *ogreObj = nullptr;
   math::Vector3d point;
   bool success = this->dataPtr->camera->SelectionBuffer()->ExecuteQuery(
-      this->dataPtr->imgPos.X(), this->dataPtr->imgPos.Y(), ogreItem, point);
+      this->dataPtr->imgPos.X(), this->dataPtr->imgPos.Y(), ogreObj, point);
   result.distance = -1;
 
   if (success)
@@ -258,20 +258,15 @@ RayQueryResult Ogre2RayQuery::ClosestPointBySelectionBuffer()
     double distance = this->dataPtr->camera->WorldPosition().Distance(point)
         - this->dataPtr->camera->NearClipPlane();
     unsigned int objectId = 0;
-    if (ogreItem)
+    if (ogreObj)
     {
-      if (!ogreItem->getUserObjectBindings().getUserAny().isEmpty() &&
-          ogreItem->getUserObjectBindings().getUserAny().getType() ==
+      if (!ogreObj->getUserObjectBindings().getUserAny().isEmpty() &&
+          ogreObj->getUserObjectBindings().getUserAny().getType() ==
           typeid(unsigned int))
       {
-        auto userAny = ogreItem->getUserObjectBindings().getUserAny();
+        auto userAny = ogreObj->getUserObjectBindings().getUserAny();
         objectId = Ogre::any_cast<unsigned int>(userAny);
       }
-    }
-    else
-    {
-      // \todo(anyone) Change ExecuteQuery to return Ogre::MovableObject
-      // in gz-rendering8 so heightmaps can be included in the result
     }
     if (!std::isinf(distance))
     {

--- a/ogre2/src/Ogre2SelectionBuffer.cc
+++ b/ogre2/src/Ogre2SelectionBuffer.cc
@@ -413,17 +413,31 @@ void Ogre2SelectionBuffer::SetDimensions(
   this->CreateRTTBuffer();
 }
 /////////////////////////////////////////////////
-Ogre::Item *Ogre2SelectionBuffer::OnSelectionClick(const int _x, const int _y)
+Ogre::MovableObject *Ogre2SelectionBuffer::OnSelectionClick(int _x, int _y)
 {
-  Ogre::Item *item = nullptr;
+  Ogre::MovableObject *obj = nullptr;
   math::Vector3d point;
-  this->ExecuteQuery(_x, _y, item, point);
-  return item;
+  this->ExecuteQuery(_x, _y, obj, point);
+  return obj;
 }
 
 /////////////////////////////////////////////////
 bool Ogre2SelectionBuffer::ExecuteQuery(const int _x, const int _y,
     Ogre::Item *&_item, math::Vector3d &_point)
+{
+  Ogre::MovableObject *obj = nullptr;
+  bool out = this->ExecuteQuery(_x, _y, obj, _point);
+
+  Ogre::Item *item = dynamic_cast<Ogre::Item *>(obj);
+  if (item)
+    _item = item;
+
+  return out;
+}
+
+/////////////////////////////////////////////////
+bool Ogre2SelectionBuffer::ExecuteQuery(int _x, int _y,
+    Ogre::MovableObject *&_obj, math::Vector3d &_point)
 {
   if (!this->dataPtr->renderTexture)
     return false;
@@ -529,11 +543,8 @@ bool Ogre2SelectionBuffer::ExecuteQuery(const int _x, const int _y,
         {
           if (entName == heightmap->Name())
           {
-            // \todo(anyone) change return type to MovableObject instead of item
-            // in gz-rendering8 so we can uncomment the line below to return a
-            //  heightmap object
-            // _item = std::dynamic_pointer_cast<Ogre2Heightmap>(
-            //     heightmap->OgreObject());
+            _obj = std::dynamic_pointer_cast<Ogre2Heightmap>(
+                heightmap)->OgreObject();
             _point = point;
             return true;
           }
@@ -543,7 +554,7 @@ bool Ogre2SelectionBuffer::ExecuteQuery(const int _x, const int _y,
     }
     else
     {
-      _item = dynamic_cast<Ogre::Item *>(collection[0]);
+      _obj = dynamic_cast<Ogre::MovableObject *>(collection[0]);
       _point = point;
       return true;
     }


### PR DESCRIPTION

# 🎉 New feature

## Summary

Addresses one of the todo items. 

Ray query related functions in ogre2 now return `Ogre::MovableObject` instead of `Ogre::Item` (`Ogre::Item` is derived from `Ogre::MovableObject`). This is so that we can include heightmap ogre objects (which are `Ogre::MovableObject` typed objects) in the ray query results.

2 API changes are documented in the Migration guide. One of them (`OnSelectionClick()`) is a change to the return type so it can not be deprecated, i.e. API breaking change. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

