### PR TITLE
Add a note in Depth camera tutorial that prerequisite is for ubuntu only.

### DIFF
--- a/tutorials/23_depth_camera_tutorial.md
+++ b/tutorials/23_depth_camera_tutorial.md
@@ -2,9 +2,9 @@
 
 This example shows how to use the depth camera.
 
-## Install prerequisites
+## Install prerequisites (Ubuntu)
 
-In order to compile this tutorial, you need to install some prerequisites :
+In order to compile this tutorial, you need to install some prerequisites:
 
 ```bash
 sudo apt-get install build-essential freeglut3-dev libglew-dev


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Added note that install prerequisites are for ubuntu only.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

