### PR TITLE
Fix waves 'double' to 'float' truncation warning

### DIFF
--- a/test/integration/waves.cc
+++ b/test/integration/waves.cc
@@ -167,11 +167,11 @@ TEST_F(WavesTest, Waves)
   (*vsParams)["dir0"].InitializeBuffer(2);
   (*vsParams)["dir0"].UpdateBuffer(dir0);
 
-  float dir1[2] = {-0.7, 0.7};
+  float dir1[2] = {-0.7f, 0.7f};
   (*vsParams)["dir1"].InitializeBuffer(2);
   (*vsParams)["dir1"].UpdateBuffer(dir1);
 
-  float dir2[2] = {0.7, 0.7};
+  float dir2[2] = {0.7f, 0.7f};
   (*vsParams)["dir2"].InitializeBuffer(2);
   (*vsParams)["dir2"].UpdateBuffer(dir2);
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #https://github.com/osrf/buildfarm-tools/issues/92#issuecomment-2353462714

## Summary
Reference builds:
* https://build.osrfoundation.org/job/gz_rendering-8-win/85/
* https://build.osrfoundation.org/job/gz_rendering-7-win/77/

Warning:
* Present in [waves.cc:171](https://github.com/gazebosim/gz-rendering/blob/ad30d4e0c2e3fcf845a6805bc64f15ede4383346/test/integration/waves.cc#L170)

Log output:
```
  waves.cc

C:\J\workspace\gz_rendering-7-win\ws\gz-rendering\test\integration\waves.cc(170,29): warning C4305: 'initializing': truncation from 'double' to 'float' [C:\J\workspace\gz_rendering-7-win\ws\build\gz-rendering7\test\integration\INTEGRATION_waves.vcxproj]

C:\J\workspace\gz_rendering-7-win\ws\gz-rendering\test\integration\waves.cc(174,28): warning C4305: 'initializing': truncation from 'double' to 'float' [C:\J\workspace\gz_rendering-7-win\ws\build\gz-rendering7\test\integration\INTEGRATION_waves.vcxproj]

  waves.obj : MSIL .netmodule or module compiled with /GL found; restarting link with /LTCG; add /LTCG to the link command line to improve linker performance
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
