### PR TITLE
Update RenderingIface_TEST's RegisterEngine test to only load the specified engine

### DIFF
--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -302,6 +302,18 @@ void RenderEngineManager::UnregisterEngine(const std::string &_name)
   std::lock_guard<std::recursive_mutex> lock(this->dataPtr->enginesMutex);
   auto iter = this->dataPtr->engines.find(_name);
 
+  if (iter == this->dataPtr->engines.end())
+  {
+    // Check if the provided name is a name of a default engine, if so,
+    // translate the name to the shared library name
+    auto defaultIt = this->dataPtr->defaultEngines.find(_name);
+    if (defaultIt != this->dataPtr->defaultEngines.end())
+      iter = this->dataPtr->engines.find(defaultIt->second);
+
+    if (iter == this->dataPtr->engines.end())
+      gzerr << "No render-engine registered with name: " << _name << std::endl;
+  }
+
   if (iter != this->dataPtr->engines.end())
   {
     this->dataPtr->UnregisterEngine(iter);

--- a/test/common_test/RenderingIface_TEST.cc
+++ b/test/common_test/RenderingIface_TEST.cc
@@ -122,14 +122,19 @@ TEST(RenderingIfaceTest, RegisterEngine)
   if (count == 0)
     return;
 
-  // unregister existing engine by index
-  RenderEngine *eng = engine(0u);
+  RenderEngine *eng = nullptr;
+  std::string engineToTest = "";
+  if (gz::utils::env(kEngineToTestEnv, engineToTest))
+    eng = engine(engineToTest);
+  else
+    eng = engine(0u);
+
   ASSERT_NE(nullptr, eng);
   auto engineName = eng->Name();
   ASSERT_FALSE(engineName.empty());
 
   EXPECT_TRUE(hasEngine(engineName));
-  EXPECT_NO_THROW(unregisterEngine(0u));
+  EXPECT_NO_THROW(unregisterEngine(engineName));
   EXPECT_FALSE(hasEngine(engineName));
 
   // register engine back with a different name


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #1072

## Summary

The `RenderingIface_TEST` tried to load the `ogre` (ogre 1.x) plugin even when `GZ_ENGINE_TO_TEST` set to `ogre2`. This PR updates the test to ensure that the specified engine is used in the test. While doing this I found and fixed a bug when unregistering a default engine by name (e.g. `ogre2`).

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

