### PR TITLE
Update code for loading normal and albedo maps from image data

### DIFF
--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -1274,7 +1274,7 @@ void Ogre2Material::SetTextureMapDataImpl(const std::string& _name,
     // \todo(iche033) See if there is a way to reuse these functions
     // from ogre-next without copying the code here.
 
-    // Step 1: convert to two component signed 8 bit format:
+    // Normal maps - convert to two component signed 8 bit format:
     // Ogre::PFG_RG8_SNORM format
     if (_type == Ogre::PBSM_NORMAL)
       this->dataPtr->PrepareForNormalMapping(texture, img);


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
Currently when we load a normal map from an image data (e.g. from a glb file that has an embedded normal map texture), we upload the image data as RGBA8 with 1 mip map level. This is different from what ogre's texture manager does when it loads a normal map from file. To make the process consistent, we follow the same steps: convert to an RG signed 8 bit format then generate multiple levels of mip maps. I found that the mip map generation process made a difference to the final appearance. It helps to make the visual look smoother when viewed from a distance.

Before: The visuals appears to have some artifacts / noise, e.g more evident on the cushions behind the tables

<img width="500" alt="ionic_demo_normal_map_before" src="https://github.com/user-attachments/assets/01904588-688c-4a38-91c2-ba4d46ca8f2e">


After: visuals appear smoother

<img width="500" alt="ionic_demo_normal_map" src="https://github.com/user-attachments/assets/d7f28203-ff5f-4974-a801-b8b0f9884441">

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
