### PR TITLE
Remove more deprecated env vars

### DIFF
--- a/ogre/src/OgreDepthCamera.cc
+++ b/ogre/src/OgreDepthCamera.cc
@@ -227,19 +227,6 @@ void OgreDepthCamera::CreatePointCloudTexture()
 
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
 
-  // TODO(CH3): Deprecated. Remove on tock.
-  if (!env)
-  {
-    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
-
-    if (env)
-    {
-      gzwarn << "Using deprecated environment variable "
-             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
-             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
-    }
-  }
-
   std::string resourcePath = (env) ? std::string(env) :
       gz::rendering::getResourcePath();
 

--- a/ogre/src/OgreMaterial.cc
+++ b/ogre/src/OgreMaterial.cc
@@ -821,19 +821,6 @@ void OgreMaterial::SetDepthMaterial(const double _far,
   // Get shader parameters path
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
 
-  // TODO(CH3): Deprecated. Remove on tock.
-  if (!env)
-  {
-    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
-
-    if (env)
-    {
-      gzwarn << "Using deprecated environment variable "
-             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
-             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
-    }
-  }
-
   std::string resourcePath = (env) ? std::string(env) :
       gz::rendering::getResourcePath();
 

--- a/ogre/src/OgreRTShaderSystem.cc
+++ b/ogre/src/OgreRTShaderSystem.cc
@@ -487,19 +487,6 @@ bool OgreRTShaderSystem::Paths(std::string &coreLibsPath,
 {
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
 
-  // TODO(CH3): Deprecated. Remove on tock.
-  if (!env)
-  {
-    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
-
-    if (env)
-    {
-      gzwarn << "Using deprecated environment variable "
-             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
-             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
-    }
-  }
-
   std::string resourcePath = (env) ? std::string(env) :
       gz::rendering::getResourcePath();
 

--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -577,19 +577,6 @@ void OgreRenderEngine::CreateResources()
   std::list<std::string> paths;
   const char *env = std::getenv("GZ_RENDERING_RESOURCE_PATH");
 
-  // TODO(CH3): Deprecated. Remove on tock.
-  if (!env)
-  {
-    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
-
-    if (env)
-    {
-      gzwarn << "Using deprecated environment variable "
-             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
-             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
-    }
-  }
-
   std::string resourcePath = (env) ? std::string(env) :
       gz::rendering::getResourcePath();
   // install path

--- a/optix/src/OptixRenderEngine.cc
+++ b/optix/src/OptixRenderEngine.cc
@@ -82,19 +82,6 @@ std::string OptixRenderEngine::PtxFile(const std::string& _fileBase) const
 
   const char *env= std::getenv("GZ_RENDERING_RESOURCE_PATH");
 
-  // TODO(CH3): Deprecated. Remove on tock.
-  if (!env)
-  {
-    env = std::getenv("IGN_RENDERING_RESOURCE_PATH");
-
-    if (env)
-    {
-      gzwarn << "Using deprecated environment variable "
-             << "[IGN_RENDERING_RESOURCE_PATH]. Please use "
-             << "[GZ_RENDERING_RESOURCE_PATH] instead." << std::endl;
-    }
-  }
-
   std::string resourcePath = (env) ? std::string(env) :
       gz::rendering::getResourcePath();
   resourcePath = common::joinPaths(resourcePath, "optix");


### PR DESCRIPTION


# 🦟 Bug fix

Related PR: #1020

## Summary

Remove use of IGN env vars in ogre 1.x

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
