### PR TITLE
Expose shadow texture size for directional lighting in SDF

### DIFF
--- a/include/gz/rendering/Light.hh
+++ b/include/gz/rendering/Light.hh
@@ -26,6 +26,15 @@ namespace gz
   namespace rendering
   {
     inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+
+      enum GZ_RENDERING_VISIBLE LightType
+      {
+        LT_EMPTY = 0,
+        LT_POINT = 1,
+        LT_DIRECTIONAL = 2,
+        LT_SPOT = 3
+      };
+
     //
     /// \class Light Light.hh gz/rendering/Light.hh
     /// \brief Represents a light source in the scene graph

--- a/include/gz/rendering/Light.hh
+++ b/include/gz/rendering/Light.hh
@@ -27,12 +27,21 @@ namespace gz
   {
     inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-    enum GZ_RENDERING_VISIBLE LightType
+    /// \enum LightType
+    /// \brief Enum for Light types.
+    enum class GZ_RENDERING_VISIBLE LightType
     {
-      LT_EMPTY = 0,
-      LT_POINT = 1,
-      LT_DIRECTIONAL = 2,
-      LT_SPOT = 3
+      /// \brief No light type specified
+      EMPTY = 0,
+
+      /// \brief Point light
+      POINT = 1,
+
+      /// \brief Directional light
+      DIRECTIONAL = 2,
+
+      /// \brief Spot light
+      SPOT = 3
     };
 
     //

--- a/include/gz/rendering/Light.hh
+++ b/include/gz/rendering/Light.hh
@@ -27,13 +27,13 @@ namespace gz
   {
     inline namespace GZ_RENDERING_VERSION_NAMESPACE {
 
-      enum GZ_RENDERING_VISIBLE LightType
-      {
-        LT_EMPTY = 0,
-        LT_POINT = 1,
-        LT_DIRECTIONAL = 2,
-        LT_SPOT = 3
-      };
+    enum GZ_RENDERING_VISIBLE LightType
+    {
+      LT_EMPTY = 0,
+      LT_POINT = 1,
+      LT_DIRECTIONAL = 2,
+      LT_SPOT = 3
+    };
 
     //
     /// \class Light Light.hh gz/rendering/Light.hh

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -1273,12 +1273,14 @@ namespace gz
 
       /// @brief  \brief Set the shadow texture size for the given light type.
       /// @param _lightType Light type that creates the shadow
-      /// @param _textureSize Shadow texture size 
-      public: virtual void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize) = 0;
+      /// @param _textureSize Shadow texture size
+      public: virtual void SetShadowTextureSize(LightType _lightType,
+                  unsigned int _textureSize) = 0;
 
       /// @brief \brief Get the shadow texture size for the given light type.
       /// @param _lightType Light type that creates the shadow
-      public: virtual unsigned int ShadowTextureSize(LightType _lightType) = 0;
+      public: virtual unsigned int ShadowTextureSize(LightType _lightType)
+                  const = 0;
 
       /// \brief Sets the given GI as the current new active GI solution
       /// \param[in] _gi GI solution that should be active. Nullptr to disable

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -34,6 +34,7 @@
 #include "gz/rendering/RenderTypes.hh"
 #include "gz/rendering/Storage.hh"
 #include "gz/rendering/Export.hh"
+#include "gz/rendering/Light.hh"
 
 namespace gz
 {
@@ -1270,7 +1271,10 @@ namespace gz
       /// \return true to sky is enabled, false otherwise
       public: virtual bool SkyEnabled() const = 0;
 
-      public: virtual void SetShadowTextureSize(unsigned int _textureSize) = 0;
+      /// @brief  \brief Set the shadow texture size for the given light type.
+      /// @param _lightType Light type that creates the shadow
+      /// @param _textureSize Shadow texture size 
+      public: virtual void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize) = 0;
 
       /// \brief Sets the given GI as the current new active GI solution
       /// \param[in] _gi GI solution that should be active. Nullptr to disable

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -1270,7 +1270,7 @@ namespace gz
       /// \return true to sky is enabled, false otherwise
       public: virtual bool SkyEnabled() const = 0;
 
-      public: virtual void SetTexSize(unsigned int _texSize) = 0;
+      public: virtual void SetShadowTextureSize(unsigned int _textureSize) = 0;
 
       /// \brief Sets the given GI as the current new active GI solution
       /// \param[in] _gi GI solution that should be active. Nullptr to disable

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -1271,14 +1271,14 @@ namespace gz
       /// \return true to sky is enabled, false otherwise
       public: virtual bool SkyEnabled() const = 0;
 
-      /// @brief  \brief Set the shadow texture size for the given light type.
-      /// @param _lightType Light type that creates the shadow
-      /// @param _textureSize Shadow texture size
+      /// \brief Set the shadow texture size for the given light type.
+      /// \param _lightType Light type that creates the shadow
+      /// \param _textureSize Shadow texture size
       public: virtual void SetShadowTextureSize(LightType _lightType,
                   unsigned int _textureSize) = 0;
 
-      /// @brief \brief Get the shadow texture size for the given light type.
-      /// @param _lightType Light type that creates the shadow
+      /// \brief Get the shadow texture size for the given light type.
+      /// \param _lightType Light type that creates the shadow
       public: virtual unsigned int ShadowTextureSize(LightType _lightType)
                   const = 0;
 

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -1276,6 +1276,10 @@ namespace gz
       /// @param _textureSize Shadow texture size 
       public: virtual void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize) = 0;
 
+      /// @brief \brief Get the shadow texture size for the given light type.
+      /// @param _lightType Light type that creates the shadow
+      public: virtual unsigned int ShadowTextureSize(LightType _lightType) = 0;
+
       /// \brief Sets the given GI as the current new active GI solution
       /// \param[in] _gi GI solution that should be active. Nullptr to disable
       public: virtual void SetActiveGlobalIllumination(

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -1274,7 +1274,7 @@ namespace gz
       /// \brief Set the shadow texture size for the given light type.
       /// \param _lightType Light type that creates the shadow
       /// \param _textureSize Shadow texture size
-      public: virtual void SetShadowTextureSize(LightType _lightType,
+      public: virtual bool SetShadowTextureSize(LightType _lightType,
                   unsigned int _textureSize) = 0;
 
       /// \brief Get the shadow texture size for the given light type.

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -1270,6 +1270,8 @@ namespace gz
       /// \return true to sky is enabled, false otherwise
       public: virtual bool SkyEnabled() const = 0;
 
+      public: virtual void SetTexSize(unsigned int _texSize) = 0;
+
       /// \brief Sets the given GI as the current new active GI solution
       /// \param[in] _gi GI solution that should be active. Nullptr to disable
       public: virtual void SetActiveGlobalIllumination(

--- a/include/gz/rendering/base/BaseScene.hh
+++ b/include/gz/rendering/base/BaseScene.hh
@@ -628,7 +628,8 @@ namespace gz
       // Documentation inherited.
       public: virtual bool SkyEnabled() const override;
 
-      public: virtual void SetShadowTextureSize(unsigned int _textureSize) override;
+      // Documentation inherited.
+      public: virtual void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize) override;
 
       // Documentation inherited.
       public: virtual void SetActiveGlobalIllumination(

--- a/include/gz/rendering/base/BaseScene.hh
+++ b/include/gz/rendering/base/BaseScene.hh
@@ -629,7 +629,7 @@ namespace gz
       public: virtual bool SkyEnabled() const override;
 
       // Documentation inherited.
-      public: virtual void SetShadowTextureSize(LightType _lightType,
+      public: virtual bool SetShadowTextureSize(LightType _lightType,
                   unsigned int _textureSize) override;
 
       // Documentation inherited.

--- a/include/gz/rendering/base/BaseScene.hh
+++ b/include/gz/rendering/base/BaseScene.hh
@@ -629,10 +629,12 @@ namespace gz
       public: virtual bool SkyEnabled() const override;
 
       // Documentation inherited.
-      public: virtual void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize) override;
+      public: virtual void SetShadowTextureSize(LightType _lightType,
+                  unsigned int _textureSize) override;
 
       // Documentation inherited.
-      public: virtual unsigned int ShadowTextureSize(LightType _lightType) override;
+      public: virtual unsigned int ShadowTextureSize(LightType _lightType) const
+                  override;
 
       // Documentation inherited.
       public: virtual void SetActiveGlobalIllumination(

--- a/include/gz/rendering/base/BaseScene.hh
+++ b/include/gz/rendering/base/BaseScene.hh
@@ -628,7 +628,7 @@ namespace gz
       // Documentation inherited.
       public: virtual bool SkyEnabled() const override;
 
-      public: virtual void SetTexSize(unsigned int _texSize) override;
+      public: virtual void SetShadowTextureSize(unsigned int _textureSize) override;
 
       // Documentation inherited.
       public: virtual void SetActiveGlobalIllumination(

--- a/include/gz/rendering/base/BaseScene.hh
+++ b/include/gz/rendering/base/BaseScene.hh
@@ -632,6 +632,9 @@ namespace gz
       public: virtual void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize) override;
 
       // Documentation inherited.
+      public: virtual unsigned int ShadowTextureSize(LightType _lightType) override;
+
+      // Documentation inherited.
       public: virtual void SetActiveGlobalIllumination(
             GlobalIlluminationBasePtr _gi) override;
 

--- a/include/gz/rendering/base/BaseScene.hh
+++ b/include/gz/rendering/base/BaseScene.hh
@@ -628,6 +628,8 @@ namespace gz
       // Documentation inherited.
       public: virtual bool SkyEnabled() const override;
 
+      public: virtual void SetTexSize(unsigned int _texSize) override;
+
       // Documentation inherited.
       public: virtual void SetActiveGlobalIllumination(
             GlobalIlluminationBasePtr _gi) override;

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -102,7 +102,11 @@ namespace gz
       // Documentation inherited
       public: virtual bool SkyEnabled() const override;
 
+      // Documentation inherited
       public: void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize);
+
+      // Documentation inherited
+      public: unsigned int ShadowTextureSize(LightType _lightType);
 
       // Documentation inherited
       public: virtual void SetActiveGlobalIllumination(

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -102,7 +102,7 @@ namespace gz
       // Documentation inherited
       public: virtual bool SkyEnabled() const override;
 
-      public: void SetTexSize(unsigned int _texSize);
+      public: void SetShadowTextureSize(unsigned int _textureSize);
 
       // Documentation inherited
       public: virtual void SetActiveGlobalIllumination(

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -102,6 +102,8 @@ namespace gz
       // Documentation inherited
       public: virtual bool SkyEnabled() const override;
 
+      public: void SetTexSize(unsigned int _texSize);
+
       // Documentation inherited
       public: virtual void SetActiveGlobalIllumination(
             GlobalIlluminationBasePtr _gi) override;

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -103,10 +103,12 @@ namespace gz
       public: virtual bool SkyEnabled() const override;
 
       // Documentation inherited
-      public: void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize);
+      public: void SetShadowTextureSize(LightType _lightType,
+            unsigned int _textureSize);
 
       // Documentation inherited
-      public: unsigned int ShadowTextureSize(LightType _lightType);
+      public: unsigned int ShadowTextureSize(LightType _lightType) const
+            override;
 
       // Documentation inherited
       public: virtual void SetActiveGlobalIllumination(

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -103,7 +103,7 @@ namespace gz
       public: virtual bool SkyEnabled() const override;
 
       // Documentation inherited
-      public: void SetShadowTextureSize(LightType _lightType,
+      public: bool SetShadowTextureSize(LightType _lightType,
             unsigned int _textureSize);
 
       // Documentation inherited

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -102,7 +102,7 @@ namespace gz
       // Documentation inherited
       public: virtual bool SkyEnabled() const override;
 
-      public: void SetShadowTextureSize(unsigned int _textureSize);
+      public: void SetShadowTextureSize(LightType _lightType, unsigned int _textureSize);
 
       // Documentation inherited
       public: virtual void SetActiveGlobalIllumination(

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -1568,9 +1568,12 @@ bool Ogre2Scene::SkyEnabled() const
   return this->dataPtr->skyEnabled;
 }
 
-void Ogre2Scene::SetShadowTextureSize(unsigned int _textureSize)
+void Ogre2Scene::SetShadowTextureSize(LightType _lightType, unsigned int _textureSize)
 {
-  this->dataPtr->dirTexSize = _textureSize;
+  if (_lightType == LightType::LT_DIRECTIONAL)
+  {
+    this->dataPtr->dirTexSize = _textureSize;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -700,6 +700,8 @@ void Ogre2Scene::UpdateShadowNode()
     GLint glMaxTexSize;
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &glMaxTexSize);
 
+    // todo: there are issues when setting dirTexSize to a val larger
+    // than 16K
     this->dataPtr->maxTexSize = std::min(this->dataPtr->maxTexSize,
         static_cast<unsigned int>(glMaxTexSize));
   }

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -1570,6 +1570,7 @@ bool Ogre2Scene::SkyEnabled() const
   return this->dataPtr->skyEnabled;
 }
 
+//////////////////////////////////////////////////
 void Ogre2Scene::SetShadowTextureSize(LightType _lightType, unsigned int _textureSize)
 {
   // If _textureSize exceeds max possible tex size, then use default
@@ -1607,6 +1608,18 @@ void Ogre2Scene::SetShadowTextureSize(LightType _lightType, unsigned int _textur
   {
     this->dataPtr->dirTexSize = _textureSize;
   }
+}
+
+//////////////////////////////////////////////////
+unsigned int Ogre2Scene::ShadowTextureSize(LightType _lightType) 
+{
+  // todo: return based on light type, currently only dir light is supported
+  if (_lightType)
+  {
+    return this->dataPtr->dirTexSize;
+  }
+
+  return this->dataPtr->dirTexSize;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -1582,15 +1582,15 @@ bool Ogre2Scene::SkyEnabled() const
 }
 
 //////////////////////////////////////////////////
-void Ogre2Scene::SetShadowTextureSize(LightType _lightType,
+bool Ogre2Scene::SetShadowTextureSize(LightType _lightType,
     unsigned int _textureSize)
 {
   // If _lightType is not supported, block with gzerr message
-  if (_lightType != LightType::LT_DIRECTIONAL)
+  if (_lightType != LightType::DIRECTIONAL)
   {
-    gzerr << "Light type [" << _lightType << "] is not supported."
-          << std::endl;
-    return;
+    gzerr << "Light type [" << static_cast<int>(_lightType)
+          << "] is not supported." << std::endl;
+    return false;
   }
 
   // If _textureSize exceeds max possible tex size, then use default
@@ -1599,7 +1599,7 @@ void Ogre2Scene::SetShadowTextureSize(LightType _lightType,
     gzerr << "<texture_size> of '" << _textureSize
           << "' exceeds maximum possible texture size,"
           << " using default texture size" << std::endl;
-    return;
+    return false;
   }
 
   // if _textureSize is an invalid texture size, then use default
@@ -1609,14 +1609,15 @@ void Ogre2Scene::SetShadowTextureSize(LightType _lightType,
     gzerr << "<texture_size> of '" << _textureSize
           << "' is not a valid texture size,"
           << " using default texture size" << std::endl;
-    return;
+    return false;
   }
 
   // Set shadow texture size as _textureSize if value is valid
-  if (_lightType == LightType::LT_DIRECTIONAL)
+  if (_lightType == LightType::DIRECTIONAL)
   {
     this->dataPtr->dirTexSize = _textureSize;
   }
+  return true;
 }
 
 //////////////////////////////////////////////////
@@ -1625,14 +1626,15 @@ unsigned int Ogre2Scene::ShadowTextureSize(LightType _lightType) const
   // todo: return based on light type, currently only dir light is supported
   switch (_lightType)
   {
-    case LightType::LT_DIRECTIONAL:
+    case LightType::DIRECTIONAL:
       return this->dataPtr->dirTexSize;
-    case LightType::LT_SPOT:
-    case LightType::LT_POINT:
+    case LightType::SPOT:
+    case LightType::POINT:
       return this->dataPtr->spotPointTexSize;
     default:
-    case LightType::LT_EMPTY:
-      gzerr << "Invalid light type [" << _lightType << "]" << std::endl;
+    case LightType::EMPTY:
+      gzerr << "Invalid light type [" << static_cast<int>(_lightType) << "]"
+            << std::endl;
       return 0;
   }
 }

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -1597,8 +1597,9 @@ bool Ogre2Scene::SetShadowTextureSize(LightType _lightType,
   if (_textureSize > this->dataPtr->maxTexSize / 2)
   {
     gzerr << "<texture_size> of '" << _textureSize
-          << "' exceeds maximum possible texture size,"
-          << " using default texture size" << std::endl;
+          << "' exceeds maximum possible texture size of "
+          << this->dataPtr->maxTexSize <<
+          << ", using default texture size" << std::endl;
     return false;
   }
 

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -90,6 +90,8 @@ class gz::rendering::Ogre2ScenePrivate
   /// \brief Flag to indicate if sky is enabled or not
   public: bool skyEnabled = false;
 
+  public: unsigned int dirTexSize = 2048u;
+
   /// \brief Flag to alert the user its usage of PreRender/PostRender
   /// is incorrect
   public: bool frameUpdateStarted = false;
@@ -651,7 +653,7 @@ void Ogre2Scene::UpdateShadowNode()
 
   // directional lights
   unsigned int atlasId = 0u;
-  unsigned int dirTexSize = 4096u;
+  unsigned int dirTexSize = this->dataPtr->dirTexSize;
   unsigned int halfTexSize = static_cast<unsigned int>(dirTexSize * 0.5);
   for (unsigned int i = 0; i < dirLightCount; ++i)
   {
@@ -1553,6 +1555,11 @@ void Ogre2Scene::SetSkyEnabled(bool _enabled)
 bool Ogre2Scene::SkyEnabled() const
 {
   return this->dataPtr->skyEnabled;
+}
+
+void Ogre2Scene::SetTexSize(unsigned int _texSize)
+{
+  this->dataPtr->dirTexSize = _texSize;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -1571,7 +1571,8 @@ bool Ogre2Scene::SkyEnabled() const
 }
 
 //////////////////////////////////////////////////
-void Ogre2Scene::SetShadowTextureSize(LightType _lightType, unsigned int _textureSize)
+void Ogre2Scene::SetShadowTextureSize(LightType _lightType,
+    unsigned int _textureSize)
 {
   // If _textureSize exceeds max possible tex size, then use default
   if (_textureSize > this->dataPtr->maxTexSize / 2)
@@ -1580,9 +1581,10 @@ void Ogre2Scene::SetShadowTextureSize(LightType _lightType, unsigned int _textur
           << "' exceeds maximum possible texture size,"
           << " using default texture size" << std::endl;
     return;
-  } 
+  }
 
-  // Generate list of possible tex size options, each a power of 2, starting at 1024
+  // Generate list of possible tex size options, each a power of 2,
+  // starting at 1024
   std::vector<unsigned int> texSizeOptions;
   unsigned int texSizeOption = 1024u;
   while (texSizeOption <= this->dataPtr->maxTexSize / 2)
@@ -1591,11 +1593,11 @@ void Ogre2Scene::SetShadowTextureSize(LightType _lightType, unsigned int _textur
     texSizeOption *= 2;
   }
 
-  // if _textureSize is not a valid texture size, then use default
+  // if _textureSize is an invalid texture size, then use default
   bool validTexSize = std::find(texSizeOptions.begin(),
       texSizeOptions.end(), _textureSize)
       != texSizeOptions.end() ? true : false;
-  if (!validTexSize) 
+  if (!validTexSize)
   {
     gzerr << "<texture_size> of '" << _textureSize
           << "' is not a valid texture size,"
@@ -1611,7 +1613,7 @@ void Ogre2Scene::SetShadowTextureSize(LightType _lightType, unsigned int _textur
 }
 
 //////////////////////////////////////////////////
-unsigned int Ogre2Scene::ShadowTextureSize(LightType _lightType) 
+unsigned int Ogre2Scene::ShadowTextureSize(LightType _lightType) const
 {
   // todo: return based on light type, currently only dir light is supported
   if (_lightType)

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <GL/gl.h>
+
 #include <gz/common/Console.hh>
 
 #include "gz/rendering/base/SceneExt.hh"
@@ -678,8 +680,17 @@ void Ogre2Scene::UpdateShadowNode()
     atlasId++;
   }
 
-  // others
   unsigned int maxTexSize = 8192u;
+
+  if (engine->GraphicsAPI() == GraphicsAPI::OPENGL)
+  {
+    GLint glMaxTexSize;
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &glMaxTexSize);
+
+    maxTexSize = glMaxTexSize;
+  }
+
+  // others
   unsigned int spotPointTexSize = 2048u;
   unsigned int rowIdx = 0;
   unsigned int colIdx = 0;
@@ -1557,9 +1568,9 @@ bool Ogre2Scene::SkyEnabled() const
   return this->dataPtr->skyEnabled;
 }
 
-void Ogre2Scene::SetTexSize(unsigned int _texSize)
+void Ogre2Scene::SetShadowTextureSize(unsigned int _textureSize)
 {
-  this->dataPtr->dirTexSize = _texSize;
+  this->dataPtr->dirTexSize = _textureSize;
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -651,15 +651,15 @@ void Ogre2Scene::UpdateShadowNode()
 
   // directional lights
   unsigned int atlasId = 0u;
-  unsigned int texSize = 2048u;
-  unsigned int halfTexSize = static_cast<unsigned int>(texSize * 0.5);
+  unsigned int dirTexSize = 4096u;
+  unsigned int halfTexSize = static_cast<unsigned int>(dirTexSize * 0.5);
   for (unsigned int i = 0; i < dirLightCount; ++i)
   {
     shadowParam.technique = Ogre::SHADOWMAP_PSSM;
     shadowParam.atlasId = atlasId;
     shadowParam.numPssmSplits = 3u;
-    shadowParam.resolution[0].x = texSize;
-    shadowParam.resolution[0].y = texSize;
+    shadowParam.resolution[0].x = dirTexSize;
+    shadowParam.resolution[0].y = dirTexSize;
     shadowParam.resolution[1].x = halfTexSize;
     shadowParam.resolution[1].y = halfTexSize;
     shadowParam.resolution[2].x = halfTexSize;
@@ -667,9 +667,9 @@ void Ogre2Scene::UpdateShadowNode()
     shadowParam.atlasStart[0].x = 0u;
     shadowParam.atlasStart[0].y = 0u;
     shadowParam.atlasStart[1].x = 0u;
-    shadowParam.atlasStart[1].y = texSize;
+    shadowParam.atlasStart[1].y = dirTexSize;
     shadowParam.atlasStart[2].x = halfTexSize;
-    shadowParam.atlasStart[2].y = texSize;
+    shadowParam.atlasStart[2].y = dirTexSize;
     shadowParam.supportedLightTypes = 0u;
     shadowParam.addLightType(Ogre::Light::LT_DIRECTIONAL);
     shadowParams.push_back(shadowParam);
@@ -678,19 +678,20 @@ void Ogre2Scene::UpdateShadowNode()
 
   // others
   unsigned int maxTexSize = 8192u;
+  unsigned int spotPointTexSize = 2048u;
   unsigned int rowIdx = 0;
   unsigned int colIdx = 0;
-  unsigned int rowSize = maxTexSize / texSize;
+  unsigned int rowSize = maxTexSize / spotPointTexSize;
   unsigned int colSize = rowSize;
 
   for (unsigned int i = 0; i < spotPointLightCount; ++i)
   {
     shadowParam.technique = Ogre::SHADOWMAP_FOCUSED;
     shadowParam.atlasId = atlasId;
-    shadowParam.resolution[0].x = texSize;
-    shadowParam.resolution[0].y = texSize;
-    shadowParam.atlasStart[0].x = colIdx * texSize;
-    shadowParam.atlasStart[0].y = rowIdx * texSize;
+    shadowParam.resolution[0].x = spotPointTexSize;
+    shadowParam.resolution[0].y = spotPointTexSize;
+    shadowParam.atlasStart[0].x = colIdx * spotPointTexSize;
+    shadowParam.atlasStart[0].y = rowIdx * spotPointTexSize;
 
     shadowParam.supportedLightTypes = 0u;
     shadowParam.addLightType(Ogre::Light::LT_DIRECTIONAL);

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -1638,7 +1638,7 @@ unsigned int Ogre2Scene::ShadowTextureSize(LightType _lightType) const
     case LightType::EMPTY:
       gzerr << "Invalid light type [" << static_cast<int>(_lightType) << "]"
             << std::endl;
-      return 0;
+      return 0u;
   }
 }
 

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1475,9 +1475,9 @@ bool BaseScene::SkyEnabled() const
   return false;
 }
 
-void BaseScene::SetTexSize(unsigned int _texSize)
+void BaseScene::SetShadowTextureSize(unsigned int _textureSize)
 {
-  return this->SetTexSize(_texSize);
+  return this->SetShadowTextureSize(_textureSize);
 }
 
 //////////////////////////////////////////////////

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1476,9 +1476,10 @@ bool BaseScene::SkyEnabled() const
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetShadowTextureSize(LightType _lightType, unsigned int _textureSize)
+void BaseScene::SetShadowTextureSize(LightType _lightType,
+    unsigned int _textureSize)
 {
-  if (_lightType || _textureSize) 
+  if (_lightType || _textureSize)
   {
     gzerr << "Setting shadow texture size not supported by: "
            << this->Engine()->Name() << std::endl;
@@ -1486,7 +1487,7 @@ void BaseScene::SetShadowTextureSize(LightType _lightType, unsigned int _texture
 }
 
 //////////////////////////////////////////////////
-unsigned int BaseScene::ShadowTextureSize(LightType _lightType)
+unsigned int BaseScene::ShadowTextureSize(LightType _lightType) const
 {
   return this->ShadowTextureSize(_lightType);
 }

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1475,9 +1475,14 @@ bool BaseScene::SkyEnabled() const
   return false;
 }
 
-void BaseScene::SetShadowTextureSize(unsigned int _textureSize)
+//////////////////////////////////////////////////
+void BaseScene::SetShadowTextureSize(LightType _lightType, unsigned int _textureSize)
 {
-  return this->SetShadowTextureSize(_textureSize);
+  if (_lightType || _textureSize) 
+  {
+    gzerr << "Setting shadow texture size not supported by: "
+           << this->Engine()->Name() << std::endl;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1482,14 +1482,19 @@ void BaseScene::SetShadowTextureSize(LightType _lightType,
   if (_lightType || _textureSize)
   {
     gzerr << "Setting shadow texture size not supported by: "
-           << this->Engine()->Name() << std::endl;
+          << this->Engine()->Name() << std::endl;
   }
 }
 
 //////////////////////////////////////////////////
 unsigned int BaseScene::ShadowTextureSize(LightType _lightType) const
 {
-  return this->ShadowTextureSize(_lightType);
+  if (_lightType) 
+  {
+    gzerr << "Shadow texture size not supported by: "
+          << this->Engine()->Name() << std::endl;
+  }
+  return 0;
 }
 
 //////////////////////////////////////////////////

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1475,6 +1475,11 @@ bool BaseScene::SkyEnabled() const
   return false;
 }
 
+void BaseScene::SetTexSize(unsigned int _texSize)
+{
+  return this->SetTexSize(_texSize);
+}
+
 //////////////////////////////////////////////////
 void BaseScene::SetActiveGlobalIllumination(GlobalIlluminationBasePtr _gi)
 {

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1486,6 +1486,12 @@ void BaseScene::SetShadowTextureSize(LightType _lightType, unsigned int _texture
 }
 
 //////////////////////////////////////////////////
+unsigned int BaseScene::ShadowTextureSize(LightType _lightType)
+{
+  return this->ShadowTextureSize(_lightType);
+}
+
+//////////////////////////////////////////////////
 void BaseScene::SetActiveGlobalIllumination(GlobalIlluminationBasePtr _gi)
 {
   // no op, let derived class implement this.

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1476,20 +1476,21 @@ bool BaseScene::SkyEnabled() const
 }
 
 //////////////////////////////////////////////////
-void BaseScene::SetShadowTextureSize(LightType _lightType,
+bool BaseScene::SetShadowTextureSize(LightType _lightType,
     unsigned int _textureSize)
 {
-  if (_lightType || _textureSize)
+  if (static_cast<int>(_lightType) || _textureSize)
   {
     gzerr << "Setting shadow texture size not supported by: "
           << this->Engine()->Name() << std::endl;
   }
+  return false;
 }
 
 //////////////////////////////////////////////////
 unsigned int BaseScene::ShadowTextureSize(LightType _lightType) const
 {
-  if (_lightType) 
+  if (static_cast<int>(_lightType))
   {
     gzerr << "Shadow texture size not supported by: "
           << this->Engine()->Name() << std::endl;

--- a/test/common_test/Scene_TEST.cc
+++ b/test/common_test/Scene_TEST.cc
@@ -751,3 +751,32 @@ TEST_F(SceneTest, Sky)
   // Clean up
   engine->DestroyScene(scene);
 }
+
+/////////////////////////////////////////////////
+TEST_F(SceneTest, ShadowTexture)
+{
+  CHECK_SUPPORTED_ENGINE("ogre2");
+
+  auto scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+
+  // Default shadow texture size for directional light is 2048u
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_DIRECTIONAL), 2048u);
+
+  // Currently only support setting shadow texture size for
+  // directional light
+  // If set shadow texture size for other light types, it is ignored
+  scene->SetShadowTextureSize(LightType::LT_POINT, 4096u);
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_POINT), 2048u);
+
+  scene->SetShadowTextureSize(LightType::LT_SPOT, 4096u);
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_SPOT), 2048u);
+
+  // If set shadow texture size to a valid value, change it
+  scene->SetShadowTextureSize(LightType::LT_DIRECTIONAL, 8192u);
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_DIRECTIONAL), 8192u);
+
+  // If set shadow texture size to an invalid value, use default
+  scene->SetShadowTextureSize(LightType::LT_DIRECTIONAL, 1000u);
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_DIRECTIONAL), 8192u);
+}

--- a/test/common_test/Scene_TEST.cc
+++ b/test/common_test/Scene_TEST.cc
@@ -766,11 +766,17 @@ TEST_F(SceneTest, ShadowTextureSize)
   // Currently only support setting shadow texture size for
   // directional light
   // If set shadow texture size for other light types, it is ignored
+  auto spotLight = scene->CreateSpotLight("spot_light");
+  auto pointLight = scene->CreatePointLight("point_light");
+
   EXPECT_FALSE(scene->SetShadowTextureSize(LightType::POINT, 4096u));
   EXPECT_EQ(scene->ShadowTextureSize(LightType::POINT), 2048u);
 
   EXPECT_FALSE(scene->SetShadowTextureSize(LightType::SPOT, 4096u));
   EXPECT_EQ(scene->ShadowTextureSize(LightType::SPOT), 2048u);
+
+  EXPECT_FALSE(scene->SetShadowTextureSize(LightType::EMPTY, 4096u));
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::EMPTY), 0u);
 
   // If set shadow texture size to a valid value, change it
   EXPECT_TRUE(scene->SetShadowTextureSize(LightType::DIRECTIONAL, 8192u));
@@ -778,5 +784,10 @@ TEST_F(SceneTest, ShadowTextureSize)
 
   // If set shadow texture size to an invalid value, use default
   EXPECT_FALSE(scene->SetShadowTextureSize(LightType::DIRECTIONAL, 1000u));
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::DIRECTIONAL), 8192u);
+
+  // If set shadow texture size to a value larger than maxTexSize,
+  // use default
+  EXPECT_FALSE(scene->SetShadowTextureSize(LightType::DIRECTIONAL, 32768u));
   EXPECT_EQ(scene->ShadowTextureSize(LightType::DIRECTIONAL), 8192u);
 }

--- a/test/common_test/Scene_TEST.cc
+++ b/test/common_test/Scene_TEST.cc
@@ -753,7 +753,7 @@ TEST_F(SceneTest, Sky)
 }
 
 /////////////////////////////////////////////////
-TEST_F(SceneTest, ShadowTexture)
+TEST_F(SceneTest, ShadowTextureSize)
 {
   CHECK_SUPPORTED_ENGINE("ogre2");
 
@@ -761,22 +761,22 @@ TEST_F(SceneTest, ShadowTexture)
   ASSERT_NE(nullptr, scene);
 
   // Default shadow texture size for directional light is 2048u
-  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_DIRECTIONAL), 2048u);
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::DIRECTIONAL), 2048u);
 
   // Currently only support setting shadow texture size for
   // directional light
   // If set shadow texture size for other light types, it is ignored
-  scene->SetShadowTextureSize(LightType::LT_POINT, 4096u);
-  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_POINT), 2048u);
+  EXPECT_FALSE(scene->SetShadowTextureSize(LightType::POINT, 4096u));
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::POINT), 2048u);
 
-  scene->SetShadowTextureSize(LightType::LT_SPOT, 4096u);
-  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_SPOT), 2048u);
+  EXPECT_FALSE(scene->SetShadowTextureSize(LightType::SPOT, 4096u));
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::SPOT), 2048u);
 
   // If set shadow texture size to a valid value, change it
-  scene->SetShadowTextureSize(LightType::LT_DIRECTIONAL, 8192u);
-  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_DIRECTIONAL), 8192u);
+  EXPECT_TRUE(scene->SetShadowTextureSize(LightType::DIRECTIONAL, 8192u));
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::DIRECTIONAL), 8192u);
 
   // If set shadow texture size to an invalid value, use default
-  scene->SetShadowTextureSize(LightType::LT_DIRECTIONAL, 1000u);
-  EXPECT_EQ(scene->ShadowTextureSize(LightType::LT_DIRECTIONAL), 8192u);
+  EXPECT_FALSE(scene->SetShadowTextureSize(LightType::DIRECTIONAL, 1000u));
+  EXPECT_EQ(scene->ShadowTextureSize(LightType::DIRECTIONAL), 8192u);
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.

![depot 2k](https://github.com/user-attachments/assets/bd4bcd16-ff18-46e6-b234-c6bf7e1341f1)
![depot 16k](https://github.com/user-attachments/assets/d2d5d293-9bc4-4aec-a6de-3d6b9b7433f5)
-->
Shadows appear jagged in some scenes. It would be nice for them to look smoother and sharper. Investigated increasing shadow texture size - it seems that as long as there isn't too many lights, it does not have a significant impact on VRAM. 

Thus, added ability to set shadow texture size (currently, only for directional lights) within the `MinimalScene` plugin, and for Ogre2. The default shadow texture size is 2K, but setting it to a higher value (4K, 8K, etc.) allows for sharper shadows.

Currently supporting 1K, 2K, 4K, 8K, and 16K. So in SDF file, the respective values 1024, 2048, 4096, 8192, and 16384. In the future, can look to enable setting shadow texture size for other light types (spot, point lights). 

Also, if using OpenGL, ensured that max shadow texture size can use `GL_MAX_TEXTURE_SIZE` instead of hardcoding it to 8K.

<b>Depot scene from Edifice demo (SDF attached below). Note that scene has 1 directional light (darker shadow) and 1 point light (lighter shadow).</b>

Shadow texture size of 2K for directional light
![depot 2k](https://github.com/user-attachments/assets/bd4bcd16-ff18-46e6-b234-c6bf7e1341f1)

Shadow texture size of 16K for directional light
![depot 16k](https://github.com/user-attachments/assets/d2d5d293-9bc4-4aec-a6de-3d6b9b7433f5)

## Test it
<!--Explain how reviewers can test this new feature manually.-->
[depot_twolights.sdf.txt](https://github.com/user-attachments/files/16592516/depot_twolights.sdf.txt)
[shapes.sdf.txt](https://github.com/user-attachments/files/16592517/shapes.sdf.txt)

Modify the param in the SDF.
```
<shadows>
  <texture_size light_type="directional">8192</texture_size>
</shadows>
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.