### PR TITLE
Fix using lightmap and emissive map together

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -753,14 +753,10 @@ void Ogre2Material::SetLightMap(const std::string &_name,
   this->dataPtr->lightMapData = _img;
   this->lightMapUvSet = _uvSet;
 
-  // in gz-rendering5 + ogre 2.1, we reserved detail map 0 for light map
-  // and set a blend mode (PBSM_BLEND_OVERLAY AND PBSM_BLEND_MULTIPLY2X
-  // produces better results) to blend with base albedo map. However, this
-  // creates unwanted red highlights with ogre 2.2. So switching to use the
-  // emissive map slot and calling setUseEmissiveAsLightmap(true)
-  // Ogre::PbsTextureTypes type = Ogre::PBSM_DETAIL0;
-  // this->ogreDatablock->setDetailMapBlendMode(0, Ogre::PBSM_BLEND_OVERLAY);
-  Ogre::PbsTextureTypes type = Ogre::PBSM_EMISSIVE;
+  // Apply lightmap by using the detail map slot to store the lightmap texture
+  // and blending it with the diffuse map.
+  Ogre::PbsTextureTypes type = Ogre::PBSM_DETAIL0;
+  this->ogreDatablock->setDetailMapBlendMode(0, Ogre::PBSM_BLEND_OVERLAY);
 
   // lightmap usually uses a different tex coord set
   if (_img == nullptr)
@@ -768,7 +764,6 @@ void Ogre2Material::SetLightMap(const std::string &_name,
   else
     this->SetTextureMapDataImpl(this->lightMapName, _img, type);
   this->ogreDatablock->setTextureUvSource(type, this->lightMapUvSet);
-  this->ogreDatablock->setUseEmissiveAsLightmap(true);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

To be used by the Ionic demo world.

Currently lightmap is applied through the emissive map slot. This means you can't use emissive map together with lightmap (only one of them can be applied). This was done to workaround an unwanted red hightlight issue found in gz-rendering6 + ogre2.2. This issue seems to be fixed now (as of gz-rendering9 + ogre 2.3). So I restored back to the original way of applying lightmaps through the detail map slot and I don't see the red highlights. Here's a screenshot of the lightmap sdf world with this change:

<img width="656" alt="lightmap_as_detailmap" src="https://github.com/user-attachments/assets/4817c80c-4875-46ec-a1b8-48dc39c23e79">


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
