### PR TITLE
Improve windows workflow

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,7 +47,7 @@ jobs:
         echo CMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_PATH" >> $GITHUB_ENV
 
     - name: Clone source dependencies
-      run: pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/$PACKAGE.yaml --skip-existing --repos src
+      run: pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml --skip-existing --repos src
 
     - name: Build Dependencies
       run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=OFF  --packages-skip ${env:PACKAGE}
@@ -56,4 +56,6 @@ jobs:
       run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=ON -DSKIP_ogre=ON --packages-select ${env:PACKAGE}
 
     - name: Test
-      run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+      run: |
+        . install\setup.ps1
+        pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -46,6 +46,13 @@ jobs:
         rm -rf gz-rendering
         # Move the gz-rendering we checkout earlier and replace the one cloned by vcs
         mv ../tmp/gz-rendering .
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.5
+    - name: sscache environment
+      shell: bash
+      run: |
+        echo CMAKE_C_COMPILER_LAUNCHER="$SCCACHE_PATH" >> $GITHUB_ENV
+        echo CMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_PATH" >> $GITHUB_ENV
 
     - name: Build Dependencies
       run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-skip ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,7 +47,7 @@ jobs:
         echo CMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_PATH" >> $GITHUB_ENV
 
     - name: Clone source dependencies
-      run: pixi run vcs import src --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/$PACKAGE.yaml --skip-existing --repos
+      run: pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/$PACKAGE.yaml --skip-existing --repos src
 
     - name: Build Dependencies
       run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=OFF  --packages-skip ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -47,15 +47,15 @@ jobs:
         echo CMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_PATH" >> $GITHUB_ENV
 
     - name: Clone source dependencies
-      run: pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml --skip-existing --repos src
+      run: vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml --skip-existing --repos src
 
     - name: Build Dependencies
-      run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=OFF  --packages-skip ${env:PACKAGE}
+      run: ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=OFF  --packages-skip ${env:PACKAGE}
 
     - name: Build Package
-      run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=ON -DSKIP_ogre=ON --packages-select ${env:PACKAGE}
+      run: ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=ON -DSKIP_ogre=ON --packages-select ${env:PACKAGE}
 
     - name: Test
       run: |
         . install\setup.ps1
-        pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+        colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -6,9 +6,18 @@ jobs:
   build:
     name: Window CI
     env:
-      PACKAGE: gz-rendering9
+      LIBRARY_NAME: gz-rendering
     runs-on: windows-latest
     steps:
+
+    - uses: actions/checkout@v4
+      with:
+        path: tmp/gz-rendering
+    - name: Determine major version
+      shell: bash
+      run: |
+        curl -LO https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/tools/detect_cmake_major_version.py
+        echo PACKAGE="$LIBRARY_NAME$(python3 detect_cmake_major_version tmp/gz-rendering/CMakeLists.txt)"" >> $GITHUB_ENV
     - name: setup-pixi
       uses: prefix-dev/setup-pixi@v0.8.1
       with:
@@ -28,14 +37,14 @@ jobs:
         # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
         pixi add assimp dlfcn-win32 eigen ffmpeg freeimage gdal gflags ogre ogre-next spdlog tinyxml2
     - name: Clone source dependencies
+      shell: bash
       run: |
         mkdir src
         cd src
         pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml
-
-    - uses: actions/checkout@v4
-      with:
-        path: src/gz-rendering
+        rm -rf gz-rendering
+        # Move the gz-rendering we checkout earlier and replace the one cloned by vcs
+        mv ../tmp/gz-rendering .
 
     - name: Build Dependencies
       run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -54,4 +54,6 @@ jobs:
       run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
 
     - name: Test
-      run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+      run: 
+        $env:PATH=${env:GITHUB_WORKSPACE}\install\bin;$env:PATH
+        pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -17,7 +17,7 @@ jobs:
       shell: bash
       run: |
         curl -LO https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/tools/detect_cmake_major_version.py
-        echo PACKAGE="$LIBRARY_NAME$(python3 detect_cmake_major_version tmp/gz-rendering/CMakeLists.txt)"" >> $GITHUB_ENV
+        echo PACKAGE="$LIBRARY_NAME$(python3 detect_cmake_major_version tmp/gz-rendering/CMakeLists.txt)" >> $GITHUB_ENV
     - name: setup-pixi
       uses: prefix-dev/setup-pixi@v0.8.1
       with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,17 +7,18 @@ jobs:
     name: Window CI
     env:
       LIBRARY_NAME: gz-rendering
+      COLCON_BUILD_CMD: 'colcon build --merge-install --event-handlers console_direct+ --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release'
     runs-on: windows-2022
     steps:
 
     - uses: actions/checkout@v4
       with:
-        path: tmp/gz-rendering
+        path: src/gz-rendering
     - name: Determine major version
       shell: bash
       run: |
         curl -LO https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/tools/detect_cmake_major_version.py
-        echo PACKAGE="$LIBRARY_NAME$(python3 detect_cmake_major_version.py tmp/gz-rendering/CMakeLists.txt)" >> $GITHUB_ENV
+        echo PACKAGE="$LIBRARY_NAME$(python3 detect_cmake_major_version.py src/gz-rendering/CMakeLists.txt)" >> $GITHUB_ENV
     - name: setup-pixi
       uses: prefix-dev/setup-pixi@v0.8.1
       with:
@@ -34,18 +35,9 @@ jobs:
         ("CMAKE_PREFIX_PATH=${env:CONDA_PREFIX}\Library") >> $env:GITHUB_ENV
         ("PATH=${env:PATH}") >> $env:GITHUB_ENV
     - name: Install base dependencies
-      run: |
-        # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
-        pixi add assimp dlfcn-win32 eigen ffmpeg freeimage gdal gflags ogre ogre-next spdlog tinyxml2
-    - name: Clone source dependencies
-      shell: bash
-      run: |
-        mkdir src
-        cd src
-        pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/$PACKAGE.yaml
-        rm -rf gz-rendering
-        # Move the gz-rendering we checkout earlier and replace the one cloned by vcs
-        mv ../tmp/gz-rendering .
+      # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
+      run: pixi add assimp dlfcn-win32 eigen ffmpeg freeimage gdal gflags ogre ogre-next spdlog tinyxml2
+
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.5
     - name: sscache environment
@@ -54,11 +46,14 @@ jobs:
         echo CMAKE_C_COMPILER_LAUNCHER="$SCCACHE_PATH" >> $GITHUB_ENV
         echo CMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_PATH" >> $GITHUB_ENV
 
+    - name: Clone source dependencies
+      run: pixi run vcs import src --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/$PACKAGE.yaml --skip-existing --repos
+
     - name: Build Dependencies
-      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-skip ${env:PACKAGE}
+      run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=OFF  --packages-skip ${env:PACKAGE}
 
     - name: Build Package
-      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+      run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=ON -DSKIP_ogre=ON --packages-select ${env:PACKAGE}
 
     - name: Test
       run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -27,12 +27,11 @@ jobs:
       run: |
         pixi init
         pixi add vcstool colcon-common-extensions pkgconfig
-    - name: Setup pixi env variables
-      shell: bash
+    - name: Set up environment variables
       run: |
-        eval "$(pixi shell-hook)"
-        echo CMAKE_PREFIX_PATH="$CONDA_PREFIX\\Library" >> $GITHUB_ENV
-        echo PATH="$PATH" >> $GITHUB_ENV
+        # Set environment variables globally
+        pixi shell-hook | Out-String | Invoke-Expression
+        ("CMAKE_PREFIX_PATH=${env:CONDA_PREFIX}\Library") >> $env:GITHUB_ENV
     - name: Install base dependencies
       run: |
         # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
@@ -55,4 +54,7 @@ jobs:
       run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
 
     - name: Test
-      run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+      run: |
+
+        eval "$(pixi shell-hook)"
+        pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -31,7 +31,7 @@ jobs:
       shell: bash
       run: |
         eval "$(pixi shell-hook)"
-        echo CMAKE_PREFIX_PATH=$CONDA_PREFIX/Library >> $GITHUB_ENV
+        echo CMAKE_PREFIX_PATH=$CONDA_PREFIX\\Library >> $GITHUB_ENV
     - name: Install base dependencies
       run: |
         # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
@@ -41,7 +41,7 @@ jobs:
       run: |
         mkdir src
         cd src
-        pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml
+        pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/$PACKAGE.yaml
         rm -rf gz-rendering
         # Move the gz-rendering we checkout earlier and replace the one cloned by vcs
         mv ../tmp/gz-rendering .

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -50,10 +50,10 @@ jobs:
       run: vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml --skip-existing --repos src
 
     - name: Build Dependencies
-      run: ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=OFF  --packages-skip ${env:PACKAGE}
+      run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=OFF  --packages-skip ${env:PACKAGE}
 
     - name: Build Package
-      run: ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=ON -DSKIP_ogre=ON --packages-select ${env:PACKAGE}
+      run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=ON -DSKIP_ogre=ON --packages-select ${env:PACKAGE}
 
     - name: Test
       run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -33,7 +33,7 @@ jobs:
         # Set environment variables globally
         pixi shell-hook | Out-String | Invoke-Expression
         ("CMAKE_PREFIX_PATH=${env:CONDA_PREFIX}\Library") >> $env:GITHUB_ENV
-        ("PATH=${env:PATH}") >> $env:GITHUB_ENV
+        ("PATH=${env:PATH};${env:GITHUB_WORKSPACE}\install\bin") >> $env:GITHUB_ENV
     - name: Install base dependencies
       # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
       run: pixi add assimp dlfcn-win32 eigen ffmpeg freeimage gdal gflags ogre ogre-next spdlog tinyxml2
@@ -56,6 +56,4 @@ jobs:
       run: pixi run ${env:COLCON_BUILD_CMD} -DBUILD_TESTING=ON -DSKIP_ogre=ON --packages-select ${env:PACKAGE}
 
     - name: Test
-      run: |
-        $env:PATH += "${env:GITHUB_WORKSPACE}\install\bin"
-        pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+      run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -32,6 +32,7 @@ jobs:
         # Set environment variables globally
         pixi shell-hook | Out-String | Invoke-Expression
         ("CMAKE_PREFIX_PATH=${env:CONDA_PREFIX}\Library") >> $env:GITHUB_ENV
+        ("PATH=${env:PATH}") >> $env:GITHUB_ENV
     - name: Install base dependencies
       run: |
         # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
@@ -47,14 +48,10 @@ jobs:
         mv ../tmp/gz-rendering .
 
     - name: Build Dependencies
-      run: |
-        pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-up-to ${env:PACKAGE}
+      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-up-to ${env:PACKAGE}
 
     - name: Build Package
       run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
 
     - name: Test
-      run: |
-
-        eval "$(pixi shell-hook)"
-        pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+      run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -62,5 +62,5 @@ jobs:
 
     - name: Test
       run: 
-        $env:PATH=${env:GITHUB_WORKSPACE}\install\bin;$env:PATH
+        $env:PATH="${env:GITHUB_WORKSPACE}\install\bin";$env:PATH
         pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -48,7 +48,7 @@ jobs:
         mv ../tmp/gz-rendering .
 
     - name: Build Dependencies
-      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-up-to ${env:PACKAGE}
+      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-skip ${env:PACKAGE}
 
     - name: Build Package
       run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -17,7 +17,7 @@ jobs:
       shell: bash
       run: |
         curl -LO https://raw.githubusercontent.com/gazebo-tooling/release-tools/master/jenkins-scripts/tools/detect_cmake_major_version.py
-        echo PACKAGE="$LIBRARY_NAME$(python3 detect_cmake_major_version tmp/gz-rendering/CMakeLists.txt)" >> $GITHUB_ENV
+        echo PACKAGE="$LIBRARY_NAME$(python3 detect_cmake_major_version.py tmp/gz-rendering/CMakeLists.txt)" >> $GITHUB_ENV
     - name: setup-pixi
       uses: prefix-dev/setup-pixi@v0.8.1
       with:

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,0 +1,48 @@
+name: Windows
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Window CI
+    env:
+      PACKAGE: gz-rendering9
+    runs-on: windows-latest
+    steps:
+    - name: setup-pixi
+      uses: prefix-dev/setup-pixi@v0.8.1
+      with:
+        run-install: false
+
+    - name: Install build tools
+      run: |
+        pixi init
+        pixi add vcstool colcon-common-extensions pkgconfig
+    - name: Setup pixi env variables
+      shell: bash
+      run: |
+        eval "$(pixi shell-hook)"
+        echo CMAKE_PREFIX_PATH=$CONDA_PREFIX/Library >> $GITHUB_ENV
+    - name: Install base dependencies
+      run: |
+        # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22
+        pixi add assimp dlfcn-win32 eigen ffmpeg freeimage gdal gflags ogre ogre-next spdlog tinyxml2
+    - name: Clone source dependencies
+      run: |
+        mkdir src
+        cd src
+        pixi run vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/${env:PACKAGE}.yaml
+
+    - uses: actions/checkout@v4
+      with:
+        path: src/gz-rendering
+
+    - name: Build Dependencies
+      run: |
+        pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-up-to ${env:PACKAGE}
+
+    - name: Build Package
+      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+
+    - name: Test
+      run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -61,6 +61,6 @@ jobs:
       run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
 
     - name: Test
-      run: 
-        $env:PATH="${env:GITHUB_WORKSPACE}\install\bin";$env:PATH
+      run: |
+        $env:PATH += "${env:GITHUB_WORKSPACE}\install\bin"
         pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -31,7 +31,8 @@ jobs:
       shell: bash
       run: |
         eval "$(pixi shell-hook)"
-        echo CMAKE_PREFIX_PATH=$CONDA_PREFIX\\Library >> $GITHUB_ENV
+        echo CMAKE_PREFIX_PATH="$CONDA_PREFIX\\Library" >> $GITHUB_ENV
+        echo PATH="$PATH" >> $GITHUB_ENV
     - name: Install base dependencies
       run: |
         # List adapted from https://github.com/gazebo-tooling/release-tools/blob/f89ac8cafc646260598eb8eb6d94be8093bdc9f7/jenkins-scripts/lib/windows_env_vars.bat#L22

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Window CI
     env:
       LIBRARY_NAME: gz-rendering
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
 
     - uses: actions/checkout@v4

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -20,9 +20,13 @@
   #include <OpenGL/gl.h>
   #include <OpenGL/glext.h>
 #else
-#ifndef _WIN32
+  #ifdef _WIN32
+    // windows.h has to be included *before* GL/gl.h
+    // to avoid redefinition errors.
+    #include <windows.h>
+  #endif
+
   #include <GL/gl.h>
-#endif
 #endif
 
 #include <gz/common/Console.hh>

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -473,6 +473,11 @@ bool RenderEngineManagerPrivate::LoadEnginePlugin(
   {
     gzerr << "Failed to load plugin [" << _filename <<
              "] : couldn't find shared library." << std::endl;
+    gzdbg << "Searched in:\n";
+    for (const auto &path: systemPaths.FilePaths()){
+      gzdbg << path << "\n";
+    }
+
     return false;
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

#1049 introduced the Windows Github Action workflow. This PR makes some improvements to the workflow:
* Use script to determine major version number
* Add sscache


The hope is to also fix the issue from #1049 with the Ogre2 plugin not being loaded properly in tests as can be seen from error messages like the following:
```
17: (2024-08-31 04:51:07.821) [debug] Read GZ_ENGINE_TO_TEST=ogre2
17: (2024-08-31 04:51:07.822) [debug] Read GZ_ENGINE_BACKEND=gl3plus
17: (2024-08-31 04:51:07.822) [info] Loading plugin [gz-rendering-ogre2]
Error: 24-08-31 04:51:07.822) [error] Failed to load plugin [gz-rendering-ogre2] : couldn't find shared library.
```


Opening as a draft since it's still not able to load the Ogre2 plugin.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
