### PR TITLE
Check for zero quaternion value in MoveToHelper

### DIFF
--- a/src/MoveToHelper.cc
+++ b/src/MoveToHelper.cc
@@ -74,7 +74,7 @@ void MoveToHelper::MoveTo(const CameraPtr &_camera,
   else
     key->Translation(start.Pos());
 
-  if (_target.Rot().IsFinite())
+  if (_target.Rot().IsFinite() && _target.Rot() != math::Quaterniond::Zero)
     key->Rotation(_target.Rot());
   else
     key->Rotation(start.Rot());


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-gui/issues/615

## Summary

Fixes crash due to zero quaternion.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
