### PR TITLE
Unload rendering plugin also on Windows

### DIFF
--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -563,14 +563,10 @@ bool RenderEngineManagerPrivate::UnloadEnginePlugin(
   std::string pluginName = it->second;
   this->enginePlugins.erase(it);
 
-#ifndef _WIN32
-  // Unloading the plugin on windows causes tests to crash on exit
-  // see issue #45
   if (!this->pluginLoader.ForgetLibraryOfPlugin(pluginName))
   {
     gzerr << "Failed to unload plugin: " << pluginName << std::endl;
   }
-#endif
 
   std::lock_guard<std::recursive_mutex> lock(this->enginesMutex);
   auto engineIt = this->engines.find(_engineName);


### PR DESCRIPTION
# 🦟 Bug fix

I am trying to run the Windows test suite on windows with conda-forge dependencies, and the only failures are:

~~~
The following tests FAILED:
         25 - INTEGRATION_gpu_rays_ogre2_gl3plus (Failed)
         35 - INTEGRATION_mesh_ogre_gl3plus (Failed)
         65 - INTEGRATION_thermal_camera_ogre2_gl3plus (Failed)
            - RenderingIface_TEST_ogre2_gl3plus (Failed)
~~~

The `RenderingIface_TEST_ogre2_gl3plus` is fixed by removing this old workaround. I opened this to understand if this breaks something.

## Summary

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
