### PR TITLE
Merge 6 -> 7 (Partial merge forward)

### DIFF
--- a/ogre/src/OgreDistortionPass.cc
+++ b/ogre/src/OgreDistortionPass.cc
@@ -196,8 +196,8 @@ void OgreDistortionPass::CreateRenderPass()
       distortedLocation,
       newDistortedCoordinates,
       currDistortedCoordinates;
-  unsigned int distortedIdx,
-      distortedCol,
+  unsigned int distortedIdx;
+  int distortedCol,
       distortedRow;
   double normalizedColLocation, normalizedRowLocation;
 
@@ -223,9 +223,9 @@ void OgreDistortionPass::CreateRenderPass()
           focalLength);
 
       // compute the index in the distortion map
-      distortedCol = static_cast<unsigned int>(round(distortedLocation.X() *
+      distortedCol = static_cast<int>(round(distortedLocation.X() *
         this->dataPtr->distortionTexWidth));
-      distortedRow = static_cast<unsigned int>(round(distortedLocation.Y() *
+      distortedRow = static_cast<int>(round(distortedLocation.Y() *
         this->dataPtr->distortionTexHeight));
 
       // Note that the following makes sure that, for significant distortions,
@@ -235,8 +235,11 @@ void OgreDistortionPass::CreateRenderPass()
       // nonlegacy distortion modes.
 
       // Make sure the distorted pixel is within the texture dimensions
-      if (distortedCol < this->dataPtr->distortionTexWidth &&
-          distortedRow < this->dataPtr->distortionTexHeight)
+      if (distortedCol >= 0 && distortedRow >= 0 &&
+          static_cast<unsigned int>(distortedCol) <
+            this->dataPtr->distortionTexWidth &&
+          static_cast<unsigned int>(distortedRow) <
+            this->dataPtr->distortionTexHeight)
       {
         distortedIdx = distortedRow * this->dataPtr->distortionTexWidth +
           distortedCol;


### PR DESCRIPTION
# ➡️ Forward port

Forward port #994 and ~~#1017~~ from `ign-rendering6` to `gz-rendering7`

There are many conflicts between `ign-rendering6` and `gz-rendering7` due to ogre-next version upgrade and ign -> gz renaming. I manually cherry-picked ~~a couple of~~ one commits in this forward port. 

I did not forward port these changes
* rendering sensor perf optimizations - many conflicts due to ogre-next upgrade. Maybe easier to backport the changes form `gz-rendering8`
* [skipping macOS tests](https://github.com/gazebosim/gz-rendering/pull/1025) - CI is already green in [gz_rendering-ci-gz-rendering7-homebrew-amd64](https://build.osrfoundation.org/job/gz_rendering-ci-gz-rendering7-homebrew-amd64/)


Branch comparison: https://github.com/gazebosim/gz-rendering/compare/gz-rendering7...ign-rendering6

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)

