### PR TITLE
Enable loading a render engine plugin from the static plugin registry

### DIFF
--- a/ogre/src/OgreRenderEngine.cc
+++ b/ogre/src/OgreRenderEngine.cc
@@ -878,3 +878,5 @@ OgreRenderEngine *OgreRenderEngine::Instance()
 // Register this plugin
 GZ_ADD_PLUGIN(rendering::OgreRenderEnginePlugin,
               rendering::RenderEnginePlugin)
+GZ_ADD_PLUGIN_ALIAS(rendering::OgreRenderEnginePlugin,
+                    "gz::rendering::ogre::Plugin")

--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1453,3 +1453,5 @@ Ogre2RenderEngine *Ogre2RenderEngine::Instance()
 // Register this plugin
 GZ_ADD_PLUGIN(rendering::Ogre2RenderEnginePlugin,
               rendering::RenderEnginePlugin)
+GZ_ADD_PLUGIN_ALIAS(rendering::Ogre2RenderEnginePlugin,
+                    "gz::rendering::ogre2::Plugin")

--- a/optix/src/OptixRenderEngine.cc
+++ b/optix/src/OptixRenderEngine.cc
@@ -143,3 +143,5 @@ OptixRenderEngine *OptixRenderEngine::Instance()
 // Register this plugin
 GZ_ADD_PLUGIN(OptixRenderEnginePlugin,
               rendering::RenderEnginePlugin)
+GZ_ADD_PLUGIN_ALIAS(OptixRenderEnginePlugin,
+                    "gz::rendering::optix::Plugin")

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -15,8 +15,10 @@
  *
  */
 
+#include <cstddef>
 #include <map>
 #include <mutex>
+#include <string>
 
 #include <gz/common/Console.hh>
 #include <gz/common/SystemPaths.hh>

--- a/src/RenderEngineManager.cc
+++ b/src/RenderEngineManager.cc
@@ -467,7 +467,7 @@ void RenderEngineManagerPrivate::RegisterDefaultEngines()
 
   // TODO(anyone): Find a cleaner way to get the default engine .so library name
   // cppcheck-suppress unreadVariable
-  const std::string_view libNamePrefix = "gz-rendering-";
+  const std::string libNamePrefix = "gz-rendering-";
 
   // Register Ogre
   const std::string ogreEngineName = "ogre";

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,21 @@
+package(
+    default_applicable_licenses = ["//:license"],
+    features = [
+        "layering_check",
+        "parse_headers",
+    ],
+)
+
+cc_test(
+    name = "INTEGRATION_load_static_render_engine_plugin",
+    srcs = ["integration/load_static_render_engine_plugin.cc"],
+    env = {"GZ_BAZEL": "1"},
+    deps = [
+        "//:gz-rendering",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@gz-common",
+        "@gz-plugin//:loader",
+        "@gz-plugin//:register",
+    ],
+)

--- a/test/integration/load_static_render_engine_plugin.cc
+++ b/test/integration/load_static_render_engine_plugin.cc
@@ -15,6 +15,9 @@
  *
  */
 
+#include <memory>
+#include <string>
+
 #include <gtest/gtest.h>
 
 #include <gz/common/Console.hh>

--- a/test/integration/load_static_render_engine_plugin.cc
+++ b/test/integration/load_static_render_engine_plugin.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <gz/common/Console.hh>
+
+#include <gz/plugin/Loader.hh>
+#include <gz/plugin/RegisterStatic.hh>
+
+#include <gz/rendering/base/BaseRenderEngine.hh>
+#include <gz/rendering/base/BaseScene.hh>
+#include <gz/rendering/base/BaseStorage.hh>
+#include <gz/rendering/RenderingIface.hh>
+#include <gz/rendering/RenderEnginePlugin.hh>
+
+using namespace gz;
+using namespace rendering;
+
+namespace {
+// Dummy scene class used in the render engine below.
+class DummyScene final: public BaseScene
+{};
+
+// Dummy singleton render engine used in the render engine plugin below.
+class DummyRenderEngine final: public BaseRenderEngine
+{
+public: typedef BaseSceneStore<DummyScene> DummySceneStore;
+public: typedef std::shared_ptr<DummySceneStore> DummySceneStorePtr;
+
+public: static DummyRenderEngine* Instance();
+
+private: DummyRenderEngine();
+
+public: std::string Name() const override {return "test_engine";}
+
+protected: bool LoadImpl(const std::map<std::string,
+    std::string> &_params) override {return true;}
+
+protected: bool InitImpl() override {return true;}
+
+protected: ScenePtr CreateSceneImpl(unsigned int _id,
+        const std::string &_name) override {return nullptr;}
+
+protected: SceneStorePtr Scenes() const override {return this->sceneStore; }
+
+private: DummySceneStorePtr sceneStore;
+};
+
+DummyRenderEngine* DummyRenderEngine::Instance()
+{
+  static DummyRenderEngine engine;
+  return &engine;
+}
+
+DummyRenderEngine::DummyRenderEngine()
+: sceneStore(std::make_shared<DummySceneStore>())
+{}
+
+// Dummy render engine plugin used in the test below. Note that the plugin is
+// registered with the static plugin registry at the bottom of this file.
+class DummyRenderEnginePlugin final : public RenderEnginePlugin
+{
+public: DummyRenderEnginePlugin();
+
+public: std::string Name() const override {return engine->Name();}
+
+public: RenderEngine *Engine() const override {return engine;}
+
+private: DummyRenderEngine* engine;
+};
+
+DummyRenderEnginePlugin::DummyRenderEnginePlugin()
+: engine(DummyRenderEngine::Instance())
+{}
+
+// Test that the dummy render engine plugin can be loaded from the static plugin
+// registry.
+TEST(LoadStaticRenderEnginePlugin, LoadUnloadWorks)
+{
+  plugin::Loader pluginLoader;
+  const std::string pluginName =
+      pluginLoader.LookupPlugin("DummyRenderEnginePlugin");
+  EXPECT_FALSE(pluginName.empty());
+
+  const std::string engineFilename = "static://DummyRenderEnginePlugin";
+  RenderEngine *engine = rendering::engine(engineFilename);
+  EXPECT_NE(nullptr, engine);
+
+  EXPECT_EQ(DummyRenderEngine::Instance(), engine);
+
+  EXPECT_TRUE(rendering::unloadEngine(engineFilename));
+}
+
+// Register the plugin with the static registry
+GZ_ADD_STATIC_PLUGIN(DummyRenderEnginePlugin, RenderEnginePlugin)
+GZ_ADD_STATIC_PLUGIN_ALIAS(DummyRenderEnginePlugin, "DummyRenderEnginePlugin")
+
+}  // namespace


### PR DESCRIPTION
# 🎉 New feature

## Summary
Extends `RenderEngineManager` to load a render engine plugin from the static plugin registry.

Also registered the default render engine plugins based on lookup in the plugin registry at runtime, in case one or more of the default render engines were statically linked in. This is required so that `unloadEngine()` can correctly unload the instantiated engine using the standard name, e.g. "ogre2". (Note: `unloadEngine` is called from the [`gz::sim::Sensors` system](https://github.com/gazebosim/gz-sim/blob/a6b8f05ee20f75b4c65d31bb4f753bdea710c480/src/rendering/RenderUtil.cc#L2682)). To make the plugin filename in the static plugin registry more obvious, I also added aliases for the existing render engine plugins with fully qualified names.

## Test it
Added a test in the bazel build:
```
$ bazel test test:INTEGRATION_load_static_render_engine_plugin
```

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

