### PR TITLE
Revert "Fix using lightmap and emissive map together (#1047)"

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -753,10 +753,14 @@ void Ogre2Material::SetLightMap(const std::string &_name,
   this->dataPtr->lightMapData = _img;
   this->lightMapUvSet = _uvSet;
 
-  // Apply lightmap by using the detail map slot to store the lightmap texture
-  // and blending it with the diffuse map.
-  Ogre::PbsTextureTypes type = Ogre::PBSM_DETAIL0;
-  this->ogreDatablock->setDetailMapBlendMode(0, Ogre::PBSM_BLEND_OVERLAY);
+  // in gz-rendering5 + ogre 2.1, we reserved detail map 0 for light map
+  // and set a blend mode (PBSM_BLEND_OVERLAY AND PBSM_BLEND_MULTIPLY2X
+  // produces better results) to blend with base albedo map. However, this
+  // creates unwanted red highlights with ogre 2.2. So switching to use the
+  // emissive map slot and calling setUseEmissiveAsLightmap(true)
+  // Ogre::PbsTextureTypes type = Ogre::PBSM_DETAIL0;
+  // this->ogreDatablock->setDetailMapBlendMode(0, Ogre::PBSM_BLEND_OVERLAY);
+  Ogre::PbsTextureTypes type = Ogre::PBSM_EMISSIVE;
 
   // lightmap usually uses a different tex coord set
   if (_img == nullptr)
@@ -764,6 +768,7 @@ void Ogre2Material::SetLightMap(const std::string &_name,
   else
     this->SetTextureMapDataImpl(this->lightMapName, _img, type);
   this->ogreDatablock->setTextureUvSource(type, this->lightMapUvSet);
+  this->ogreDatablock->setUseEmissiveAsLightmap(true);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
This reverts commit 6ec0c520f28a61b9505ada49d21adcf92e31b291.


# 🦟 Bug fix


## Summary

Reverts #1047 because it changed the appearance of visuals with lightmaps.

~~Marked as draft as we are waiting to see if we can find another workaround to make emissive maps work together with lightmaps.~~

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

