### PR TITLE
Fix segmentation camera color id computation with new math::Color clamping behavior (ogre2)

### DIFF
--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -187,9 +187,9 @@ math::Color Ogre2SegmentationMaterialSwitcher::LabelToColor(int64_t _label,
   int b = distribution(this->generator);
 
   math::Color color(
-    static_cast<float>(r),
-    static_cast<float>(g),
-    static_cast<float>(b));
+    static_cast<float>(r / 255.0f),
+    static_cast<float>(g / 255.0f),
+    static_cast<float>(b / 255.0f));
 
   // if the label is colored before return the color
   // don't check for taken colors in that case, all items


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

gz-sensors caught a crash in in its segmentation camera integration test on [github actions](https://github.com/gazebosim/gz-sensors/actions/runs/10461972989/job/28972696100). The error msgs reveal that it related to the new color clamping behavior in `gz::math::Color`:

```
2024-08-19T23:31:54.9495719Z Color values were clamped
2024-08-19T23:31:54.9495817Z Color values were clamped
2024-08-19T23:31:54.9495909Z Color values were clamped
```

The new Color behavior expects the range to be within [0, 1] but we are passing it values of [0, 255].

More info on the crash:  the crash was due to infinite recursion. The function tried to compute (recursively) unique color ids but each new generated color gets clamped to the same value `[1, 1, 1]`.

To test:

Run the gz-sensors segmentation camera integration test:

```
./build/gz-sensors9/bin/INTEGRATION_segmentation_camera 
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
