### PR TITLE
Prepare for gz-rendering 9.0.0~pre1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(GZ_CMAKE_VER ${gz-cmake4_VERSION_MAJOR})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,14 @@
 
 ### Gazebo Rendering 9.0.0 (2024-09-XX)
 
+1. **Baseline:** this includes all changes from 8.2.0 and earlier.
+
+1. Update badges to point to gz-rendering9 branch
+    * [Pull request #1044](https://github.com/gazebosim/gz-rendering/pull/1044)
+
+1. Ionic Changelog
+    * [Pull request #1042](https://github.com/gazebosim/gz-rendering/pull/1042)
+
 1. Remove gl preference in cmake
     * [Pull request #1041](https://github.com/gazebosim/gz-rendering/pull/1041)
 


### PR DESCRIPTION


# 🎈 Release

Preparation for 9.0.0~pre1 release.

Comparison to 8.2.0: https://github.com/gazebosim/gz-rendering/compare/gz-rendering8_8.2.0...prep_9.0.0pre1

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
