### PR TITLE
Frustum Visual ABI compatibility changes

### DIFF
--- a/examples/frustum_visual/CMakeLists.txt
+++ b/examples/frustum_visual/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 project(gz-rendering-frustum-visual)
-find_package(gz-rendering10 REQUIRED)
+find_package(gz-rendering9 REQUIRED)
 
 find_package(GLUT REQUIRED)
 include_directories(SYSTEM ${GLUT_INCLUDE_DIRS})

--- a/examples/frustum_visual/Main.cc
+++ b/examples/frustum_visual/Main.cc
@@ -92,7 +92,12 @@ NodePtr createMainNode(ScenePtr _scene)
   root->AddChild(box);
 
   // create frustum visual and attach to main node
-  FrustumVisualPtr frustumVisual = _scene->CreateFrustumVisual();
+  // \todo(iche033) Commented out for ABI compatibility. Uncomment in
+  // gz-rendering10.
+  // \todo(iche033) uncomment and use official API in gz-rendering10
+  // FrustumVisualPtr frustumVisual = scene->CreateFrustumVisual();
+  FrustumVisualPtr frustumVisual = std::dynamic_pointer_cast<FrustumVisual>(
+      _scene->Extension()->CreateExt("frustum_visual"));
   frustumVisual->SetNearClipPlane(1);
   frustumVisual->SetFarClipPlane(5);
   frustumVisual->SetHFOV(0.7);

--- a/include/gz/rendering/FrustumVisual.hh
+++ b/include/gz/rendering/FrustumVisual.hh
@@ -18,7 +18,6 @@
 #define GZ_RENDERING_FRUSTUMVISUAL_HH_
 
 #include <gz/math/Angle.hh>
-#include <gz/math/AxisAlignedBox.hh>
 #include <gz/math/Plane.hh>
 #include <gz/math/Pose3.hh>
 #include <gz/utils/ImplPtr.hh>
@@ -26,7 +25,6 @@
 #include "gz/rendering/Visual.hh"
 #include "gz/rendering/Object.hh"
 #include "gz/rendering/RenderTypes.hh"
-#include "gz/rendering/Marker.hh"
 
 namespace gz
 {

--- a/include/gz/rendering/Scene.hh
+++ b/include/gz/rendering/Scene.hh
@@ -1108,34 +1108,44 @@ namespace gz
       public: virtual LidarVisualPtr CreateLidarVisual(
                   unsigned int _id, const std::string &_name) = 0;
 
+      /// \cond PRIVATE
       /// \brief Create new frusum visual. A unique ID and name will
       /// automatically be assigned to the frustum visual.
       /// \return The created frustum visual
-      public: virtual FrustumVisualPtr CreateFrustumVisual() = 0;
+      /// \todo(iche033) Commented out for ABI compatibility. Uncomment in
+      /// gz-rendering10
+      /// public: virtual FrustumVisualPtr CreateFrustumVisual() = 0;
 
       /// \brief Create new frustum visual with the given ID. A unique name
       /// will automatically be assigned to the frustum visual. If the given
       /// ID is already in use, NULL will be returned.
       /// \param[in] _id ID of the new frustum visual
       /// \return The created frustum visual
-      public: virtual FrustumVisualPtr CreateFrustumVisual(
-                  unsigned int _id) = 0;
+      /// \todo(iche033) Commented out for ABI compatibility. Uncomment in
+      /// gz-rendering10
+      /// public: virtual FrustumVisualPtr CreateFrustumVisual(
+      ///             unsigned int _id) = 0;
 
       /// \brief Create new frustum visual with the given name. A unique ID
       /// will automatically be assigned to the frustum visual. If the given
       /// name is already in use, NULL will be returned.
       /// \param[in] _name Name of the new frustum visual
       /// \return The created frustum visual
-      public: virtual FrustumVisualPtr CreateFrustumVisual(
-                  const std::string &_name) = 0;
+      /// \todo(iche033) Commented out for ABI compatibility. Uncomment in
+      /// gz-rendering10
+      /// public: virtual FrustumVisualPtr CreateFrustumVisual(
+      ///             const std::string &_name) = 0;
 
       /// \brief Create new frustum visual with the given name. If either
       /// the given ID or name is already in use, NULL will be returned.
       /// \param[in] _id ID of the frustum visual.
       /// \param[in] _name Name of the new frustum visual.
       /// \return The created frustum visual
-      public: virtual FrustumVisualPtr CreateFrustumVisual(
-                  unsigned int _id, const std::string &_name) = 0;
+      /// \todo(iche033) Commented out for ABI compatibility. Uncomment in
+      /// gz-rendering10
+      /// public: virtual FrustumVisualPtr CreateFrustumVisual(
+      ///             unsigned int _id, const std::string &_name) = 0;
+      /// \endcond
 
       /// \brief Create new heightmap geomerty. The rendering::Heightmap will be
       /// created from the given HeightmapDescriptor.

--- a/include/gz/rendering/base/BaseScene.hh
+++ b/include/gz/rendering/base/BaseScene.hh
@@ -538,19 +538,23 @@ namespace gz
                                             const std::string &_name) override;
 
       // Documentation inherited.
-      public: virtual FrustumVisualPtr CreateFrustumVisual() override;
+      // \todo(iche033) commented out for ABI compatibility
+      // public: virtual FrustumVisualPtr CreateFrustumVisual() override;
 
       // Documentation inherited.
-      public: virtual FrustumVisualPtr CreateFrustumVisual(
-                                            unsigned int _id) override;
+      // \todo(iche033) commented out for ABI compatibility
+      // public: virtual FrustumVisualPtr CreateFrustumVisual(
+      //                                     unsigned int _id) override;
 
       // Documentation inherited.
-      public: virtual FrustumVisualPtr CreateFrustumVisual(
-                                            const std::string &_name) override;
+      // \todo(iche033) commented out for ABI compatibility
+      // public: virtual FrustumVisualPtr CreateFrustumVisual(
+      //                                     const std::string &_name) override;
 
       // Documentation inherited.
-      public: virtual FrustumVisualPtr CreateFrustumVisual(unsigned int _id,
-                                            const std::string &_name) override;
+      // \todo(iche033) commented out for ABI compatibility
+      // public: virtual FrustumVisualPtr CreateFrustumVisual(unsigned int _id,
+      //                                     const std::string &_name) override;
 
       // Documentation inherited.
       public: virtual HeightmapPtr CreateHeightmap(
@@ -843,12 +847,23 @@ namespace gz
       protected: virtual LidarVisualPtr CreateLidarVisualImpl(unsigned int _id,
                      const std::string &_name) = 0;
 
+      /// \cond PRIVATE
       /// \brief Implementation for creating a frustum visual
       /// \param[in] _id unique object id.
       /// \param[in] _name unique object name.
       /// \return Pointer to a frustum visual
-      protected: virtual FrustumVisualPtr CreateFrustumVisualImpl(
-                     unsigned int _id, const std::string &_name) = 0;
+      /// \todo(iche033) Commented out for ABI compatibility. Uncomment in
+      /// gz-rendering10
+      /// protected: virtual FrustumVisualPtr CreateFrustumVisualImpl(
+      ///                unsigned int _id, const std::string &_name)
+      ///            {
+      ///              (void)_id;
+      ///              (void)_name;
+      ///              gzerr << "FrustumVisual not supported by: "
+      ///                     << this->Engine()->Name() << std::endl;
+      ///              return FrustumVisualPtr();
+      ///            }
+      /// \endcond
 
       /// \brief Implementation for creating a heightmap geometry
       /// \param[in] _id Unique object id.

--- a/ogre/include/gz/rendering/ogre/OgreScene.hh
+++ b/ogre/include/gz/rendering/ogre/OgreScene.hh
@@ -181,8 +181,9 @@ namespace gz
                      const std::string &_name) override;
 
       // Documentation inherited
-      protected: virtual FrustumVisualPtr CreateFrustumVisualImpl(
-                     unsigned int _id, const std::string &_name) override;
+      // \todo(iche033) make this virtual in gz-rendering10
+      protected: FrustumVisualPtr CreateFrustumVisualImpl(
+                     unsigned int _id, const std::string &_name);
 
       // Documentation inherited
       protected: virtual WireBoxPtr CreateWireBoxImpl(unsigned int _id,

--- a/ogre/src/OgreScene.cc
+++ b/ogre/src/OgreScene.cc
@@ -781,7 +781,7 @@ OgreSceneExt::OgreSceneExt(Scene *_scene)
 ObjectPtr OgreSceneExt::CreateExt(const std::string &_type,
       const std::string &_name)
 {
-  if (_type == "projector")
+  if (_type == "frustum_visual")
   {
     OgreScene *ogreScene = dynamic_cast<OgreScene *>(this->scene);
     unsigned int objId = ogreScene->CreateObjectId();
@@ -789,14 +789,14 @@ ObjectPtr OgreSceneExt::CreateExt(const std::string &_type,
     if (objName.empty())
     {
       std::stringstream ss;
-      ss << ogreScene->Name() << "::" <<  "Projector";
+      ss << ogreScene->Name() << "::" <<  "FrustumVisual";
       ss << "(" << std::to_string(objId) << ")";
       objName = ss.str();
     }
-    ProjectorPtr projector = ogreScene->CreateProjectorImpl(
+    FrustumVisualPtr frustumVisual = ogreScene->CreateFrustumVisualImpl(
         objId, objName);
-    bool result = ogreScene->Visuals()->Add(projector);
-    return (result) ? projector : nullptr;
+    bool result = ogreScene->Visuals()->Add(frustumVisual);
+    return (result) ? frustumVisual : nullptr;
   }
 
   return ObjectPtr();

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -344,8 +344,9 @@ namespace gz
                      const std::string &_name) override;
 
       // Documentation inherited
-      protected: virtual FrustumVisualPtr CreateFrustumVisualImpl(
-                     unsigned int _id, const std::string &_name) override;
+      // \todo(iche033) make this virtual in gz-rendering10
+      protected: FrustumVisualPtr CreateFrustumVisualImpl(
+                     unsigned int _id, const std::string &_name);
 
       // Documentation inherited
       protected: virtual WireBoxPtr CreateWireBoxImpl(unsigned int _id,

--- a/ogre2/src/Ogre2FrustumVisual.cc
+++ b/ogre2/src/Ogre2FrustumVisual.cc
@@ -58,10 +58,6 @@ class gz::rendering::Ogre2FrustumVisualPrivate
   /// \brief Frustum Ray DynamicLines Object to display
   public: std::vector<std::shared_ptr<Ogre2DynamicRenderable>> rayLines;
 
-  /// \brief Frustum visual type
-  //  public: FrustumVisualPlane frustumVisPlane =
-  //    FrustumVisualPlane::FRUSTUM_PLANE_TOP;
-
   /// \brief The visibility of the visual
   public: bool visible = true;
 

--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -1694,7 +1694,7 @@ Ogre2SceneExt::Ogre2SceneExt(Scene *_scene)
 ObjectPtr Ogre2SceneExt::CreateExt(const std::string &_type,
     const std::string &_name)
 {
-  if (_type == "projector")
+  if (_type == "frustum_visual")
   {
     Ogre2Scene *ogreScene = dynamic_cast<Ogre2Scene *>(this->scene);
     unsigned int objId = ogreScene->CreateObjectId();
@@ -1702,14 +1702,14 @@ ObjectPtr Ogre2SceneExt::CreateExt(const std::string &_type,
     if (objName.empty())
     {
       std::stringstream ss;
-      ss << ogreScene->Name() << "::" <<  "Projector";
+      ss << ogreScene->Name() << "::" <<  "FrustumVisual";
       ss << "(" << std::to_string(objId) << ")";
       objName = ss.str();
     }
-    ProjectorPtr projector = ogreScene->CreateProjectorImpl(
+    FrustumVisualPtr frustumVisual = ogreScene->CreateFrustumVisualImpl(
         objId, objName);
-    bool result = ogreScene->Visuals()->Add(projector);
-    return (result) ? projector : nullptr;
+    bool result = ogreScene->Visuals()->Add(frustumVisual);
+    return (result) ? frustumVisual : nullptr;
   }
 
   return ObjectPtr();

--- a/src/base/BaseScene.cc
+++ b/src/base/BaseScene.cc
@@ -1263,35 +1263,37 @@ LidarVisualPtr BaseScene::CreateLidarVisual(unsigned int _id,
   return (result) ? lidar : nullptr;
 }
 
-//////////////////////////////////////////////////
-FrustumVisualPtr BaseScene::CreateFrustumVisual()
-{
-  unsigned int objId = this->CreateObjectId();
-  return this->CreateFrustumVisual(objId);
-}
-
-//////////////////////////////////////////////////
-FrustumVisualPtr BaseScene::CreateFrustumVisual(unsigned int _id)
-{
-  const std::string objName = this->CreateObjectName(_id, "FrustumVisual");
-  return this->CreateFrustumVisual(_id, objName);
-}
-
-//////////////////////////////////////////////////
-FrustumVisualPtr BaseScene::CreateFrustumVisual(const std::string &_name)
-{
-  unsigned int objId = this->CreateObjectId();
-  return this->CreateFrustumVisual(objId, _name);
-}
-
-//////////////////////////////////////////////////
-FrustumVisualPtr BaseScene::CreateFrustumVisual(unsigned int _id,
-                                            const std::string &_name)
-{
-  FrustumVisualPtr frustum = this->CreateFrustumVisualImpl(_id, _name);
-  bool result = this->RegisterVisual(frustum);
-  return (result) ? frustum : nullptr;
-}
+// \todo(iche033) Commented out for ABI compatibility. Uncomment in
+// gz-rendering10
+// //////////////////////////////////////////////////
+// FrustumVisualPtr BaseScene::CreateFrustumVisual()
+// {
+//   unsigned int objId = this->CreateObjectId();
+//   return this->CreateFrustumVisual(objId);
+// }
+//
+// //////////////////////////////////////////////////
+// FrustumVisualPtr BaseScene::CreateFrustumVisual(unsigned int _id)
+// {
+//   const std::string objName = this->CreateObjectName(_id, "FrustumVisual");
+//   return this->CreateFrustumVisual(_id, objName);
+// }
+//
+// //////////////////////////////////////////////////
+// FrustumVisualPtr BaseScene::CreateFrustumVisual(const std::string &_name)
+// {
+//   unsigned int objId = this->CreateObjectId();
+//   return this->CreateFrustumVisual(objId, _name);
+// }
+//
+// //////////////////////////////////////////////////
+// FrustumVisualPtr BaseScene::CreateFrustumVisual(unsigned int _id,
+//                                             const std::string &_name)
+// {
+//   FrustumVisualPtr frustum = this->CreateFrustumVisualImpl(_id, _name);
+//   bool result = this->RegisterVisual(frustum);
+//   return (result) ? frustum : nullptr;
+// }
 
 //////////////////////////////////////////////////
 WireBoxPtr BaseScene::CreateWireBox()

--- a/test/common_test/CMakeLists.txt
+++ b/test/common_test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
   Camera_TEST
   Capsule_TEST
   COMVisual_TEST
+  FrustumVisual_TEST
   GaussianNoisePass_TEST
   GizmoVisual_TEST
   GlobalIllumination_TEST

--- a/test/common_test/FrustumVisual_TEST.cc
+++ b/test/common_test/FrustumVisual_TEST.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "CommonRenderingTest.hh"
+
+#include "gz/rendering/FrustumVisual.hh"
+#include "gz/rendering/Scene.hh"
+
+using namespace gz;
+using namespace rendering;
+
+/// \brief The test fixture.
+class FrustumVisualTest : public CommonRenderingTest
+{
+};
+
+/////////////////////////////////////////////////
+TEST_F(FrustumVisualTest, FrustumVisual)
+{
+  CHECK_SUPPORTED_ENGINE("ogre2");
+
+  ScenePtr scene = engine->CreateScene("scene");
+  EXPECT_NE(nullptr, scene);
+
+  // FrustumVisual and can only be accessed by the scene extension API
+  // in gz-rendering9
+  // \todo(iche033) Remove this in gz-rendering10
+  if (!scene->Extension())
+    return;
+
+  // Create a frustum visual
+  // \todo(iche033) uncomment and use official API in gz-rendering10
+  // FrustumVisualPtr frustumVisual = scene->CreateFrustumVisual();
+  FrustumVisualPtr frustumVisual = std::dynamic_pointer_cast<FrustumVisual>(
+      scene->Extension()->CreateExt("frustum_visual"));
+
+  // Check default properties
+  EXPECT_DOUBLE_EQ(0, frustumVisual->NearClipPlane());
+  EXPECT_DOUBLE_EQ(1.0, frustumVisual->FarClipPlane());
+  EXPECT_EQ(math::Angle(GZ_DTOR(45)), frustumVisual->HFOV().Radian());
+  EXPECT_DOUBLE_EQ(1.0, frustumVisual->AspectRatio());
+  auto emptyPlane = math::Planed();
+  EXPECT_DOUBLE_EQ(emptyPlane.Offset(),
+                   frustumVisual->Plane(FRUSTUM_PLANE_NEAR).Offset());
+  EXPECT_EQ(emptyPlane.Normal(),
+            frustumVisual->Plane(FRUSTUM_PLANE_NEAR).Normal());
+  EXPECT_DOUBLE_EQ(emptyPlane.Offset(),
+                   frustumVisual->Plane(FRUSTUM_PLANE_FAR).Offset());
+  EXPECT_EQ(emptyPlane.Normal(),
+            frustumVisual->Plane(FRUSTUM_PLANE_FAR).Normal());
+  EXPECT_DOUBLE_EQ(emptyPlane.Offset(),
+                   frustumVisual->Plane(FRUSTUM_PLANE_LEFT).Offset());
+  EXPECT_EQ(emptyPlane.Normal(),
+            frustumVisual->Plane(FRUSTUM_PLANE_LEFT).Normal());
+  EXPECT_DOUBLE_EQ(emptyPlane.Offset(),
+                   frustumVisual->Plane(FRUSTUM_PLANE_RIGHT).Offset());
+  EXPECT_EQ(emptyPlane.Normal(),
+            frustumVisual->Plane(FRUSTUM_PLANE_RIGHT).Normal());
+  EXPECT_DOUBLE_EQ(emptyPlane.Offset(),
+                   frustumVisual->Plane(FRUSTUM_PLANE_TOP).Offset());
+  EXPECT_EQ(emptyPlane.Normal(),
+            frustumVisual->Plane(FRUSTUM_PLANE_TOP).Normal());
+  EXPECT_DOUBLE_EQ(emptyPlane.Offset(),
+                   frustumVisual->Plane(FRUSTUM_PLANE_BOTTOM).Offset());
+  EXPECT_EQ(emptyPlane.Normal(),
+            frustumVisual->Plane(FRUSTUM_PLANE_BOTTOM).Normal());
+
+  // Test APIs
+  double nearClip = 1.1;
+  double farClip = 15.5;
+  math::Angle hfov(1.06);
+  double aspect = 1.3333;
+
+  frustumVisual->SetNearClipPlane(nearClip);
+  EXPECT_DOUBLE_EQ(nearClip, frustumVisual->NearClipPlane());
+
+  frustumVisual->SetFarClipPlane(farClip);
+  EXPECT_DOUBLE_EQ(farClip, frustumVisual->FarClipPlane());
+
+  frustumVisual->SetHFOV(hfov);
+  EXPECT_EQ(hfov, frustumVisual->HFOV());
+
+  frustumVisual->SetAspectRatio(aspect);
+  EXPECT_EQ(aspect, frustumVisual->AspectRatio());
+
+  frustumVisual->Update();
+
+  EXPECT_DOUBLE_EQ(nearClip,
+      std::fabs(frustumVisual->Plane(FRUSTUM_PLANE_NEAR).Offset()));
+  EXPECT_EQ(math::Vector3d::UnitX,
+      frustumVisual->Plane(FRUSTUM_PLANE_NEAR).Normal());
+  EXPECT_DOUBLE_EQ(farClip,
+      std::fabs(frustumVisual->Plane(FRUSTUM_PLANE_FAR).Offset()));
+  EXPECT_EQ(-math::Vector3d::UnitX,
+      frustumVisual->Plane(FRUSTUM_PLANE_FAR).Normal());
+  EXPECT_NEAR(0.0, frustumVisual->Plane(FRUSTUM_PLANE_LEFT).Offset(), 1e-6);
+  EXPECT_GT(0.0, frustumVisual->Plane(FRUSTUM_PLANE_LEFT).Normal().Y());
+  EXPECT_NEAR(0.0, frustumVisual->Plane(FRUSTUM_PLANE_RIGHT).Offset(), 1e-6);
+  EXPECT_LT(0.0, frustumVisual->Plane(FRUSTUM_PLANE_RIGHT).Normal().Y());
+  EXPECT_NEAR(0.0, frustumVisual->Plane(FRUSTUM_PLANE_TOP).Offset(), 1e-6);
+  EXPECT_GT(0.0, frustumVisual->Plane(FRUSTUM_PLANE_TOP).Normal().Z());
+  EXPECT_NEAR(0.0, frustumVisual->Plane(FRUSTUM_PLANE_BOTTOM).Offset(), 1e-6);
+  EXPECT_LT(0.0, frustumVisual->Plane(FRUSTUM_PLANE_BOTTOM).Normal().Z());
+
+  engine->DestroyScene(scene);
+}


### PR DESCRIPTION


# 🎉 New feature

## Summary

Implement ABI compatibility changes for the Frustum Visual feature (#1095) so that it can be backported to gz-rendering9. The approach is similar to #845 which uses the `SceneExt` class for creating the visual frustum to prevent overriding virtual functions (which breaks ABI). The official functions for creating `FrustumVisual` classes are commented out (instead of being removed) to keep the diff with `main` minimal.

I also added a unit test for the FrustumVisual class.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

