### PR TITLE
Guard against bad memory access in RenderPassSystem

### DIFF
--- a/include/gz/rendering/RenderPassSystem.hh
+++ b/include/gz/rendering/RenderPassSystem.hh
@@ -83,7 +83,7 @@ namespace gz
       GZ_UTILS_WARN_IGNORE__DLL_INTERFACE_MISSING
       private: typedef std::map<std::string, RenderPassFactory *>
           RenderPassMap;
-      private: static RenderPassMap& GetRenderPassMap();
+      private: static RenderPassMap &GetRenderPassMap();
 
       /// \internal
       /// \brief Pointer to private data class

--- a/src/RenderPassSystem.cc
+++ b/src/RenderPassSystem.cc
@@ -63,7 +63,7 @@ void RenderPassSystem::Register(const std::string &_name,
 }
 
 //////////////////////////////////////////////////
-RenderPassSystem::RenderPassMap& RenderPassSystem::GetRenderPassMap()
+RenderPassSystem::RenderPassMap &RenderPassSystem::GetRenderPassMap()
 {
   static RenderPassMap renderPassMap;
   return renderPassMap;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fixes a bad memory access that in `RenderPassSystem` that happens in some linux builds. The issue stems from indeterminism in the order in which these two global variables are initialized:

https://github.com/gazebosim/gz-rendering/blob/3e695f96e2232b47b208851ed601da98bd34b881/src/RenderPassSystem.cc#L30
and
https://github.com/gazebosim/gz-rendering/blob/3e695f96e2232b47b208851ed601da98bd34b881/include/gz/rendering/RenderPassSystem.hh#L108

On Ubuntu with gcc, `global_##classname##Factory` is initialized _after_ `RenderPassSystem::renderPassMap`, so the `Register` call in the constructor for `##classname##Factory` works as expected.
However, on some linux builds, `global_##classname##Factory` may be initialized _before_ `RenderPassSystem::renderPassMap`, leading to a bad memory access.

This is fixed by using the Construct On First Use idiom, where the static `renderPassMap` member variable is replaced by a `GetRenderPassMap()` member function in which the actual static render pass map is instantiated. This member function is then called in `RenderPassSystem::Register()` and in `RenderPassSystem::CreateImpl()` to write to/ read from the static render map.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
