### PR TITLE
Suppress dll-interface warnings (C4251) on windows 

### DIFF
--- a/ogre2/include/gz/rendering/ogre2/Ogre2DynamicRenderable.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2DynamicRenderable.hh
@@ -33,6 +33,13 @@
   #pragma warning(pop)
 #endif
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed hidden by default.
+  #pragma warning(disable:4251)
+#endif
+
 namespace Ogre
 {
   class MovableObject;
@@ -154,4 +161,9 @@ namespace gz
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 #endif

--- a/ogre2/include/gz/rendering/ogre2/Ogre2GaussianNoisePass.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2GaussianNoisePass.hh
@@ -23,6 +23,13 @@
 #include "gz/rendering/ogre2/Ogre2RenderPass.hh"
 #include "gz/rendering/ogre2/Export.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed hidden by default.
+  #pragma warning(disable:4251)
+#endif
+
 namespace gz
 {
   namespace rendering
@@ -57,4 +64,9 @@ namespace gz
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 #endif

--- a/ogre2/include/gz/rendering/ogre2/Ogre2GlobalIlluminationCiVct.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2GlobalIlluminationCiVct.hh
@@ -24,6 +24,13 @@
 
 #include <memory>
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed hidden by default.
+  #pragma warning(disable:4251)
+#endif
+
 namespace Ogre
 {
   class HlmsPbs;
@@ -230,4 +237,9 @@ namespace gz
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 #endif

--- a/ogre2/include/gz/rendering/ogre2/Ogre2GlobalIlluminationVct.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2GlobalIlluminationVct.hh
@@ -24,6 +24,13 @@
 
 #include <memory>
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed hidden by default.
+  #pragma warning(disable:4251)
+#endif
+
 namespace Ogre
 {
   class HlmsPbs;
@@ -148,4 +155,9 @@ namespace gz
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 #endif

--- a/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2LensFlarePass.hh
@@ -27,6 +27,13 @@
 #include "gz/rendering/ogre2/Export.hh"
 #include "gz/rendering/ogre2/Ogre2RenderPass.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed hidden by default.
+  #pragma warning(disable:4251)
+#endif
+
 namespace gz
 {
   namespace rendering
@@ -101,4 +108,9 @@ namespace gz
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 #endif

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Object.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Object.hh
@@ -22,6 +22,13 @@
 #include "gz/rendering/ogre2/Ogre2RenderTypes.hh"
 #include "gz/rendering/ogre2/Export.hh"
 
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed hidden by default.
+  #pragma warning(disable:4251)
+#endif
+
 namespace gz
 {
   namespace rendering
@@ -50,4 +57,9 @@ namespace gz
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 #endif

--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderPass.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderPass.hh
@@ -24,6 +24,14 @@
 #include "gz/rendering/ogre2/Export.hh"
 #include "gz/rendering/ogre2/Ogre2Object.hh"
 
+
+#ifdef _MSC_VER
+  #pragma warning(push)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed to hidden by default.
+  #pragma warning(disable:4251)
+#endif
+
 namespace Ogre
 {
   class CompositorWorkspace;
@@ -92,4 +100,9 @@ namespace gz
     }
   }
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
 #endif

--- a/ogre2/include/gz/rendering/ogre2/Ogre2RenderTargetMaterial.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2RenderTargetMaterial.hh
@@ -35,6 +35,9 @@
   #pragma warning(push)
   // Silence deriving from Ogre::RenderTargetListener dll-linkage warnings
   #pragma warning(disable:4275)
+  // Suppress dll-interface warning. This should no longer be needed in
+  // gz-rendering9 as visibility changed hidden by default.
+  #pragma warning(disable:4251)
 #endif
 
 namespace gz


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/1106

## Summary

Suppress [C4251](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=msvc-170#example) warnings on windows.  

Example warning msgs:
```
'gz::rendering::v8::Ogre2DynamicRenderable::dataPtr': class 'std::unique_ptr>' needs to have dll-interface to be used by clients of class 'gz::rendering::v8::Ogre2DynamicRenderable'
```

The warnings are emitted when there are STL typed objects declared in header classes. The reason for this warning is explained [here](https://stackoverflow.com/a/4563701), specifically:

> ...emitted when you use a non-dllexported class X in a dllexported class Y 

This is no longer an issue in [gz-rendering9 windows builds](https://build.osrfoundation.org/job/gz_rendering-9-clowin/) as I believe that's because visibility [changed](https://github.com/gazebosim/gz-cmake/blob/be88616b9cb20b688be85921fcb854d3b0da2940/Migration.md?plain=1#L12) to hidden by default. So suppressing the warnings in gz-rendering8 / harmonic.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
