### PR TITLE
Add macOS instructions for render_order tutorial

### DIFF
--- a/tutorials/21_render_order.md
+++ b/tutorials/21_render_order.md
@@ -48,5 +48,9 @@ make
 Execute the example:
 
 ```{.sh}
+# Linux (defaults to using ogre1)
 ./simple_demo
+
+# macOS (ogre1 is not supported on macOS, but ogre2 is)
+./simple_demo ogre2
 ```


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/1483

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Running `simple_demo` as per tutorial on macOS with ogre1 as default render engine doesn't work. Added small comment on running with ogre2 for macOS.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
