### PR TITLE
Check valid camera near far clip distances

### DIFF
--- a/include/gz/rendering/base/BaseCamera.hh
+++ b/include/gz/rendering/base/BaseCamera.hh
@@ -17,6 +17,7 @@
 #ifndef GZ_RENDERING_BASE_BASECAMERA_HH_
 #define GZ_RENDERING_BASE_BASECAMERA_HH_
 
+#include <cmath>
 #include <string>
 
 #include <gz/math/Matrix3.hh>
@@ -709,6 +710,12 @@ namespace gz
     template <class T>
     void BaseCamera<T>::SetFarClipPlane(const double _far)
     {
+      if (_far <= 0 || !std::isfinite(_far))
+      {
+        gzerr << "Far clip distance must be a finite number greater than 0."
+              << std::endl;
+        return;
+      }
       this->farClip = _far;
     }
 
@@ -723,6 +730,12 @@ namespace gz
     template <class T>
     void BaseCamera<T>::SetNearClipPlane(const double _near)
     {
+      if (_near <= 0 || !std::isfinite(_near))
+      {
+        gzerr << "Near clip distance must be a finite number greater than 0."
+              << std::endl;
+        return;
+      }
       this->nearClip = _near;
     }
 

--- a/ogre/src/OgreCamera.cc
+++ b/ogre/src/OgreCamera.cc
@@ -340,14 +340,14 @@ void OgreCamera::SetNearClipPlane(const double _near)
 {
   // this->nearClip = _near;
   BaseCamera::SetNearClipPlane(_near);
-  this->ogreCamera->setNearClipDistance(_near);
+  this->ogreCamera->setNearClipDistance(this->nearClip);
 }
 
 //////////////////////////////////////////////////
 void OgreCamera::SetFarClipPlane(const double _far)
 {
   BaseCamera::SetFarClipPlane(_far);
-  this->ogreCamera->setFarClipDistance(_far);
+  this->ogreCamera->setFarClipDistance(this->farClip);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2Camera.cc
+++ b/ogre2/src/Ogre2Camera.cc
@@ -403,14 +403,14 @@ void Ogre2Camera::SetProjectionType(CameraProjectionType _type)
 void Ogre2Camera::SetNearClipPlane(const double _near)
 {
   BaseCamera::SetNearClipPlane(_near);
-  this->ogreCamera->setNearClipDistance(_near);
+  this->ogreCamera->setNearClipDistance(this->nearClip);
 }
 
 //////////////////////////////////////////////////
 void Ogre2Camera::SetFarClipPlane(const double _far)
 {
   BaseCamera::SetFarClipPlane(_far);
-  this->ogreCamera->setFarClipDistance(_far);
+  this->ogreCamera->setFarClipDistance(this->farClip);
 }
 
 //////////////////////////////////////////////////

--- a/test/common_test/Camera_TEST.cc
+++ b/test/common_test/Camera_TEST.cc
@@ -61,8 +61,16 @@ TEST_F(CameraTest, ViewProjectionMatrix)
   camera->SetNearClipPlane(0.1);
   EXPECT_DOUBLE_EQ(0.1, camera->NearClipPlane());
 
+  // set invalid clip distance and verify it is not set
+  camera->SetNearClipPlane(0.0);
+  EXPECT_DOUBLE_EQ(0.1, camera->NearClipPlane());
+
   EXPECT_GT(camera->FarClipPlane(), 0);
   camera->SetFarClipPlane(800);
+  EXPECT_DOUBLE_EQ(800, camera->FarClipPlane());
+
+  // set invalid clip distance and verify it is not set
+  camera->SetFarClipPlane(-10.0);
   EXPECT_DOUBLE_EQ(800, camera->FarClipPlane());
 
   EXPECT_NE(projMatrix, camera->ProjectionMatrix());


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-sim/issues/2615

## Summary

Added checks for valid camera clip distances to prevent ogre from throwing an exception

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
