### PR TITLE
Fix overloaded virtual warnings on noble

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -19,6 +19,14 @@ release will remove the deprecated code.
     + Removed: `Ogre::OgreItem *OnSelectionClick(const int _x, const int _y)`
     + Replacement: `Ogre::MovableObject *OnSelectionClick(int _x, int _y)`
 
+1. **GpuRays**
+    + Made function private: `void Copy(Image &_image)`
+    + Use the overloaded function: `void Copy(float *_data)`
+
+1. **RenderPass**
+    + Made function private: `void PreRender()`
+    + Use the overloaded function: `void PreRender(const CameraPtr &_camera)`
+
 ## Gazebo Rendering 7.x to 8.x
 
 ### Deprecations

--- a/include/gz/rendering/Camera.hh
+++ b/include/gz/rendering/Camera.hh
@@ -28,14 +28,6 @@
 #include "gz/rendering/Sensor.hh"
 #include "gz/rendering/Scene.hh"
 
-// overloaded-virtuals warnings appeared on Ubuntu Noble
-// GCC-13. it is not easy to fix them without breaking ABI
-// ignore them to preserve current ABI.
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
-
 namespace gz
 {
   namespace rendering
@@ -376,9 +368,5 @@ namespace gz
     }
   }
 }
-
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
 
 #endif

--- a/include/gz/rendering/GpuRays.hh
+++ b/include/gz/rendering/GpuRays.hh
@@ -190,6 +190,10 @@ namespace gz
       /// \return The vertical resolution.
       /// \sa VerticalRayCount()
       public: virtual double VerticalResolution() const = 0;
+
+      // Disallow use of Camera::Copy by making it private.
+      // Use the overloaded Copy(float *) function instead.
+      private: using Camera::Copy;
     };
   }
   }

--- a/include/gz/rendering/Object.hh
+++ b/include/gz/rendering/Object.hh
@@ -22,14 +22,6 @@
 #include "gz/rendering/RenderTypes.hh"
 #include "gz/rendering/Export.hh"
 
-// overloaded-virtuals warnings appeared on Ubuntu Noble
-// GCC-13. it is not easy to fix them without breaking ABI
-// ignore them to preserve current ABI.
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
-
 namespace gz
 {
   namespace rendering
@@ -77,9 +69,5 @@ namespace gz
     }
   }
 }
-
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
 
 #endif

--- a/include/gz/rendering/ParticleEmitter.hh
+++ b/include/gz/rendering/ParticleEmitter.hh
@@ -158,16 +158,6 @@ namespace gz
       /// \sa Lifetime
       public: virtual void SetLifetime(double _lifetime) = 0;
 
-      /// \brief Get the material which all particles in the emitter will use.
-      /// \return The material pointer.
-      /// \sa SetMaterial
-      public: virtual MaterialPtr Material() const = 0;
-
-      /// \brief Sets the material which all particles in the emitter will use.
-      /// \param[in] _material The material pointer.
-      /// \sa Material
-      public: virtual void SetMaterial(const MaterialPtr &_material) = 0;
-
       /// \brief Get the minimum velocity each particle is emitted (m/s).
       /// \return Minimum velocity.
       /// \sa MaxVelocity

--- a/include/gz/rendering/RenderPass.hh
+++ b/include/gz/rendering/RenderPass.hh
@@ -69,6 +69,10 @@ namespace gz
       /// \brief See SetWideAngleCameraAfterStitching()
       /// \return The current value set by SetWideAngleCameraAfterStitching
       public: virtual bool WideAngleCameraAfterStitching() const = 0;
+
+      // Documentation inherited
+      // Use PreRender(const CameraPtr &) instead
+      private: using Object::PreRender;
     };
     }
   }

--- a/include/gz/rendering/RenderTarget.hh
+++ b/include/gz/rendering/RenderTarget.hh
@@ -85,6 +85,9 @@ namespace gz
       /// \return Render target background color.
       public: virtual math::Color BackgroundColor() const = 0;
 
+      // Documentation inherited
+      public: using Object::PreRender;
+
       /// \brief See Object::PreRender. This function will call
       /// Object::PreRender but with the added bonus that it has access
       /// to the camera that is about to render

--- a/include/gz/rendering/Visual.hh
+++ b/include/gz/rendering/Visual.hh
@@ -22,14 +22,6 @@
 #include "gz/rendering/config.hh"
 #include "gz/rendering/Node.hh"
 
-// overloaded-virtuals warnings appeared on Ubuntu Noble
-// GCC-13. it is not easy to fix them without breaking ABI
-// ignore them to preserve current ABI.
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
-
 namespace gz
 {
   namespace rendering
@@ -214,9 +206,5 @@ namespace gz
     }
   }
 }
-
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
 
 #endif

--- a/include/gz/rendering/base/BaseParticleEmitter.hh
+++ b/include/gz/rendering/base/BaseParticleEmitter.hh
@@ -101,7 +101,8 @@ namespace gz
       public: virtual MaterialPtr Material() const override;
 
       // Documentation inherited.
-      public: virtual void SetMaterial(const MaterialPtr &_material) override;
+      public: virtual void SetMaterial(MaterialPtr _material,
+                  bool _unique = true) override;
 
       // Documentation inherited.
       public: virtual double MinVelocity() const override;
@@ -341,7 +342,8 @@ namespace gz
 
     /////////////////////////////////////////////////
     template <class T>
-    void BaseParticleEmitter<T>::SetMaterial(const MaterialPtr &_material)
+    void BaseParticleEmitter<T>::SetMaterial(MaterialPtr _material,
+        bool /*_unique*/)
     {
       this->material = _material;
     }

--- a/include/gz/rendering/base/BaseRenderPass.hh
+++ b/include/gz/rendering/base/BaseRenderPass.hh
@@ -48,7 +48,7 @@ namespace gz
       public: virtual bool IsEnabled() const override;
 
       // Documentation inherited
-      public: void PreRender(const CameraPtr &_camera) override;
+      public: virtual void PreRender(const CameraPtr &_camera) override;
 
       // Documentation inherited
       public: void SetWideAngleCameraAfterStitching(bool _afterStitching)

--- a/include/gz/rendering/base/BaseRenderTarget.hh
+++ b/include/gz/rendering/base/BaseRenderTarget.hh
@@ -25,14 +25,6 @@
 #include "gz/rendering/Scene.hh"
 #include "gz/rendering/base/BaseRenderTypes.hh"
 
-// overloaded-virtuals warnings appeared on Ubuntu Noble
-// GCC-13. it is not easy to fix them without breaking ABI
-// ignore them to preserve current ABI.
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Woverloaded-virtual"
-#endif
-
 namespace gz
 {
   namespace rendering
@@ -414,9 +406,5 @@ namespace gz
     }
   }
 }
-
-#if defined(__GNUC__) || defined(__clang__)
-# pragma GCC diagnostic pop
-#endif
 
 #endif

--- a/ogre/include/gz/rendering/ogre/OgreRenderTarget.hh
+++ b/ogre/include/gz/rendering/ogre/OgreRenderTarget.hh
@@ -144,7 +144,7 @@ namespace gz
       public: virtual void PostRender() override;
 
       // Documentation inherited.
-      public: virtual unsigned int GLId();
+      public: virtual unsigned int GLId() const override;
 
       public: virtual void Buffer(float *buffer);
 

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -426,7 +426,7 @@ void OgreRenderTexture::BuildTarget()
 }
 
 //////////////////////////////////////////////////
-unsigned int OgreRenderTexture::GLId()
+unsigned int OgreRenderTexture::GLId() const
 {
   if (!this->ogreTexture)
     return 0u;

--- a/ogre2/include/gz/rendering/ogre2/Ogre2GaussianNoisePass.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2GaussianNoisePass.hh
@@ -46,7 +46,7 @@ namespace gz
       public: virtual ~Ogre2GaussianNoisePass();
 
       // Documentation inherited
-      public: void PreRender() override;
+      public: virtual void PreRender(const CameraPtr &_camera) override;
 
       // Documentation inherited
       public: void CreateRenderPass() override;

--- a/ogre2/include/gz/rendering/ogre2/Ogre2ParticleEmitter.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2ParticleEmitter.hh
@@ -68,7 +68,8 @@ namespace gz
       public: virtual void SetLifetime(double _lifetime) override;
 
       // Documentation inherited.
-      public: virtual void SetMaterial(const MaterialPtr &_material) override;
+      public: virtual void SetMaterial(MaterialPtr _material,
+                  bool _unique = true) override;
 
       // Documentation inherited.
       public: virtual void SetVelocityRange(double _minVelocity,

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -76,7 +76,7 @@ class Ogre2DepthGaussianNoisePass : public Ogre2GaussianNoisePass
   public: virtual ~Ogre2DepthGaussianNoisePass() {}
 
   // Documentation inherited.
-  public: void PreRender() override;
+  public: virtual void PreRender(const CameraPtr &_camera) override;
 
   // Documentation inherited.
   public: void CreateRenderPass() override;
@@ -180,7 +180,7 @@ using namespace gz;
 using namespace rendering;
 
 //////////////////////////////////////////////////
-void Ogre2DepthGaussianNoisePass::PreRender()
+void Ogre2DepthGaussianNoisePass::PreRender(const CameraPtr &/*_camera*/)
 {
   // This function is similar to Ogre2GaussianNoisePass but duplicated here
   // for Ogre2DepthCamera

--- a/ogre2/src/Ogre2GaussianNoisePass.cc
+++ b/ogre2/src/Ogre2GaussianNoisePass.cc
@@ -60,7 +60,7 @@ Ogre2GaussianNoisePass::~Ogre2GaussianNoisePass()
 }
 
 //////////////////////////////////////////////////
-void Ogre2GaussianNoisePass::PreRender()
+void Ogre2GaussianNoisePass::PreRender(const CameraPtr &/*_camera*/)
 {
   if (!this->dataPtr->gaussianNoiseMat)
     return;

--- a/ogre2/src/Ogre2ParticleEmitter.cc
+++ b/ogre2/src/Ogre2ParticleEmitter.cc
@@ -260,7 +260,8 @@ void Ogre2ParticleEmitter::SetLifetime(double _lifetime)
 }
 
 //////////////////////////////////////////////////
-void Ogre2ParticleEmitter::SetMaterial(const MaterialPtr &_material)
+void Ogre2ParticleEmitter::SetMaterial(MaterialPtr _material,
+    bool /*_unique*/)
 {
   // Sanity check: The material cannot be nullptr.
   if (!_material)


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

These warnings are disabled in https://github.com/gazebosim/gz-rendering/pull/995 for harmonic on noble because fixes would involve ABI breaking changes. These warnings are useful and may help to uncover non-trivial errors. This PR removes most of the changes in https://github.com/gazebosim/gz-rendering/pull/995 and fixes the warnings.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

