### PR TITLE
Fix user settings of thermal camera being ignored

### DIFF
--- a/ogre/src/OgreThermalCamera.cc
+++ b/ogre/src/OgreThermalCamera.cc
@@ -527,6 +527,15 @@ void OgreThermalCamera::PreRender()
   BaseCamera::PreRender();
   if (!this->dataPtr->ogreThermalTexture)
     this->CreateThermalTexture();
+
+  // ensure that certain shader constants are up-to-date so that changes that
+  // users can make to the settings show up in the thermal result immediately
+  Ogre::Pass *pass =
+      this->dataPtr->thermalMaterial->getTechnique(0)->getPass(0);
+  auto params = pass->getFragmentProgramParameters();
+  params->setNamedConstant("max", this->maxTemp);
+  params->setNamedConstant("min", this->minTemp);
+  params->setNamedConstant("resolution", this->resolution);
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2ThermalCamera.cc
+++ b/ogre2/src/Ogre2ThermalCamera.cc
@@ -1120,6 +1120,21 @@ void Ogre2ThermalCamera::PreRender()
   if (!this->dataPtr->ogreThermalTexture)
     this->CreateThermalTexture();
 
+  // ensure that certain shader constants are up-to-date so that changes that
+  // users can make to the settings show up in the thermal result immediately
+  Ogre::Pass *pass =
+    this->dataPtr->thermalMaterial->getTechnique(0)->getPass(0);
+  Ogre::GpuProgramParametersSharedPtr psParams =
+    pass->getFragmentProgramParameters();
+  psParams->setNamedConstant("max",
+      static_cast<float>(this->maxTemp));
+  psParams->setNamedConstant("min",
+      static_cast<float>(this->minTemp));
+  psParams->setNamedConstant("resolution",
+      static_cast<float>(this->resolution));
+
+  this->dataPtr->thermalMaterialSwitcher->SetLinearResolution(this->resolution);
+
   // todo(iche033) Override BaseCamera::SetProjectionMatrix() function in
   // main / gz-rendering9 instead of checking and setting the custom
   // projection matrix here

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -706,6 +706,71 @@ TEST_F(ThermalCameraTest, ThermalCameraParticles)
 }
 
 //////////////////////////////////////////////////
+TEST_F(ThermalCameraTest, ThermalCameraResolutionUpdate)
+{
+  const unsigned int imgWidth = 50;
+  const unsigned int imgHeight = 50;
+
+  gz::rendering::ScenePtr scene = engine->CreateScene("scene");
+
+  {
+    // Create thermal camera
+    auto thermalCamera = scene->CreateThermalCamera("ThermalCamera");
+    ASSERT_NE(thermalCamera, nullptr);
+
+    // Configure thermal camera
+    thermalCamera->SetImageWidth(imgWidth);
+    EXPECT_EQ(thermalCamera->ImageWidth(), imgWidth);
+    thermalCamera->SetImageHeight(imgHeight);
+    EXPECT_EQ(thermalCamera->ImageHeight(), imgHeight);
+
+    scene->RootVisual()->AddChild(thermalCamera);
+
+    // Set a callback on the camera sensor to get a thermal camera frame
+    std::vector<uint16_t> thermalData(imgHeight * imgWidth);
+    gz::common::ConnectionPtr connection =
+      thermalCamera->ConnectNewThermalFrame(
+          std::bind(&::OnNewThermalFrame, thermalData.data(),
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    EXPECT_NE(nullptr, connection);
+
+    const float ambientTemp = 300.0f;
+    thermalCamera->SetAmbientTemperature(ambientTemp);
+    EXPECT_FLOAT_EQ(ambientTemp, thermalCamera->AmbientTemperature());
+
+    const float linearResolution = 0.01f;
+    thermalCamera->SetLinearResolution(linearResolution);
+    EXPECT_FLOAT_EQ(linearResolution, thermalCamera->LinearResolution());
+
+    // Update once to create image
+    thermalCamera->Update();
+
+    // check result with initial resolution
+    for (const uint16_t value : thermalData) {
+      const float temp = static_cast<float>(value) * linearResolution;
+      EXPECT_NEAR(temp, ambientTemp, linearResolution);
+    }
+
+    // set new resolution
+    const float newLinearResolution = 0.02f;
+    thermalCamera->SetLinearResolution(newLinearResolution);
+    thermalCamera->Update();
+
+    // check that camera has applied the new resolution
+    for (const uint16_t value : thermalData) {
+      const float temp = static_cast<float>(value) * newLinearResolution;
+      EXPECT_NEAR(temp, ambientTemp, newLinearResolution);
+    }
+
+    // Clean up
+    connection.reset();
+  }
+
+  engine->DestroyScene(scene);
+}
+
+//////////////////////////////////////////////////
 TEST_F(ThermalCameraTest, ThermalCameraMinTemperatureIsClamped)
 {
   const unsigned int imgWidth = 50;
@@ -753,6 +818,17 @@ TEST_F(ThermalCameraTest, ThermalCameraMinTemperatureIsClamped)
     for (const uint16_t value : thermalData) {
       const float temp = static_cast<float>(value) * linearResolution;
       EXPECT_NEAR(temp, minTemp, linearResolution);
+    }
+
+    // set new minimum temperature
+    const float newMinTemp = 150.0f;
+    thermalCamera->SetMinTemperature(newMinTemp);
+    thermalCamera->Update();
+
+    // check that new minimum temperature is applied
+    for (const uint16_t value : thermalData) {
+      const float temp = static_cast<float>(value) * linearResolution;
+      EXPECT_NEAR(temp, newMinTemp, linearResolution);
     }
 
     // Clean up
@@ -810,6 +886,17 @@ TEST_F(ThermalCameraTest, ThermalCameraMaxTemperatureIsClamped)
     for (const uint16_t value : thermalData) {
       const float temp = static_cast<float>(value) * linearResolution;
       EXPECT_NEAR(temp, maxTemp, linearResolution);
+    }
+
+    // set new maximum temperature
+    const float newMaxTemp = 525.0f;
+    thermalCamera->SetMaxTemperature(newMaxTemp);
+    thermalCamera->Update();
+
+    // check that new maximum temperature is applied
+    for (const uint16_t value : thermalData) {
+      const float temp = static_cast<float>(value) * linearResolution;
+      EXPECT_NEAR(temp, newMaxTemp, linearResolution);
     }
 
     // Clean up


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1134

## Summary
Changes to thermal camera settings that can be made through the plugin gz-sim-thermal-sensor-system would not show up in the result. While the value of the data members was updated, the named constants in the material shader used for rendering were not. We fix that by always setting the shader constants in `PreRender` to the current values.

This might be relevant for other thermal camera settings as well, but this focuses on min and max temperature and resolution, as those can be modified through the gz-sim-thermal-sensor-system plugin.

Unfortunately this only seems to work for Ogre2 right now, updating the shader constants does not seem to work for Ogre1. Keeping this as draft in hope to find a fix for Ogre1 before merging.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
