### PR TITLE
Add Github Action for Windows and fix build

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,48 @@
+name: Windows
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Window CI
+    env:
+      PACKAGE: gz-rendering9
+    runs-on: windows-latest
+    steps:
+    - name: setup-pixi
+      uses: prefix-dev/setup-pixi@v0.8.1
+      with:
+        run-install: false
+
+    - name: Install build tools
+      run: |
+        pixi init
+        pixi add vcstool colcon-common-extensions pkgconfig
+    - name: Setup pixi env variables
+      shell: bash
+      run: |
+        eval "$(pixi shell-hook)"
+        echo CMAKE_PREFIX_PATH=$CONDA_PREFIX/Library >> $GITHUB_ENV
+    - name: Install base dependencies
+      run: |
+        # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
+        pixi add assimp dlfcn-win32 eigen ffmpeg freeimage gdal gflags ogre ogre-next spdlog tinyxml2
+    - name: Clone source dependencies
+      run: |
+        mkdir src
+        cd src
+        pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml
+
+    - uses: actions/checkout@v4
+      with:
+        path: src/gz-rendering
+
+    - name: Build Dependencies
+      run: |
+        pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-up-to ${env:PACKAGE}
+
+    - name: Build Package
+      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+
+    - name: Test
+      run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -20,9 +20,13 @@
   #include <OpenGL/gl.h>
   #include <OpenGL/glext.h>
 #else
-#ifndef _WIN32
+  #ifdef _WIN32
+    // windows.h has to be included *before* GL/gl.h
+    // to avoid redefinition errors.
+    #include <windows.h>
+  #endif
+
   #include <GL/gl.h>
-#endif
 #endif
 
 #include <gz/common/Console.hh>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
Build failure was reported in https://github.com/gazebosim/gazebo_test_cases/issues/1701#issuecomment-2321951252. It looks like #1034 introduced the regression and since we don't have Ogre2 being tested on CI, we didn't catch it.

The first commit just adds GitHub action for windows as a temporary solution until we fix Jenkins.
Here's the failed Action from the first commit: https://github.com/gazebosim/gz-rendering/actions/runs/10642231243/job/29504381117?pr=1049 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
