### PR TITLE
Remove setting OpenGL_GL_PREFERENCE in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,6 @@ set(GZ_UTILS_VER ${gz-utils3_VERSION_MAJOR})
 
 #--------------------------------------
 # Find OpenGL
-# See CMP0072 for more details (cmake --help-policy CMP0072)
-if (NOT OpenGL_GL_PREFERENCE)
-  set(OpenGL_GL_PREFERENCE "GLVND")
-endif()
-
 if (APPLE)
   gz_find_package(OpenGL
     REQUIRED_BY ogre ogre2


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

This is no longer necessary now that we require a newer version of CMake, see https://github.com/gazebosim/gz-sensors/pull/457#discussion_r1720402930

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
