### PR TITLE
Fail test if no scene can be created (gz-rendering6)

### DIFF
--- a/src/ArrowVisual_TEST.cc
+++ b/src/ArrowVisual_TEST.cc
@@ -52,9 +52,8 @@ void ArrowVisualTest::ArrowVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
-           << "' is not supported" << std::endl;
-    return;
+    FAIL() << "Engine '" << _renderEngine
+      << "' is not supported" << std::endl;
   }
 
   ScenePtr scene = engine->CreateScene("scene");

--- a/src/AxisVisual_TEST.cc
+++ b/src/AxisVisual_TEST.cc
@@ -52,7 +52,7 @@ void AxisVisualTest::AxisVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/BoundingBoxCamera_TEST.cc
+++ b/src/BoundingBoxCamera_TEST.cc
@@ -42,7 +42,7 @@ void BoundingBoxCameraTest::BoundingBoxCamera(const std::string &_renderEngine)
   if (_renderEngine.compare("optix") == 0 ||
       _renderEngine.compare("ogre") == 0)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' doesn't support bounding box cameras" << std::endl;
     return;
   }
@@ -51,7 +51,7 @@ void BoundingBoxCameraTest::BoundingBoxCamera(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/COMVisual_TEST.cc
+++ b/src/COMVisual_TEST.cc
@@ -43,7 +43,7 @@ void COMVisualTest::COMVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Camera_TEST.cc
+++ b/src/Camera_TEST.cc
@@ -64,7 +64,7 @@ void CameraTest::ViewProjectionMatrix(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -171,7 +171,7 @@ void CameraTest::RenderTexture(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -229,7 +229,7 @@ void CameraTest::TrackFollow(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -305,7 +305,7 @@ void CameraTest::AddRemoveRenderPass(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -363,7 +363,7 @@ void CameraTest::VisibilityMask(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -400,7 +400,7 @@ void CameraTest::IntrinsicMatrix(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Capsule_TEST.cc
+++ b/src/Capsule_TEST.cc
@@ -53,7 +53,7 @@ void CapsuleTest::Capsule(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/GaussianNoisePass_TEST.cc
+++ b/src/GaussianNoisePass_TEST.cc
@@ -43,7 +43,7 @@ void GaussianNoisePassTest::GaussianNoise(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/GizmoVisual_TEST.cc
+++ b/src/GizmoVisual_TEST.cc
@@ -46,7 +46,7 @@ void GizmoVisualTest::GizmoVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -117,7 +117,7 @@ void GizmoVisualTest::Material(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Grid_TEST.cc
+++ b/src/Grid_TEST.cc
@@ -51,7 +51,7 @@ void GridTest::Grid(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/Heightmap_TEST.cc
+++ b/src/Heightmap_TEST.cc
@@ -54,7 +54,7 @@ TEST_P(HeightmapTest, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(Heightmap))
   auto engine = rendering::engine(renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << renderEngine
+    FAIL() << "Engine '" << renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/InertiaVisual_TEST.cc
+++ b/src/InertiaVisual_TEST.cc
@@ -43,7 +43,7 @@ void InertiaVisualTest::InertiaVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/JointVisual_TEST.cc
+++ b/src/JointVisual_TEST.cc
@@ -47,7 +47,7 @@ void JointVisualTest::JointVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/LidarVisual_TEST.cc
+++ b/src/LidarVisual_TEST.cc
@@ -52,7 +52,7 @@ void LidarVisualTest::LidarVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/LightVisual_TEST.cc
+++ b/src/LightVisual_TEST.cc
@@ -47,7 +47,7 @@ void LightVisualTest::LightVisual(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Light_TEST.cc
+++ b/src/Light_TEST.cc
@@ -47,7 +47,7 @@ void LightTest::Light(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/LoadOgre2_TEST.cc
+++ b/src/LoadOgre2_TEST.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <gz/common/Console.hh>
+
+#include "test_config.h"  // NOLINT(build/include)
+
+#include "gz/rendering/RenderingIface.hh"
+#include "gz/rendering/RenderEngine.hh"
+
+using namespace gz;
+using namespace rendering;
+
+TEST(LoadOgre2Test, LoadOgre2)
+{
+  // Get engine
+  auto engine = rendering::engine("ogre2");
+  ASSERT_NE(nullptr, engine) << "Unable to load ogre2 render engine"
+                             << std::endl;
+
+  // Clean up
+  unloadEngine(engine->Name());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/LoadOgre_TEST.cc
+++ b/src/LoadOgre_TEST.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <gz/common/Console.hh>
+
+#include "test_config.h"  // NOLINT(build/include)
+
+#include "gz/rendering/RenderingIface.hh"
+#include "gz/rendering/RenderEngine.hh"
+
+using namespace gz;
+using namespace rendering;
+
+TEST(LoadOgreTest, LoadOgre)
+{
+  // Get engine
+  auto engine = rendering::engine("ogre");
+  ASSERT_NE(nullptr, engine) << "Unable to load ogre render engine"
+                             << std::endl;
+
+  // Clean up
+  unloadEngine(engine->Name());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/Marker_TEST.cc
+++ b/src/Marker_TEST.cc
@@ -56,7 +56,7 @@ void MarkerTest::Marker(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }
@@ -200,7 +200,7 @@ void MarkerTest::Material(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/Material_TEST.cc
+++ b/src/Material_TEST.cc
@@ -63,7 +63,7 @@ void MaterialTest::MaterialProperties(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -301,7 +301,7 @@ void MaterialTest::Copy(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/MeshDescriptor_TEST.cc
+++ b/src/MeshDescriptor_TEST.cc
@@ -45,7 +45,7 @@ void MeshDescriptorTest::Descriptor(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Mesh_TEST.cc
+++ b/src/Mesh_TEST.cc
@@ -64,7 +64,7 @@ void MeshTest::MeshSubMesh(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -134,7 +134,7 @@ void MeshTest::MeshSkeleton(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -237,7 +237,7 @@ void MeshTest::MeshSkeletonAnimation(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -337,7 +337,7 @@ void MeshTest::MeshClone(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/MoveToHelper_TEST.cc
+++ b/src/MoveToHelper_TEST.cc
@@ -82,7 +82,7 @@ void MoveToHelperTest::MoveTo(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -48,7 +48,7 @@ void NodeTest::Pose(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/OrbitViewController_TEST.cc
+++ b/src/OrbitViewController_TEST.cc
@@ -53,7 +53,7 @@ void OrbitViewControllerTest::OrbitViewControl(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -102,7 +102,7 @@ void OrbitViewControllerTest::OrbitViewControlCameraConstructor(
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -142,7 +142,7 @@ void OrbitViewControllerTest::Control(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/OrthoViewController_TEST.cc
+++ b/src/OrthoViewController_TEST.cc
@@ -49,7 +49,7 @@ void OrthoViewControllerTest::OrthoViewControl(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -96,7 +96,7 @@ void OrthoViewControllerTest::Control(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/RayQuery_TEST.cc
+++ b/src/RayQuery_TEST.cc
@@ -55,7 +55,7 @@ void RayQueryTest::RayQuery(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/RenderEngine_TEST.cc
+++ b/src/RenderEngine_TEST.cc
@@ -41,7 +41,7 @@ void RenderEngineTest::RenderEngine(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/RenderPassSystem_TEST.cc
+++ b/src/RenderPassSystem_TEST.cc
@@ -43,7 +43,7 @@ void RenderPassSystemTest::RenderPassSystem(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/RenderTarget_TEST.cc
+++ b/src/RenderTarget_TEST.cc
@@ -56,7 +56,7 @@ void RenderTargetTest::RenderTexture(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -100,7 +100,7 @@ void RenderTargetTest::RenderWindow(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -153,7 +153,7 @@ void RenderTargetTest::AddRemoveRenderPass(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Scene_TEST.cc
+++ b/src/Scene_TEST.cc
@@ -77,7 +77,7 @@ void SceneTest::Scene(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }
@@ -146,7 +146,7 @@ void SceneTest::Nodes(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 
@@ -234,7 +234,7 @@ void SceneTest::RemoveNodes(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 
@@ -340,7 +340,7 @@ void SceneTest::DestroyNodes(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 
@@ -567,7 +567,7 @@ void SceneTest::NodeCycle(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 
@@ -637,7 +637,7 @@ void SceneTest::Materials(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 
@@ -771,7 +771,7 @@ void SceneTest::Time(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 
@@ -822,7 +822,7 @@ void SceneTest::BackgroundMaterial(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 
@@ -853,7 +853,7 @@ void SceneTest::Sky(const std::string &_renderEngine)
   auto engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine << "' is not supported" << std::endl;
+    FAIL() << "Engine '" << _renderEngine << "' is not supported" << std::endl;
     return;
   }
 

--- a/src/Text_TEST.cc
+++ b/src/Text_TEST.cc
@@ -50,7 +50,7 @@ void TextTest::Text(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/ThermalCamera_TEST.cc
+++ b/src/ThermalCamera_TEST.cc
@@ -46,7 +46,7 @@ void ThermalCameraTest::ThermalCamera(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/TransformController_TEST.cc
+++ b/src/TransformController_TEST.cc
@@ -56,7 +56,7 @@ void TransformControllerTest::TransformControl(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -147,7 +147,7 @@ void TransformControllerTest::WorldSpace(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -214,7 +214,7 @@ void TransformControllerTest::LocalSpace(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -332,7 +332,7 @@ void TransformControllerTest::Control2d(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/Utils_TEST.cc
+++ b/src/Utils_TEST.cc
@@ -47,7 +47,7 @@ void UtilTest::ClickToScene(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }

--- a/src/Visual_TEST.cc
+++ b/src/Visual_TEST.cc
@@ -73,7 +73,7 @@ void VisualTest::Material(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -162,7 +162,7 @@ void VisualTest::Children(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -235,7 +235,7 @@ void VisualTest::Scale(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -330,7 +330,7 @@ void VisualTest::UserData(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -433,7 +433,7 @@ void VisualTest::Geometry(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -512,7 +512,7 @@ void VisualTest::VisibilityFlags(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -583,7 +583,7 @@ void VisualTest::BoundingBox(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }
@@ -628,7 +628,7 @@ void VisualTest::Wireframe(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported\n";
     return;
   }
@@ -661,7 +661,7 @@ void VisualTest::Clone(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
               << "' is not supported" << std::endl;
     return;
   }

--- a/src/WireBox_TEST.cc
+++ b/src/WireBox_TEST.cc
@@ -51,7 +51,7 @@ void WireBoxTest::WireBox(const std::string &_renderEngine)
   RenderEngine *engine = rendering::engine(_renderEngine);
   if (!engine)
   {
-    igndbg << "Engine '" << _renderEngine
+    FAIL() << "Engine '" << _renderEngine
            << "' is not supported" << std::endl;
     return;
   }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Replace current print by a FAIL in Gtest to make the test that can not create an scene to fail. This should help to avoid false positives in testing.

Note that is going to make the current build of ign-rendering6 to fail many tests.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.