### PR TITLE
Port Windows fix for unregistering OgreGLWindows class in ogre 2.2

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -153,6 +153,10 @@ void Ogre2RenderEngine::Destroy()
     {
     }
     this->ogreRoot = nullptr;
+
+#ifdef _WIN32
+    UnregisterClassA("OgreGLWindow", nullptr);
+#endif
   }
 
   delete this->ogreLogManager;


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Unregister window class on Windows to allow repeated loading / unloading of ogre 2.2 (used by ign-rendering6) in the same process, i.e. our unit and integration tests. A similar patch (https://github.com/OGRECave/ogre-next/pull/327) was already submitted by @mjcarroll  to ogre-next for version 2.3 (used by gz-rendering7 onwards). Adding the change here for ign-rendering6 so we can run ogre2 tests on our new Windows conda CI.

Note that the `gz_rendering-pr-win` jenkins job in the checks below still uses the old vcpkg based builds so we'll still get many test failures. 

Here are the new conda test builds:

* before: 59 test failures - https://build.osrfoundation.org/view/conda/job/_test_gz_rendering-pr-cwin/68/
* after: 8 test failures - https://build.osrfoundation.org/view/conda/job/_test_gz_rendering-pr-cwin/71/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
