### PR TITLE
Fix Windows github action workflow

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -39,10 +39,10 @@ jobs:
 
     - name: Build Dependencies
       run: |
-        pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF  --event-handlers console_direct+ --packages-up-to ${env:PACKAGE}
+        pixi run colcon build --merge-install --cmake-args " -GVisual Studio 17 2022" " -A x64" " -DCMAKE_BUILD_TYPE=Release" " -DBUILD_TESTING=OFF" --event-handlers console_direct+ --packages-up-to ${env:PACKAGE}
 
     - name: Build Package
-      run: pixi run colcon build --merge-install --cmake-args -G"Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DSKIP_ogre=ON --event-handlers console_direct+ --packages-select ${env:PACKAGE}
+      run: pixi run colcon build --merge-install --cmake-args " -GVisual Studio 17 2022" " -A x64" " -DCMAKE_BUILD_TYPE=Release" " -DBUILD_TESTING=ON" " -DSKIP_ogre=ON" --event-handlers console_direct+ --packages-select ${env:PACKAGE}
 
     - name: Test
       run: pixi run colcon test --merge-install --event-handlers console_direct+ --packages-select ${env:PACKAGE}

--- a/README.md
+++ b/README.md
@@ -95,5 +95,3 @@ This library uses [Semantic Versioning](https://semver.org/). Additionally, this
 # License
 
 This library is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). See also the [LICENSE](https://github.com/gazebosim/gz-rendering/blob/main/LICENSE) file.
-
-test

--- a/README.md
+++ b/README.md
@@ -95,3 +95,5 @@ This library uses [Semantic Versioning](https://semver.org/). Additionally, this
 # License
 
 This library is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0). See also the [LICENSE](https://github.com/gazebosim/gz-rendering/blob/main/LICENSE) file.
+
+test


### PR DESCRIPTION
# 🦟 Bug fix


Fix windows github actions workflow. It started failing recently on `gz-rendering9 `and `main`, with the error:

```
usage: colcon [-h] [--log-base LOG_BASE] [--log-level LOG_LEVEL]
              {build,extension-points,extensions,graph,info,list,metadata,test,test-result,version-check}
              ...
colcon: error: unrecognized arguments: -A x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
```

Not sure what has changed but the fixed by putting double quotes around each cmake arg passed to `colcon build`

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
