### PR TITLE
Try fixing test failure with RTLD_NODELETE

### DIFF
--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -477,7 +477,7 @@ bool RenderEngineManagerPrivate::LoadEnginePlugin(
   }
 
   // Load plugin
-  auto pluginNames = this->pluginLoader.LoadLib(pathToLib);
+  auto pluginNames = this->pluginLoader.LoadLib(pathToLib, true);
   if (pluginNames.empty())
   {
     gzerr << "Failed to load plugin [" << _filename <<


### PR DESCRIPTION
# 🦟 Bug fix

Alternative to https://github.com/gazebosim/gz-rendering/pull/1033

## Summary

From #1033:

> The `INTEGRATION_load_unload` test crashes with ogre 1.x. The tests checks to see if the render engine can be loaded and unloaded in a thread (which is how `gz sim` runs the render engine). The crash happens on ubuntu 24.04 with the system debs, see https://github.com/gazebosim/gz-rendering/issues/1007 for more info.

Instead of the approach from #1033, this uses the suggestion from https://github.com/gazebosim/gz-rendering/pull/1033#issuecomment-2289815324

## To test (also from #1033)

The `INTEGRATION_load_unload` test should now pass with ogre 1.x on Ubuntu 24.04 with the system ogre debs:

```
GZ_ENGINE_TO_TEST=ogre  ./build/gz-rendering9/bin/INTEGRATION_load_unload
```

gz-sim should no longer crash on exit:

```
gz sim -v 4 -r --iterations 5 -s sensors_demo.sdf --render-engine ogre
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
