### PR TITLE
Remove ClearMaterialsCache call when a material is destroyed in ogre2

### DIFF
--- a/ogre2/include/gz/rendering/ogre2/Ogre2MeshFactory.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2MeshFactory.hh
@@ -95,6 +95,7 @@ namespace gz
       protected: Ogre2ScenePtr scene;
 
       /// \brief Remove internal material cache for a specific material
+      /// \todo(iche033) Deprecate this function in gz-rendering10
       public: void ClearMaterialsCache(const std::string &_name);
 
       /// \brief Pointer to private data class

--- a/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
+++ b/ogre2/include/gz/rendering/ogre2/Ogre2Scene.hh
@@ -457,6 +457,7 @@ namespace gz
 
       /// \brief Remove internal material cache for a specific material
       /// \param[in] _name Name of the template material to remove.
+      /// \todo(iche033) Deprecate this function in gz-rendering10
       public: void ClearMaterialsCache(const std::string &_name);
 
       /// \brief Create a shared pointer to self

--- a/ogre2/src/Ogre2Material.cc
+++ b/ogre2/src/Ogre2Material.cc
@@ -277,8 +277,6 @@ void Ogre2Material::Destroy()
 
   if (textureToRemove && !textureIsUse)
   {
-    Ogre2ScenePtr s = std::dynamic_pointer_cast<Ogre2Scene>(this->Scene());
-    s->ClearMaterialsCache(this->textureName);
     this->Scene()->UnregisterMaterial(this->name);
     textureManager->destroyTexture(textureToRemove);
   }

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -57,13 +57,6 @@
 /// \brief Private data for the Ogre2MeshFactory class
 class gz::rendering::Ogre2MeshFactoryPrivate
 {
-  /// \brief Vector with the template materials, we keep the pointer to be
-  /// able to remove it when nobody is using it.
-  /// \todo(iche033) We should no longer need to store the material in a cache
-  /// removal. Ogre2Material::Destroy function checks if materials/ textures
-  /// are in use and will remove internal ogre objects there.
-  /// Remove this variable once ClearMaterialsCache function is removed.
-  public: std::vector<MaterialPtr> materialCache;
 };
 
 /// \brief Private data for the Ogre2SubMeshStoreFactory class
@@ -95,22 +88,9 @@ void Ogre2MeshFactory::Clear()
 }
 
 //////////////////////////////////////////////////
-void Ogre2MeshFactory::ClearMaterialsCache(const std::string &_name)
+void Ogre2MeshFactory::ClearMaterialsCache(const std::string &)
 {
-  auto it = this->dataPtr->materialCache.begin();
-  for (auto &mat : this->dataPtr->materialCache)
-  {
-    std::string matName = mat->Name();
-    std::string textureName = mat->Texture();
-    if (textureName == _name)
-    {
-      this->scene->UnregisterMaterial(matName);
-      break;
-    }
-    ++it;
-  }
-  if (it != this->dataPtr->materialCache.end())
-    this->dataPtr->materialCache.erase(it);
+  // no-op
 }
 
 //////////////////////////////////////////////////
@@ -505,7 +485,6 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
       if (material)
       {
         mat->CopyFrom(*material);
-        this->dataPtr->materialCache.push_back(mat);
       }
       else
       {

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -59,6 +59,10 @@ class gz::rendering::Ogre2MeshFactoryPrivate
 {
   /// \brief Vector with the template materials, we keep the pointer to be
   /// able to remove it when nobody is using it.
+  /// \todo(iche033) We should no longer need to store the material in a cache
+  /// removal. Ogre2Material::Destroy function checks if materials/ textures
+  /// are in use and will remove internal ogre objects there.
+  /// Remove this variable once ClearMaterialsCache function is removed.
   public: std::vector<MaterialPtr> materialCache;
 };
 


### PR DESCRIPTION


# 🦟 Bug fix

## Summary

The material cache in `Ogre2MeshFactory` was introduced in #324 to clear material objects when a mesh is removed. Looking at the current state, this call should no longer be needed as we now have logic in `Ogre2Material::Destroy` function to destroy ogre internal material / texture objects (and also unregistering gz-rendering material objects) when they [are not in use](https://github.com/gazebosim/gz-rendering/blob/a48f757d9448e05bdc3e6e73c61ddf4869febac6/ogre2/src/Ogre2Material.cc#L254-L268). So this PR removes the material cache and the the call to `ClearMaterialCache` function.

Note that we ran into an issue with the `ClearMaterialsCache` function. It clears materials by the name of the texture it contains. However, it's possible for multiple materials to use the same texture, and the current logic may incorrectly destroy the wrong material. Removing the call to `ClearMaterialsCache` resolves that issue.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

