### PR TITLE
Fix running rendering tests if GZ_ENABLE_RELOCATABLE_INSTALL is ON

### DIFF
--- a/test/gz_rendering_test.cmake
+++ b/test/gz_rendering_test.cmake
@@ -81,6 +81,11 @@ macro(gz_configure_rendering_test)
       APPEND PROPERTY
         ENVIRONMENT "GZ_ENGINE_BACKEND=${gz_configure_rendering_test_RENDER_ENGINE_BACKEND}")
 
+  set_property(
+      TEST ${test_name}
+      APPEND PROPERTY
+        ENVIRONMENT "GZ_RENDERING_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
+
   if(gz_configure_rendering_test_HEADLESS)
     set_property(
         TEST ${test_name}


### PR DESCRIPTION
# 🦟 Bug fix

If `GZ_ENABLE_RELOCATABLE_INSTALL` is `ON`, for all tests the environment variable `GZ_RENDERING_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}` need to be defined, to make sure that even if the shared library in the build directory is used instead of the install prefix, the correctly installed engine plugins are loaded. As part of https://github.com/gazebosim/gz-rendering/pull/804 I modified some tests to set `GZ_RENDERING_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}`, but I forgot to do this modification in `gz_configure_rendering_test`, that is actually how most tests in gz-rendering are added.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
