### PR TITLE
Disable tests that have segfaults on Mac (rendering6)

### DIFF
--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -355,6 +355,10 @@ void CameraTest::AddRemoveRenderPass(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void CameraTest::VisibilityMask(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
@@ -388,6 +392,10 @@ void CameraTest::VisibilityMask(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void CameraTest::IntrinsicMatrix(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   // create and populate scene
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)

--- a/src/Capsule_TEST.cc
+++ b/src/Capsule_TEST.cc
@@ -39,6 +39,10 @@ class CapsuleTest : public testing::Test,
 /////////////////////////////////////////////////
 void CapsuleTest::Capsule(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       
+  return;
+#endif
   if (_renderEngine != "ogre" && _renderEngine != "ogre2")
   {
     igndbg << "Capsule not supported yet in rendering engine: "

--- a/src/Heightmap_TEST.cc
+++ b/src/Heightmap_TEST.cc
@@ -47,7 +47,7 @@ class HeightmapTest : public testing::Test,
 
 /////////////////////////////////////////////////
 // ogre1 not supported on Windows
-TEST_P(HeightmapTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
+TEST_P(HeightmapTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Heightmap))
 {
   std::string renderEngine{this->GetParam()};
 

--- a/src/JointVisual_TEST.cc
+++ b/src/JointVisual_TEST.cc
@@ -40,6 +40,10 @@ class JointVisualTest : public testing::Test,
 /////////////////////////////////////////////////
 void JointVisualTest::JointVisual(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/LidarVisual_TEST.cc
+++ b/src/LidarVisual_TEST.cc
@@ -37,6 +37,10 @@ class LidarVisualTest : public testing::Test,
 /////////////////////////////////////////////////
 void LidarVisualTest::LidarVisual(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   if (_renderEngine == "optix")
   {
     igndbg << "LidarVisual not supported yet in rendering engine: "

--- a/src/LightVisual_TEST.cc
+++ b/src/LightVisual_TEST.cc
@@ -40,6 +40,10 @@ class LightVisualTest : public testing::Test,
 /////////////////////////////////////////////////
 void LightVisualTest::LightVisual(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -230,6 +230,10 @@ TEST_P(MeshTest, MeshSkeleton)
 /////////////////////////////////////////////////
 void MeshTest::MeshSkeletonAnimation(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -326,6 +330,10 @@ TEST_P(MeshTest, MeshSkeletonAnimation)
 /////////////////////////////////////////////////
 void MeshTest::MeshClone(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/OrthoViewController_TEST.cc
+++ b/src/OrthoViewController_TEST.cc
@@ -42,6 +42,10 @@ class OrthoViewControllerTest : public testing::Test,
 /////////////////////////////////////////////////
 void OrthoViewControllerTest::OrthoViewControl(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -85,6 +89,10 @@ void OrthoViewControllerTest::OrthoViewControl(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void OrthoViewControllerTest::Control(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/RenderTarget_TEST.cc
+++ b/src/RenderTarget_TEST.cc
@@ -85,6 +85,10 @@ void RenderTargetTest::RenderTexture(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void RenderTargetTest::RenderWindow(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   if (_renderEngine != "ogre")
   {
     igndbg << "RenderWindow not supported yet in rendering engine: "
@@ -134,6 +138,10 @@ void RenderTargetTest::RenderWindow(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void RenderTargetTest::AddRemoveRenderPass(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   if (_renderEngine != "ogre")
   {
     igndbg << "RenderWindow not supported yet in rendering engine: "

--- a/src/Scene_TEST.cc
+++ b/src/Scene_TEST.cc
@@ -764,6 +764,10 @@ void SceneTest::Materials(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::Time(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -811,6 +815,10 @@ void SceneTest::Time(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::BackgroundMaterial(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -838,6 +846,10 @@ void SceneTest::BackgroundMaterial(const std::string &_renderEngine)
 /////////////////////////////////////////////////
 void SceneTest::Sky(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/Text_TEST.cc
+++ b/src/Text_TEST.cc
@@ -36,6 +36,10 @@ class TextTest : public testing::Test,
 /////////////////////////////////////////////////
 void TextTest::Text(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   if (_renderEngine != "ogre")
   {
     igndbg << "Text not supported yet in rendering engine: "

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -505,6 +505,10 @@ TEST_P(VisualTest, Geometry)
 /////////////////////////////////////////////////
 void VisualTest::VisibilityFlags(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -572,6 +576,10 @@ TEST_P(VisualTest, VisibilityFlags)
 /////////////////////////////////////////////////
 void VisualTest::BoundingBox(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -613,6 +621,10 @@ TEST_P(VisualTest, BoundingBox)
 /////////////////////////////////////////////////
 void VisualTest::Wireframe(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
@@ -642,6 +654,10 @@ TEST_P(VisualTest, Wireframe)
 /////////////////////////////////////////////////
 void VisualTest::Clone(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {

--- a/src/WireBox_TEST.cc
+++ b/src/WireBox_TEST.cc
@@ -37,6 +37,10 @@ class WireBoxTest : public testing::Test,
 /////////////////////////////////////////////////
 void WireBoxTest::WireBox(const std::string &_renderEngine)
 {
+#ifdef __APPLE__                                                                                                                                                                              
+  std::cerr << "Skipping test for apple, see issue #847." << std::endl;
+  return;
+#endif
   if (_renderEngine != "ogre" && _renderEngine != "ogre2")
   {
     igndbg << "WireBox not supported yet in rendering engine: "

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -16,12 +16,14 @@ set(tests
 )
 
 if (APPLE)
+  list(REMOVE_ITEM tests gpu_rays.cc)
   list(REMOVE_ITEM tests camera.cc)
   list(REMOVE_ITEM tests depth_camera.cc)
   list(REMOVE_ITEM tests render_pass.cc)
   list(REMOVE_ITEM tests shadows.cc)
   list(REMOVE_ITEM tests scene.cc)
   list(REMOVE_ITEM tests thermal_camera.cc)
+  list(REMOVE_ITEM tessts lidar_visual.cc)
 endif()
 
 link_directories(${PROJECT_BINARY_DIR}/test)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -23,7 +23,7 @@ if (APPLE)
   list(REMOVE_ITEM tests shadows.cc)
   list(REMOVE_ITEM tests scene.cc)
   list(REMOVE_ITEM tests thermal_camera.cc)
-  list(REMOVE_ITEM tessts lidar_visual.cc)
+  list(REMOVE_ITEM tests lidar_visual.cc)
 endif()
 
 link_directories(${PROJECT_BINARY_DIR}/test)


### PR DESCRIPTION
# 🦟 Bug fix

Follow up from https://github.com/gazebosim/gz-rendering/pull/1023

Disable tests from https://github.com/gazebosim/gz-rendering/issues/847

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.