### PR TITLE
Enable 24.04 CI, require cmake 3.22.1

### DIFF
--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,0 +1,2 @@
+libogre-next-dev
+libvulkan-dev

--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,2 +1,2 @@
-libogre-next-dev
+libogre-next-2.3-dev
 libvulkan-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'ign-rendering[0-9]'
-      - 'gz-rendering[0-9]?'
+      - 'gz-rendering[1-9]?[0-9]'
       - 'main'
 
 jobs:
@@ -20,6 +20,16 @@ jobs:
         uses: gazebo-tooling/action-gz-ci@jammy
         with:
           codecov-enabled: true
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble
+        with:
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         uses: gazebo-tooling/action-gz-ci@jammy
         with:
           codecov-enabled: true
+          doxygen-enabled: true
   noble-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Noble CI
@@ -32,4 +33,3 @@ jobs:
         with:
           cppcheck-enabled: true
           cpplint-enabled: true
-          doxygen-enabled: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(GZ_UTILS_VER ${gz-utils3_VERSION_MAJOR})
 #--------------------------------------
 # Find OpenGL
 # See CMP0072 for more details (cmake --help-policy CMP0072)
-if ((NOT ${CMAKE_VERSION} VERSION_LESS 3.11) AND (NOT OpenGL_GL_PREFERENCE))
+if (NOT OpenGL_GL_PREFERENCE)
   set(OpenGL_GL_PREFERENCE "GLVND")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 Build | Status
 -- | --
-Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-rendering/tree/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-rendering/tree/main)
-Ubuntu Jammy  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering-ci-main-jammy-amd64)](https://build.osrfoundation.org/job/gz_rendering-ci-main-jammy-amd64)
+Test coverage | [![codecov](https://codecov.io/gh/gazebosim/gz-rendering/branch/main/graph/badge.svg)](https://codecov.io/gh/gazebosim/gz-rendering/branch/main)
+Ubuntu Noble  | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering-ci-main-noble-amd64)](https://build.osrfoundation.org/job/gz_rendering-ci-main-noble-amd64)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering-ci-main-homebrew-amd64)](https://build.osrfoundation.org/job/gz_rendering-ci-main-homebrew-amd64)
-Windows       | [![Build Status](https://build.osrfoundation.org/job/gz_rendering-main-win/badge/icon)](https://build.osrfoundation.org/job/gz_rendering-main-win/)
+Windows       | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering-main-win)](https://build.osrfoundation.org/job/gz_rendering-main-win)
 
 Gazebo Rendering is a C++ library designed to provide an abstraction
 for different rendering engines. It offers unified APIs for creating

--- a/examples/actor_animation/CMakeLists.txt
+++ b/examples/actor_animation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-actor-animation)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/boundingbox_camera/CMakeLists.txt
+++ b/examples/boundingbox_camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-boundingbox-camera)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/camera_tracking/CMakeLists.txt
+++ b/examples/camera_tracking/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-camera-tracking)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/custom_scene_viewer/CMakeLists.txt
+++ b/examples/custom_scene_viewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-custom-scene-viewer)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/custom_shaders/CMakeLists.txt
+++ b/examples/custom_shaders/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-custom-shaders)
 
 include_directories(SYSTEM

--- a/examples/custom_shaders_uniforms/CMakeLists.txt
+++ b/examples/custom_shaders_uniforms/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-custom_shaders_uniforms)
 
 include_directories(SYSTEM

--- a/examples/depth_camera/CMakeLists.txt
+++ b/examples/depth_camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-depth-camera)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/global_illumination/CMakeLists.txt
+++ b/examples/global_illumination/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-global_illumination)
 
 find_package(gz-rendering9)

--- a/examples/heightmap/CMakeLists.txt
+++ b/examples/heightmap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-heightmap)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/hello_world_plugin/CMakeLists.txt
+++ b/examples/hello_world_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 find_package(gz-rendering9 REQUIRED)
 set(GZ_RENDERING_VER ${gz-rendering9_VERSION_MAJOR})

--- a/examples/lidar_visual/CMakeLists.txt
+++ b/examples/lidar_visual/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-lidar_visual)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/lux_core_engine/CMakeLists.txt
+++ b/examples/lux_core_engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 set(GZ_PLUGIN_VER 2)
 set(GZ_COMMON_VER 5)

--- a/examples/mesh_viewer/CMakeLists.txt
+++ b/examples/mesh_viewer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-mesh-viewer)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/mouse_picking/CMakeLists.txt
+++ b/examples/mouse_picking/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-mouse-picking)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/ogre2_demo/CMakeLists.txt
+++ b/examples/ogre2_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-ogre2-demo)
 
 find_package(gz-rendering9)

--- a/examples/particles_demo/CMakeLists.txt
+++ b/examples/particles_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-particles-demo)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/projector/CMakeLists.txt
+++ b/examples/projector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-projector)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/render_pass/CMakeLists.txt
+++ b/examples/render_pass/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-render-pass)
 
 find_package(gz-rendering9)

--- a/examples/segmentation_camera/CMakeLists.txt
+++ b/examples/segmentation_camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-segmentation-camera)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/simple_demo/CMakeLists.txt
+++ b/examples/simple_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-simple-demo)
 
 find_package(gz-rendering9)

--- a/examples/simple_demo_qml/CMakeLists.txt
+++ b/examples/simple_demo_qml/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-simple-demo-qml)
 
 #------------------------------------------------------------------------

--- a/examples/text_geom/CMakeLists.txt
+++ b/examples/text_geom/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-text-geom)
 
 find_package(gz-rendering9)

--- a/examples/thermal_camera/CMakeLists.txt
+++ b/examples/thermal_camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-thermal-camera)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/transform_control/CMakeLists.txt
+++ b/examples/transform_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-transform-control)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/view_control/CMakeLists.txt
+++ b/examples/view_control/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-view-control)
 find_package(gz-rendering9 REQUIRED)
 

--- a/examples/visualization_demo/CMakeLists.txt
+++ b/examples/visualization_demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-visualization-demo)
 
 find_package(gz-rendering9)

--- a/examples/waves/CMakeLists.txt
+++ b/examples/waves/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-waves)
 
 include_directories(SYSTEM

--- a/examples/wide_angle_camera/CMakeLists.txt
+++ b/examples/wide_angle_camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-wide-angle-camera)
 find_package(gz-rendering9 REQUIRED)
 

--- a/test/integration/waves.cc
+++ b/test/integration/waves.cc
@@ -168,11 +168,11 @@ TEST_F(WavesTest, Waves)
   (*vsParams)["dir0"].InitializeBuffer(2);
   (*vsParams)["dir0"].UpdateBuffer(dir0);
 
-  float dir1[2] = {-0.7, 0.7};
+  float dir1[2] = {-0.7f, 0.7f};
   (*vsParams)["dir1"].InitializeBuffer(2);
   (*vsParams)["dir1"].UpdateBuffer(dir1);
 
-  float dir2[2] = {0.7, 0.7};
+  float dir2[2] = {0.7f, 0.7f};
   (*vsParams)["dir2"].InitializeBuffer(2);
   (*vsParams)["dir2"].UpdateBuffer(dir2);
 


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-cmake/issues/350.

## Summary

This adds a GitHub workflow using Noble and increases our minimum required cmake version to 3.22.1 since we are already requiring that in gz-cmake4. I removed one bit of logic for outdated cmake versions in https://github.com/gazebosim/gz-rendering/commit/4925c87b6b32616db58d717b8ba217b3e5a36c30.

It also fixes the push branch regex to support multi-digit versions (copied from https://github.com/gazebosim/sdformat/pull/1445) and fixes the CI badges in the README.

## Test it

Check CI results

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
