### PR TITLE
Change to std::get_if for gz::rendering::Variant for throwless behaviour

### DIFF
--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -218,29 +218,23 @@ Ogre::Technique *OgreThermalCameraMaterialSwitcher::handleSchemeNotFound(
   Variant tempAny = ogreVisual->UserData(tempKey);
   if (tempAny.index() != 0)
   {
-    float temp = -1;
-    try
+    float temp = -1.0f;
+    if (const float* tempPtr = std::get_if<float>(&tempAny))
     {
-      temp = std::get<float>(tempAny);
+      temp = *tempPtr;
     }
-    catch(...)
+    else if (const double* tempPtr = std::get_if<double>(&tempAny))
     {
-      try
-      {
-        temp = static_cast<float>(std::get<double>(tempAny));
-      }
-      catch(...)
-      {
-        try
-        {
-          temp = static_cast<float>(std::get<int>(tempAny));
-        }
-        catch(std::bad_variant_access &e)
-        {
-          gzerr << "Error casting user data: " << e.what() << "\n";
-          temp = -1.0;
-        }
-      }
+      temp = static_cast<float>(*tempPtr);
+    }
+    else if (const int* tempPtr = std::get_if<int>(&tempAny))
+    {
+      temp = static_cast<float>(*tempPtr);
+    }
+    else
+    {
+      gzerr << "Error casting user data: variant containers unexpected type\n";
+      temp = -1.0;
     }
 
     // only accept positive temperature (in kelvin)

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -24,6 +24,7 @@
 #endif
 
 #include <limits>
+#include <variant>
 
 #include <gz/math/Helpers.hh>
 #include "gz/rendering/ShaderParams.hh"

--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -219,17 +219,17 @@ Ogre::Technique *OgreThermalCameraMaterialSwitcher::handleSchemeNotFound(
   if (tempAny.index() != 0)
   {
     float temp = -1.0f;
-    if (const float* tempPtr = std::get_if<float>(&tempAny))
+    if (const float* floatPtr = std::get_if<float>(&tempAny))
     {
-      temp = *tempPtr;
+      temp = *floatPtr;
     }
-    else if (const double* tempPtr = std::get_if<double>(&tempAny))
+    else if (const double* doublePtr = std::get_if<double>(&tempAny))
     {
-      temp = static_cast<float>(*tempPtr);
+      temp = static_cast<float>(*doublePtr);
     }
-    else if (const int* tempPtr = std::get_if<int>(&tempAny))
+    else if (const int* intPtr = std::get_if<int>(&tempAny))
     {
-      temp = static_cast<float>(*tempPtr);
+      temp = static_cast<float>(*intPtr);
     }
     else
     {

--- a/ogre2/src/Ogre2BoundingBoxMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2BoundingBoxMaterialSwitcher.cc
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
 */
+
+#include <variant>
+
 #include "Ogre2BoundingBoxMaterialSwitcher.hh"
 
 #include "gz/rendering/ogre2/Ogre2Scene.hh"
@@ -118,7 +121,8 @@ void Ogre2BoundingBoxMaterialSwitcher::cameraPreRenderScene(
       // set default label to background
       int label = this->backgroundLabel;
       // if not background, then modify to label
-      if (const int* labelPtr = std::get_if<int>(&labelAny)){
+      if (const int* labelPtr = std::get_if<int>(&labelAny))
+      {
         label = *labelPtr;
       }
 

--- a/ogre2/src/Ogre2BoundingBoxMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2BoundingBoxMaterialSwitcher.cc
@@ -115,16 +115,12 @@ void Ogre2BoundingBoxMaterialSwitcher::cameraPreRenderScene(
 
       // get class user data
       Variant labelAny = ogreVisual->UserData(this->labelKey);
-
+      
+      // set default label to background
       int label = this->backgroundLabel;
-      try
-      {
-        label = std::get<int>(labelAny);
-      }
-      catch(std::bad_variant_access &e)
-      {
-        // items with no class are considered background
-        label = this->backgroundLabel;
+      // if not background, then modify to label
+      if (const int* labelPtr = std::get_if<int>(&labelAny)){
+        label = *labelPtr;
       }
 
       // for full bbox, each pixel contains 1 channel for label

--- a/ogre2/src/Ogre2BoundingBoxMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2BoundingBoxMaterialSwitcher.cc
@@ -115,7 +115,6 @@ void Ogre2BoundingBoxMaterialSwitcher::cameraPreRenderScene(
 
       // get class user data
       Variant labelAny = ogreVisual->UserData(this->labelKey);
-      
       // set default label to background
       int label = this->backgroundLabel;
       // if not background, then modify to label

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <variant>
+
 #include <gz/math/Vector2.hh>
 #include <gz/math/Vector3.hh>
 
@@ -342,7 +344,6 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
         {
           gzerr << "Error casting user data: laser_retro\n";
         }
-
       }
 
       // only accept positive laser retro value

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -326,23 +326,24 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
       {
         // get laser_retro
         Variant tempLaserRetro = ogreVisual->UserData(laserRetroKey);
-
-        if (std::holds_alternative<float>(tempLaserRetro))
+      
+        if (const auto* retroValuePtr = std::get_if<float>(&tempLaserRetro))
         {
-          retroValue = std::get<float>(tempLaserRetro);
+          retroValue = *retroValuePtr;
         }
-        else if (std::holds_alternative<double>(tempLaserRetro))
+        else if (const auto* retroValuePtr = std::get_if<double>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(std::get<double>(tempLaserRetro));
+          retroValue = static_cast<float>(*retroValuePtr);
         }
-        else if (std::holds_alternative<int>(tempLaserRetro))
+        else if (const auto* retroValuePtr = std::get_if<int>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(std::get<int>(tempLaserRetro));
+          retroValue = static_cast<float>(*retroValuePtr);
         }
         else
         {
           gzerr << "Error casting user data: laser_retro\n";
         }
+
       }
 
       // only accept positive laser retro value
@@ -442,17 +443,17 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
         // get laser_retro
         Variant tempLaserRetro = visual->UserData(laserRetroKey);
 
-        if (std::holds_alternative<float>(tempLaserRetro))
+        if (const auto* retroValuePtr = std::get_if<float>(&tempLaserRetro))
         {
-          retroValue = std::get<float>(tempLaserRetro);
+          retroValue = *retroValuePtr;
         }
-        else if (std::holds_alternative<double>(tempLaserRetro))
+        else if (const auto* retroValuePtr = std::get_if<double>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(std::get<double>(tempLaserRetro));
+          retroValue = static_cast<float>(*retroValuePtr);
         }
-        else if (std::holds_alternative<int>(tempLaserRetro))
+        else if (const auto* retroValuePtr = std::get_if<int>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(std::get<int>(tempLaserRetro));
+          retroValue = static_cast<float>(*retroValuePtr);
         }
         else
         {

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -327,17 +327,17 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
         // get laser_retro
         Variant tempLaserRetro = ogreVisual->UserData(laserRetroKey);
       
-        if (const auto* retroValuePtr = std::get_if<float>(&tempLaserRetro))
+        if (const float* floatPtr = std::get_if<float>(&tempLaserRetro))
         {
-          retroValue = *retroValuePtr;
+          retroValue = *floatPtr;
         }
-        else if (const auto* retroValuePtr = std::get_if<double>(&tempLaserRetro))
+        else if (const double* doublePtr = std::get_if<double>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(*retroValuePtr);
+          retroValue = static_cast<float>(*doublePtr);
         }
-        else if (const auto* retroValuePtr = std::get_if<int>(&tempLaserRetro))
+        else if (const int* intPtr = std::get_if<int>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(*retroValuePtr);
+          retroValue = static_cast<float>(*intPtr);
         }
         else
         {
@@ -443,17 +443,17 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
         // get laser_retro
         Variant tempLaserRetro = visual->UserData(laserRetroKey);
 
-        if (const auto* retroValuePtr = std::get_if<float>(&tempLaserRetro))
+        if (const float* floatPtr = std::get_if<float>(&tempLaserRetro))
         {
-          retroValue = *retroValuePtr;
+          retroValue = *floatPtr;
         }
-        else if (const auto* retroValuePtr = std::get_if<double>(&tempLaserRetro))
+        else if (const double* doublePtr = std::get_if<double>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(*retroValuePtr);
+          retroValue = static_cast<float>(*doublePtr);
         }
-        else if (const auto* retroValuePtr = std::get_if<int>(&tempLaserRetro))
+        else if (const int* intPtr = std::get_if<int>(&tempLaserRetro))
         {
-          retroValue = static_cast<float>(*retroValuePtr);
+          retroValue = static_cast<float>(*intPtr);
         }
         else
         {

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -326,7 +326,6 @@ void Ogre2LaserRetroMaterialSwitcher::passPreExecute(
       {
         // get laser_retro
         Variant tempLaserRetro = ogreVisual->UserData(laserRetroKey);
-      
         if (const float* floatPtr = std::get_if<float>(&tempLaserRetro))
         {
           retroValue = *floatPtr;

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -86,11 +86,11 @@ Ogre::Vector4 Ogre2SegmentationMaterialSwitcher::ColorForVisual(
   // get class user data
   Variant labelAny = _visual->UserData("label");
   int label;
-  try
+  if (const int* labelPtr = std::get_if<int>(&labelAny))
   {
-    label = std::get<int>(labelAny);
+    label = *labelPtr;
   }
-  catch (std::bad_variant_access &)
+  else
   {
     // items with no class are considered background
     label = this->segmentationCamera->BackgroundLabel();

--- a/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
+++ b/ogre2/src/Ogre2SegmentationMaterialSwitcher.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <utility>
 #include <vector>
+#include <variant>
 
 #include <gz/common/Console.hh>
 

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -281,17 +281,17 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
       {
         float temp = -1.0f;
         bool foundTemp = true;
-        if (std::holds_alternative<float>(tempAny))
+        if (const float* tempPtr = std::get_if<float>(&tempAny))
         {
-          temp = std::get<float>(tempAny);
+          temp = *tempPtr;
         }
-        else if (std::holds_alternative<double>(tempAny))
+        else if (const double* temptPtr = std::get_if<double>(&tempAny))
         {
-          temp = static_cast<float>(std::get<double>(tempAny));
+          temp = static_cast<float>(*tempPtr);
         }
-        else if (std::holds_alternative<int>(tempAny))
+        else if (const int* tempPtr = std::get_if<int>(&tempAny))
         {
-          temp = static_cast<float>(std::get<int>(tempAny));
+          temp = static_cast<float>(*tempPtr);
         }
         else
         {
@@ -554,17 +554,18 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
       {
         float temp = -1.0;
         bool foundTemp = true;
-        if (std::holds_alternative<float>(tempAny))
+        if (const float* tempPtr = std::get_if<float>(&tempAny))
         {
-          temp = std::get<float>(tempAny);
+          temp = *tempPtr;
         }
-        else if (std::holds_alternative<double>(tempAny))
+        else if (const double* tempPtr = std::get_if<double>(&tempAny))
         {
-          temp = static_cast<float>(std::get<double>(tempAny));
+
+          temp = static_cast<float>(*tempPtr);
         }
-        else if (std::holds_alternative<int>(tempAny))
+        else if (const int* tempPtr = std::get_if<int>(&tempAny))
         {
-          temp = static_cast<float>(std::get<int>(tempAny));
+          temp = static_cast<float>(*tempPtr);
         }
         else
         {

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -560,7 +560,6 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
         }
         else if (const double* doublePtr = std::get_if<double>(&tempAny))
         {
-
           temp = static_cast<float>(*doublePtr);
         }
         else if (const int* intPtr = std::get_if<int>(&tempAny))

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -281,17 +281,17 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
       {
         float temp = -1.0f;
         bool foundTemp = true;
-        if (const float* tempPtr = std::get_if<float>(&tempAny))
+        if (const float* floatPtr = std::get_if<float>(&tempAny))
         {
-          temp = *tempPtr;
+          temp = *floatPtr;
         }
-        else if (const double* temptPtr = std::get_if<double>(&tempAny))
+        else if (const double* doublePtr = std::get_if<double>(&tempAny))
         {
-          temp = static_cast<float>(*tempPtr);
+          temp = static_cast<float>(*doublePtr);
         }
-        else if (const int* tempPtr = std::get_if<int>(&tempAny))
+        else if (const int* intPtr = std::get_if<int>(&tempAny))
         {
-          temp = static_cast<float>(*tempPtr);
+          temp = static_cast<float>(*intPtr);
         }
         else
         {
@@ -554,18 +554,18 @@ void Ogre2ThermalCameraMaterialSwitcher::cameraPreRenderScene(
       {
         float temp = -1.0;
         bool foundTemp = true;
-        if (const float* tempPtr = std::get_if<float>(&tempAny))
+        if (const float* floatPtr = std::get_if<float>(&tempAny))
         {
-          temp = *tempPtr;
+          temp = *floatPtr;
         }
-        else if (const double* tempPtr = std::get_if<double>(&tempAny))
+        else if (const double* doublePtr = std::get_if<double>(&tempAny))
         {
 
-          temp = static_cast<float>(*tempPtr);
+          temp = static_cast<float>(*doublePtr);
         }
-        else if (const int* tempPtr = std::get_if<int>(&tempAny))
+        else if (const int* intPtr = std::get_if<int>(&tempAny))
         {
-          temp = static_cast<float>(*tempPtr);
+          temp = static_cast<float>(*intPtr);
         }
         else
         {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/516

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Use of std::get for gz::rendering::Variant throws exceptions whenever it is interpreted as the wrong type. Non-critical exceptions when working Gazebo can cause lead to cumbersome debugging. So the code has been changed to use std::get_if for a softer error handling when encountering wrong Variant type.

Two things have been changed
- Code using `try` `catch` with `std::get` changed to `std::get_if` in `ogre/src/OgreThermalCamera.cc`, `ogre2/src/Ogre2BoundingBoxMaterialSwitcher.cc` and `ogre2/src/Ogre2SegmentationMaterialSwitcher.cc`
- `std::holds_alternative` nested with `std::get` changed to use only `std::get_if` for simpler value access in `ogre2/src/Ogre2GpuRays.cc` and `ogre2/src/Ogre2ThermalCamera.cc`

The following tests FAILED:
```
         23 - INTEGRATION_gpu_rays_ogre_gl3plus (Failed)
         88 - REGRESSION_reload_engine_ogre2_gl3plus (Failed)
        216 - UNIT_RenderingIface_TEST_ogre2_gl3plus (Failed)
```

due to the [bug](https://bugs.launchpad.net/ubuntu/+source/ogre-next/+bug/2063359) pointed out by @j-rivero. 
Reason: `Error while loading the library [/gz_ws/install/lib/gz-rendering-9/engine-plugins/libgz-rendering-ogre2.so]: /gz_ws/install/lib/gz-rendering-9/engine-plugins/libgz-rendering-ogre2.so: undefined symbol: _ZThn944_N4Ogre7HlmsPbs19_changeRenderSystemEPNS_12RenderSystemE `

Will need your help to test it properly. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.