### PR TITLE
Fix clamp of temperature in thermal camera output

### DIFF
--- a/ogre/src/media/materials/programs/thermal_camera_fs.glsl
+++ b/ogre/src/media/materials/programs/thermal_camera_fs.glsl
@@ -50,7 +50,7 @@ void main()
   // simulate temp variation as a function of depth
   float delta = (1.0 - d) * heatRange;
   temp = temp - heatRange / 2.0 + delta;
-  clamp(temp, min, max);
+  temp = clamp(temp, min, max);
 
   // apply resolution factor
   temp /= resolution;

--- a/ogre2/src/media/materials/programs/GLSL/thermal_camera_fs.glsl
+++ b/ogre2/src/media/materials/programs/GLSL/thermal_camera_fs.glsl
@@ -117,7 +117,7 @@ void main()
   // simulate temp variations
   float delta = (1.0 - dNorm) * heatRange;
   temp = temp - heatRange / 2.0 + delta;
-  clamp(temp, min, max);
+  temp = clamp(temp, min, max);
 
   // apply resolution factor
   temp /= resolution;

--- a/ogre2/src/media/materials/programs/Metal/thermal_camera_fs.metal
+++ b/ogre2/src/media/materials/programs/Metal/thermal_camera_fs.metal
@@ -124,7 +124,7 @@ fragment float4 main_metal
   // simulate temp variations
   float delta = (1.0 - dNorm) * heatRange;
   temp = temp - heatRange / 2.0 + delta;
-  clamp(temp, p.min, p.max);
+  temp = clamp(temp, p.min, p.max);
 
   // apply resolution factor
   temp /= p.resolution;

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -19,6 +19,8 @@
 
 #include "CommonRenderingTest.hh"
 
+#include <vector>
+
 #include <gz/common/Filesystem.hh>
 #include <gz/common/Event.hh>
 
@@ -698,6 +700,120 @@ TEST_F(ThermalCameraTest, ThermalCameraParticles)
     // Clean up
     connection.reset();
     delete [] thermalData;
+  }
+
+  engine->DestroyScene(scene);
+}
+
+//////////////////////////////////////////////////
+TEST_F(ThermalCameraTest, ThermalCameraMinTemperatureIsClamped)
+{
+  const unsigned int imgWidth = 50;
+  const unsigned int imgHeight = 50;
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  {
+    // Create thermal camera
+    auto thermalCamera = scene->CreateThermalCamera("ThermalCamera");
+    ASSERT_NE(thermalCamera, nullptr);
+
+    // Configure thermal camera
+    thermalCamera->SetImageWidth(imgWidth);
+    EXPECT_EQ(thermalCamera->ImageWidth(), imgWidth);
+    thermalCamera->SetImageHeight(imgHeight);
+    EXPECT_EQ(thermalCamera->ImageHeight(), imgHeight);
+
+    scene->RootVisual()->AddChild(thermalCamera);
+
+    // Set a callback on the camera sensor to get a thermal camera frame
+    std::vector<uint16_t> thermalData(imgHeight * imgWidth);
+    gz::common::ConnectionPtr connection =
+      thermalCamera->ConnectNewThermalFrame(
+          std::bind(&::OnNewThermalFrame, thermalData.data(),
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    EXPECT_NE(nullptr, connection);
+
+    const float linearResolution = 0.01f;
+    thermalCamera->SetLinearResolution(linearResolution);
+    EXPECT_FLOAT_EQ(linearResolution, thermalCamera->LinearResolution());
+
+    // set a minimum temperature and a smaller ambient temperature
+    const float minTemp = 100.0f;
+    const float ambientTemp = 50.0f;
+    thermalCamera->SetMinTemperature(minTemp);
+    EXPECT_FLOAT_EQ(minTemp, thermalCamera->MinTemperature());
+    thermalCamera->SetAmbientTemperature(ambientTemp);
+    EXPECT_FLOAT_EQ(ambientTemp, thermalCamera->AmbientTemperature());
+
+    // Update once to create image
+    thermalCamera->Update();
+
+    for (const uint16_t value : thermalData) {
+      const float temp = static_cast<float>(value) * linearResolution;
+      EXPECT_NEAR(temp, minTemp, linearResolution);
+    }
+
+    // Clean up
+    connection.reset();
+  }
+
+  engine->DestroyScene(scene);
+}
+
+//////////////////////////////////////////////////
+TEST_F(ThermalCameraTest, ThermalCameraMaxTemperatureIsClamped)
+{
+  const unsigned int imgWidth = 50;
+  const unsigned int imgHeight = 50;
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  {
+    // Create thermal camera
+    auto thermalCamera = scene->CreateThermalCamera("ThermalCamera");
+    ASSERT_NE(thermalCamera, nullptr);
+
+    // Configure thermal camera
+    thermalCamera->SetImageWidth(imgWidth);
+    EXPECT_EQ(thermalCamera->ImageWidth(), imgWidth);
+    thermalCamera->SetImageHeight(imgHeight);
+    EXPECT_EQ(thermalCamera->ImageHeight(), imgHeight);
+
+    scene->RootVisual()->AddChild(thermalCamera);
+
+    // Set a callback on the camera sensor to get a thermal camera frame
+    std::vector<uint16_t> thermalData(imgHeight * imgWidth);
+    gz::common::ConnectionPtr connection =
+      thermalCamera->ConnectNewThermalFrame(
+          std::bind(&::OnNewThermalFrame, thermalData.data(),
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    EXPECT_NE(nullptr, connection);
+
+    const float linearResolution = 0.01f;
+    thermalCamera->SetLinearResolution(linearResolution);
+    EXPECT_FLOAT_EQ(linearResolution, thermalCamera->LinearResolution());
+
+    // set a maximum temperature and a greater ambient temperature
+    const float maxTemp = 500.0f;
+    const float ambientTemp = 550.0f;
+    thermalCamera->SetMaxTemperature(maxTemp);
+    EXPECT_FLOAT_EQ(maxTemp, thermalCamera->MaxTemperature());
+    thermalCamera->SetAmbientTemperature(ambientTemp);
+    EXPECT_FLOAT_EQ(ambientTemp, thermalCamera->AmbientTemperature());
+
+    // Update once to create image
+    thermalCamera->Update();
+
+    for (const uint16_t value : thermalData) {
+      const float temp = static_cast<float>(value) * linearResolution;
+      EXPECT_NEAR(temp, maxTemp, linearResolution);
+    }
+
+    // Clean up
+    connection.reset();
   }
 
   engine->DestroyScene(scene);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The minimum and maximum temperature of the thermal camera were not applied properly. clamp was called in the shader without using the result. This also adds simple test cases that allow easily reproducing the bug before this change. 

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
