### PR TITLE
Hide Ogre and Ogre2 external window on MacOS and Windows

### DIFF
--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -687,6 +687,7 @@ std::string OgreRenderEngine::CreateRenderWindow(const std::string &_handle,
     // Mac and Windows *must* use externalWindow handle.
 #if defined(__APPLE__) || defined(_MSC_VER)
     params["externalWindowHandle"] = _handle;
+    params["hidden"] = "true";
 #else
     params["parentWindowHandle"] = _handle;
 #endif

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1196,6 +1196,7 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
       // Mac and Windows *must* use externalWindow handle.
 #if defined(__APPLE__) || defined(_MSC_VER)
       params["externalWindowHandle"] = _handle;
+      params["hidden"] = "true";
 #else
       params["parentWindowHandle"] = _handle;
 #endif


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Hides Ogre and Ogre2 external window on MacOS and Windows.

Unlike Linux, Ogre backend *must* use external window handles. When Gazebo client starts, it opens two windows: one is the main client window with GUI, and the other is just an empty window like this:
<img width="612" alt="Screenshot 2025-05-15 at 06 15 17" src="https://github.com/user-attachments/assets/bc9e1f9a-f0f0-4e36-b4d7-e0071b852f2a" />

This PR sets `hidden=true` param for Ogre and Ogre2 which allows to use external window handle but hides window itself.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
