### PR TITLE
Update homebrew install instruction

### DIFF
--- a/tutorials/02_install.md
+++ b/tutorials/02_install.md
@@ -196,9 +196,11 @@ This assumes you have created and activated a Conda environment while [installin
 
 ## Binary Installation
 
-On macOS, add OSRF packages:
+Install [Homebrew](https://brew.sh/).
+
+Add OSRF packages:
+
   ```
-  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
   brew tap osrf/simulation
   ```
 
@@ -207,7 +209,7 @@ Install Gazebo Rendering:
   brew install gz-rendering<#>
   ```
 
-Be sure to replace `<#>` with a number value, such as 7 or 8, depending on
+Be sure to replace `<#>` with a number value, such as 8 or 9, depending on
 which version you need.
 
 ## Source Installation


### PR DESCRIPTION


# 🦟 Bug fix

Related: https://github.com/gazebosim/gazebo_test_cases/issues/1444

## Summary

Updated instruction for installing homebrew.

The command no longer works as the  URL is incorrect, so updated to just point to homebrew website for installation instructions.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

