### PR TITLE
Hide optix related cmake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,6 @@ gz_find_package(gz-utils3 REQUIRED)
 set(GZ_UTILS_VER ${gz-utils3_VERSION_MAJOR})
 
 #--------------------------------------
-# Find FreeImage
-gz_find_package(FreeImage VERSION 3.9
-  REQUIRED_BY optix
-  PRIVATE_FOR optix)
-
-#--------------------------------------
 # Find OpenGL
 # See CMP0072 for more details (cmake --help-policy CMP0072)
 if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
@@ -170,19 +164,23 @@ set(GZ_RENDERING_ENGINE_INSTALL_DIR
 # Find dependencies that we ignore for Visual Studio
 if(NOT MSVC)
   #--------------------------------------
+  # Find FreeImage
+  gz_find_package(FreeImage VERSION 3.9
+    REQUIRED_BY optix
+    PRIVATE_FOR optix)
+
+  #--------------------------------------
   # Find CUDA
   # Module is being removed in CMake and needs a non trivial
   # migration https://cmake.org/cmake/help/latest/policy/CMP0146.html
   if(POLICY CMP0146)
     cmake_policy(SET CMP0146 OLD)
   endif()
-  find_package(CUDA)
+  find_package(CUDA QUIET)
 
   #--------------------------------------
   # Find OptiX
-  gz_find_package(OptiX VERSION 3.8.0
-      REQUIRED_BY optix
-      PRIVATE_FOR optix)
+  gz_find_package(OptiX QUIET VERSION 3.8.0)
 
   if (OptiX_FOUND AND CUDA_FOUND)
     set(GZ_RENDERING_HAVE_OPTIX TRUE)


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Hide optix and cuda related cmake warnings. Given that we're not actively maintaining the optix plugin, these warnings are distracting and may be misleading to users so hide them. In the future, let's consider archiving / removing the optix plugin.

Hides these warnings if cuda and optix are not available on your system:

```
CUDA_TOOLKIT_ROOT_DIR not found or specified
CMake Warning at /home/iche/code/gz_i_ws/install/share/cmake/gz-cmake4/cmake4/GzConfigureBuild.cmake:59 (message):
   CONFIGURATION WARNINGS:
   -- Missing dependency [OptiX]
Call Stack (most recent call first):
  CMakeLists.txt:219 (gz_configure_build)
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

