### PR TITLE
examples/heightmap: Fixed Windows build

### DIFF
--- a/examples/heightmap/CMakeLists.txt
+++ b/examples/heightmap/CMakeLists.txt
@@ -20,7 +20,9 @@ if (NOT APPLE)
   link_directories(${GLEW_LIBRARY_DIRS})
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+if(NOT MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
 
 configure_file (example_config.hh.in ${PROJECT_BINARY_DIR}/example_config.hh)
 

--- a/examples/heightmap/Main.cc
+++ b/examples/heightmap/Main.cc
@@ -22,6 +22,8 @@
   #include <GL/glew.h>
   #include <GL/gl.h>
   #include <GL/glut.h>
+#else
+  #include <GL/glut.h>
 #endif
 
 #include <iostream>
@@ -39,8 +41,13 @@
 using namespace gz;
 using namespace rendering;
 
+#if not defined(_WIN32)
 const std::string RESOURCE_PATH =
     common::joinPaths(std::string(PROJECT_BINARY_PATH), "media");
+#else
+const std::string RESOURCE_PATH =
+    common::joinPaths(std::string(PROJECT_BINARY_PATH), "..", "media");
+#endif
 
 //////////////////////////////////////////////////
 void createImageHeightmaps(const ScenePtr _scene, VisualPtr _root)

--- a/tutorials/21_heightmap.md
+++ b/tutorials/21_heightmap.md
@@ -6,7 +6,7 @@ It loads 2 different heightmaps (image and Digital Elevation Model (DEM)) with d
 
 ## Compile and run the example
 
-Clone the source code, create a build directory and use `cmake` and `make` to compile the code:
+Clone the source code, create a build directory and use `cmake` to compile the code:
 
 ```{.sh}
 git clone https://github.com/gazebosim/gz-rendering
@@ -14,12 +14,19 @@ cd gz-rendering/examples/heightmap
 mkdir build
 cd build
 cmake ..
-make
+# Linux
+cmake --build .
+# Windows
+cmake --build . --config Release
 ```
 Example 1 (image heightmap):
 
 ```{.sh}
+# Linux
 ./heightmap
+
+# Windows
+.\Release\heightmap.exe
 ```
 
 You'll see:


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/1482

## Summary
This PR adds support for building the heightmap example on Windows.

I was able to compile the example and run it using `.\Release\heightmap.exe ogre`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.