### PR TITLE
examples/depth_camera: Fixed windows usage

### DIFF
--- a/examples/depth_camera/CMakeLists.txt
+++ b/examples/depth_camera/CMakeLists.txt
@@ -20,7 +20,9 @@ if (NOT APPLE)
   link_directories(${GLEW_LIBRARY_DIRS})
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
 
 configure_file (example_config.hh.in ${PROJECT_BINARY_DIR}/example_config.hh)
 

--- a/examples/depth_camera/Main.cc
+++ b/examples/depth_camera/Main.cc
@@ -38,8 +38,13 @@
 using namespace gz;
 using namespace rendering;
 
+#if not defined(_WIN32)
 const std::string RESOURCE_PATH =
     common::joinPaths(std::string(PROJECT_BINARY_PATH), "media");
+#else
+const std::string RESOURCE_PATH =
+    common::joinPaths(std::string(PROJECT_BINARY_PATH), "..", "media");
+#endif
 
 void buildScene(ScenePtr _scene)
 {

--- a/tutorials/23_depth_camera_tutorial.md
+++ b/tutorials/23_depth_camera_tutorial.md
@@ -7,7 +7,11 @@ This example shows how to use the depth camera.
 In order to compile this tutorial, you need to install some prerequisites :
 
 ```bash
+# Linux
 sudo apt-get install build-essential freeglut3-dev libglew-dev
+
+# Windows (via conda)
+conda install glew --channel conda-forge
 ```
 
 ## Compile and run the example
@@ -20,13 +24,20 @@ cd gz-rendering/examples/depth_camera
 mkdir build
 cd build
 cmake ..
-make
+# On Linux
+cmake --build .
+# On Windows
+cmake --build . --config Release
 ```
 
 Execute the example:
 
 ```{.sh}
+# Linux
 ./depth_camera ogre
+
+# Windows
+.\Release\depth_camera.exe ogre
 ```
 
 You'll see:


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/1494

## Summary
This PR allows building and running depth_camera example on Windows.

I'm not sure about the thing with `RESOURCE_PATH`, but I had to do it on Windows.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.