### PR TITLE
Fix test_config.h to include real engines found (gz-rendering6)

### DIFF
--- a/test/test_config.h.in
+++ b/test/test_config.h.in
@@ -15,7 +15,7 @@
 
 /// \todo(anyone) re-enable ogre2 test once ogre 2.2 works on macOS
 #ifdef __APPLE__
-static const std::vector<const char *> kRenderEngineTestValues{"ogre", "optix"};
+static const std::vector<const char *> kRenderEngineTestValues{"ogre"};
 #else
   /// We can not mix ogre and ogre2 tests in Fortress for a single test file
   /// prefer here ogre2 over ogre.

--- a/test/test_config.h.in
+++ b/test/test_config.h.in
@@ -17,12 +17,14 @@
 #ifdef __APPLE__
 static const std::vector<const char *> kRenderEngineTestValues{"ogre", "optix"};
 #else
+  /// We can not mix ogre and ogre2 tests in Fortress for a single test file
+  /// prefer here ogre2 over ogre.
   #if defined(HAVE_OGRE) && defined(HAVE_OPTIX) && defined(HAVE_OGRE2)
-  static const std::vector<const char *> kRenderEngineTestValues{"ogre", "ogre2", "optix"};
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre2", "optix"};
   #elif defined(HAVE_OGRE) && defined(HAVE_OPTIX)
   static const std::vector<const char *> kRenderEngineTestValues{"ogre", "optix"};
   #elif defined(HAVE_OGRE) && defined(HAVE_OGRE2)
-  static const std::vector<const char *> kRenderEngineTestValues{"ogre", "ogre2"};
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre2"};
   #elif defined(HAVE_OGRE2) && defined(HAVE_OPTIX)
   static const std::vector<const char *> kRenderEngineTestValues{"ogre2", "optix"};
   #elif defined(HAVE_OGRE)

--- a/test/test_config.h.in
+++ b/test/test_config.h.in
@@ -9,15 +9,32 @@
 #define RENDER_ENGINE_VALUES ::testing::ValuesIn(\
     gz::rendering::TestValues())
 
+#include <vector>
+#include <gz/common/Util.hh>
+#include <gz/rendering/config.hh>
+
 /// \todo(anyone) re-enable ogre2 test once ogre 2.2 works on macOS
 #ifdef __APPLE__
 static const std::vector<const char *> kRenderEngineTestValues{"ogre", "optix"};
 #else
-static const std::vector<const char *> kRenderEngineTestValues{"ogre2", "optix"};
+  #if defined(HAVE_OGRE) && defined(HAVE_OPTIX) && defined(HAVE_OGRE2)
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre", "ogre2", "optix"};
+  #elif defined(HAVE_OGRE) && defined(HAVE_OPTIX)
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre", "optix"};
+  #elif defined(HAVE_OGRE) && defined(HAVE_OGRE2)
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre", "ogre2"};
+  #elif defined(HAVE_OGRE2) && defined(HAVE_OPTIX)
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre2", "optix"};
+  #elif defined(HAVE_OGRE)
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre"};
+  #elif defined(HAVE_OGRE2)
+  static const std::vector<const char *> kRenderEngineTestValues{"ogre2"};
+  #elif defined(HAVE_OPTIX)
+  static const std::vector<const char *> kRenderEngineTestValues{"optix"};
+  #else
+  #warning "Can not detect a rendering engine support: ogre | ogre2 | optix"
+  #endif
 #endif
-
-#include <vector>
-#include <gz/common/Util.hh>
 
 namespace ignition
 {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

Instead of hardcoding them by architecture, create the right list of engines from the support found by CMake.

This change will enable ogre1 tests for Windows currently disabled.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.