### PR TITLE
Extend wide angle cameras to support L8 and L16 image formats

### DIFF
--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -798,11 +798,11 @@ void OgreWideAngleCamera::PostRender()
   PixelFormat format = this->ImageFormat();
   unsigned int channelCount = PixelUtil::ChannelCount(format);
   unsigned int bytesPerChannel = PixelUtil::BytesPerChannel(format);
-
+  unsigned int bufferSize = len * channelCount * bytesPerChannel;
   if (!this->dataPtr->wideAngleImage)
-    this->dataPtr->wideAngleImage = new unsigned char[len * channelCount];
+    this->dataPtr->wideAngleImage = new unsigned char[bufferSize];
   if (!this->dataPtr->imageBuffer)
-    this->dataPtr->imageBuffer = new unsigned char[len * channelCount];
+    this->dataPtr->imageBuffer = new unsigned char[bufferSize];
 
   // get image data
   Ogre::RenderTarget *rt =
@@ -813,7 +813,7 @@ void OgreWideAngleCamera::PostRender()
 
   // fill image data
   memcpy(this->dataPtr->wideAngleImage, this->dataPtr->imageBuffer,
-      height*width*channelCount*bytesPerChannel);
+      bufferSize);
 
   this->dataPtr->newImageFrame(
       this->dataPtr->wideAngleImage, width, height, channelCount,

--- a/ogre2/src/Ogre2WideAngleCamera.cc
+++ b/ogre2/src/Ogre2WideAngleCamera.cc
@@ -161,7 +161,6 @@ class gz::rendering::Ogre2WideAngleCamera::Implementation
   /// changed
   public: bool backgroundMaterialDirty = false;
 
-
   /// \brief Destination image data - used if image format is not rgb
   ///  and needs to be converted to another format.
   public: std::unique_ptr<unsigned char []> dstImgData;


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/gz-sensors/issues/479

Related PR: https://github.com/gazebosim/gz-sensors/pull/494

## Summary

Added support for wide angle cameras to read image data back in L8 and L16 image formats for ogre and ogre2

## Test it

Updated `INTEGRATION_wide_angle_camera` test.

From your colcon's gz-rendering's build folder, you can run tests like this:

```
GZ_ENGINE_TO_TEST=ogre2  ./bin/INTEGRATION_wide_angle_camera
GZ_ENGINE_TO_TEST=ogre  ./bin/INTEGRATION_wide_angle_camera
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
