### PR TITLE
Do not create wirebox with empty AABB (ogre)

### DIFF
--- a/ogre/src/OgreWireBox.cc
+++ b/ogre/src/OgreWireBox.cc
@@ -84,6 +84,9 @@ void OgreWireBox::Create()
       this->scene->OgreSceneManager()->createManualObject(this->name);
   }
 
+  if (this->box == math::AxisAlignedBox())
+    return;
+
   this->dataPtr->manualObject->clear();
   this->dataPtr->manualObject->setCastShadows(false);
 
@@ -92,9 +95,6 @@ void OgreWireBox::Create()
       this->dataPtr->material->Name() : "Default/White";
   this->dataPtr->manualObject->begin(materialName,
       Ogre::RenderOperation::OT_LINE_LIST);
-
-  if (this->box == math::AxisAlignedBox())
-    return;
 
   gz::math::Vector3d max = this->box.Max();
   gz::math::Vector3d min = this->box.Min();
@@ -172,6 +172,10 @@ void OgreWireBox::SetMaterial(MaterialPtr _material, bool _unique)
 //////////////////////////////////////////////////
 void OgreWireBox::SetMaterialImpl(OgreMaterialPtr _material)
 {
+  if (!this->dataPtr->manualObject ||
+      this->dataPtr->manualObject->getNumSections() == 0u)
+    return;
+
   std::string materialName = _material->Name();
   Ogre::MaterialPtr ogreMaterial = _material->Material();
   this->dataPtr->manualObject->setMaterialName(0, materialName);

--- a/ogre/src/OgreWireBox.cc
+++ b/ogre/src/OgreWireBox.cc
@@ -93,6 +93,9 @@ void OgreWireBox::Create()
   this->dataPtr->manualObject->begin(materialName,
       Ogre::RenderOperation::OT_LINE_LIST);
 
+  if (this->box == math::AxisAlignedBox())
+    return;
+
   gz::math::Vector3d max = this->box.Max();
   gz::math::Vector3d min = this->box.Min();
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/1000

## Summary

Prevent creating a wirebox with empty AABB in ogre.

A `gz::math::AxisAlignedBox` initializes the bounds to `MAX_D` and `LOW_D` which results in an `inf` AABB in ogre as it uses floats for AABB instead of doubles. This then leads to a crash when ogre tries to render the scene.

See #1000 for a description on how to reproduce the crash with gz-sim. You can launch gazebo with ogre render engine by running:

```
gz sim -v 4 shapes.sdf  --render-engine ogre
```

Expand the `sun` item in the `Entity Tree` and click on `sunVisual` to see the crash.

The changes in this PR only prevent the crash - it does not actually display the wirebox for the light visual, which is the same as the original behavior.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
