### PR TITLE
Add sanity check for valid submesh indices

### DIFF
--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -231,6 +231,26 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
         continue;
       }
 
+      // todo(iche033) use SubMesh::HasValidIndices() when gz-common 6.0.3
+      // is released
+      bool validIndices = true;
+      for (unsigned int j = 0u; j < s->IndexCount(); ++j)
+      {
+        int index = s->Index(j);
+        if (index > 0 && static_cast<unsigned int>(index) >= s->VertexCount())
+        {
+          validIndices = false;
+          break;
+        }
+      }
+      if (!validIndices)
+      {
+        gzwarn << "Mesh[" << _desc.mesh->Name() << "] submesh[" << s->Name()
+               << "] has invalid indices. Skipping submesh creation."
+               << std::endl;
+        continue;
+      }
+
       Ogre::SubMesh *ogreSubMesh;
       Ogre::VertexData *vertexData;
       Ogre::VertexDeclaration* vertexDecl;

--- a/ogre2/src/Ogre2MeshFactory.cc
+++ b/ogre2/src/Ogre2MeshFactory.cc
@@ -286,6 +286,26 @@ bool Ogre2MeshFactory::LoadImpl(const MeshDescriptor &_desc)
         continue;
       }
 
+      // todo(iche033) use SubMesh::HasValidIndices() when gz-common 6.0.3
+      // is released
+      bool validIndices = true;
+      for (unsigned int j = 0u; j < s->IndexCount(); ++j)
+      {
+        int index = s->Index(j);
+        if (index > 0 && static_cast<unsigned int>(index) >= s->VertexCount())
+        {
+          validIndices = false;
+          break;
+        }
+      }
+      if (!validIndices)
+      {
+        gzwarn << "Mesh[" << _desc.mesh->Name() << "] submesh[" << s->Name()
+               << "] has invalid indices. Skipping submesh creation."
+               << std::endl;
+        continue;
+      }
+
       Ogre::v1::SubMesh *ogreSubMesh;
       Ogre::v1::VertexData *vertexData;
       Ogre::v1::VertexDeclaration* vertexDecl;


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

Check that a submesh has valid indices before passing them to the render engines.

This does pretty much the same check as the new function added in `common::SubMesh` in https://github.com/gazebosim/gz-common/pull/667. We can switch to use that function when a new gz-common release is made.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

