### PR TITLE
Add bazel build for ogre2 engine

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,11 @@ module(
     repo_name = "org_gazebosim_gz-rendering",
 )
 
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "egl-registry", version = "0.0.0-20250527")
 bazel_dep(name = "googletest", version = "1.15.2")
+bazel_dep(name = "ogre-next", version = "2.3.3")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "rules",
+    srcs = ["gz_rendering_engine_libraries.bzl"],
+    visibility = ["//:__subpackages__"],
+)

--- a/bazel/gz_rendering_engine_libraries.bzl
+++ b/bazel/gz_rendering_engine_libraries.bzl
@@ -1,0 +1,102 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+visibility("public")
+
+def _generate_static_plugin_src_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.plugin_cc,
+        output = ctx.outputs.out,
+        substitutions = {
+            # Macro substitutions:
+            "GZ_ADD_PLUGIN": "GZ_ADD_STATIC_PLUGIN",
+            "GZ_ADD_PLUGIN_ALIAS": "GZ_ADD_STATIC_PLUGIN_ALIAS",
+            # Header substitutions:
+            "plugin/Register.hh": "plugin/RegisterStatic.hh",
+            "plugin/RegisterMore.hh": "plugin/RegisterStatic.hh",
+        },
+    )
+
+# This rule performs a substitution to link the plugin class to the static
+# plugin registry instead of the plugin hook registry for dynamic loading.
+_generate_static_plugin_src = rule(
+    attrs = {
+        "plugin_cc": attr.label(allow_single_file = True, mandatory = True),
+        "out": attr.output(mandatory = True),
+    },
+    implementation = _generate_static_plugin_src_impl,
+)
+
+def gz_rendering_engine_libraries(static_lib_name, so_lib_name, srcs, includes = [], **kwargs):
+    """
+    Adds two library targets for the render engine plugin for static and dynamic loading respectively
+
+    Args:
+        static_lib_name: Name of the `cc_library` target with static linking.
+          Note that the plugin registration macro is substituted with
+          `GZ_ADD_STATIC_PLUGIN` in the source file for this target to register
+          the plugin with the static registry.
+          The `alwayslink` attribute of this target is set to True, so that
+          downstream linking preserves symbols which are not referenced
+          explicitly.
+        so_lib_name: Name of the `cc_binary` shared library target which can be
+          loaded at runtime. Set this to empty string if the shared library
+          target should not be added.
+        srcs: List of source files including private headers. For example, this
+          can be a globbed list of *.cc and *.hh files.
+          Any test files should be excluded and can be added to separate
+           `cc_test` targets.
+        includes: List of include dirs to be added to the `cc_library` and
+          `cc_binary` targets
+        **kwargs: Forwarded to both the `cc_library` and `cc_binary` targets.
+    """
+    if not static_lib_name:
+        fail("The static_lib_name field must be non-empty.")
+
+    supported_cc_extensions = ["cc", "cpp"]
+    cc_files = [f for f in srcs if f.split(".")[-1] in supported_cc_extensions]
+    non_cc_files = [f for f in srcs if f not in cc_files]
+
+    if not cc_files:
+        fail("Did not find any .cc files in the provided srcs for library with static_lib_name '", static_lib_name, "'.")
+
+    plugin_dir = "/".join(cc_files[0].split("/")[:-1])
+
+    # Run the _generate_static_plugin_src rule to generate modified source files
+    # suitable for registering the render engine plugin with the static plugin
+    # registry. Ideally the rule only needs to be run on the source file which
+    # registers the render engine plugin with the GZ_ADD_PLUGIN macro. However,
+    # in the bazel analysis phase, there is no way to determine whether a
+    # particular .cc file registers a render engine plugin or not. To circumvent
+    # this limitation, the _generate_static_plugin_src rule is simply run for
+    # all source files. This has a very small overhead of writing out the
+    # original file as-is into a new source file for the input source files
+    # which do not register a render engine plugin.
+    static_cc_files = []
+    for cc_file in cc_files:
+        name_without_extension = ".".join(cc_file.split(".")[:-1])
+        static_plugin_src_gen_without_extension = name_without_extension + "_static_plugin"
+        static_plugin_src_gen = static_plugin_src_gen_without_extension + ".cc"
+        _generate_static_plugin_src(
+            name = static_plugin_src_gen_without_extension,
+            plugin_cc = cc_file,
+            out = static_plugin_src_gen,
+        )
+        static_cc_files.append(static_plugin_src_gen)
+
+    cc_library(
+        name = static_lib_name,
+        alwayslink = True,
+        includes = includes + [plugin_dir],
+        srcs = non_cc_files + static_cc_files,
+        **kwargs
+    )
+
+    if so_lib_name:
+        cc_binary(
+            name = so_lib_name,
+            linkshared = True,
+            includes = includes,
+            srcs = srcs,
+            **kwargs
+        )

--- a/ogre2/BUILD.bazel
+++ b/ogre2/BUILD.bazel
@@ -1,0 +1,99 @@
+# Bazel targets for Ogre2 render engine plugin.
+load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
+load("//bazel:gz_rendering_engine_libraries.bzl", "gz_rendering_engine_libraries")
+
+gz_export_header(
+    name = "Export",
+    out = "include/gz/rendering/ogre2/Export.hh",
+    export_base = "GZ_RENDERING_OGRE2",
+    lib_name = "gz-rendering",
+)
+
+filegroup(
+    name = "ogre_media",
+    srcs = glob(["src/media/**"]),
+)
+
+cc_library(
+    name = "terra",
+    srcs = glob([
+        "src/terrain/Terra/src/*.cpp",
+        "src/terrain/Terra/src/Hlms/*.cpp",
+        "src/terrain/Terra/src/Hlms/*.cpp.inc",
+        "src/terrain/Terra/src/Hlms/PbsListener/*.cpp",
+    ]),
+    hdrs = glob([
+        "src/terrain/Terra/include/Terra/*.h",
+        "src/terrain/Terra/include/Terra/Hlms/*.h",
+        "src/terrain/Terra/include/Terra/Hlms/PbsListener/*.h",
+    ]),
+    copts = [
+        "-Wno-ctad-maybe-unsupported",
+        "-Wno-unused-value",
+        "-Wno-non-virtual-dtor",
+        "-fexceptions",
+    ],
+    includes = ["src/terrain/Terra/include"],
+    deps = [
+        "@ogre-next//:hlms_pbs",
+        "@ogre-next//:ogre-main",
+    ],
+)
+
+# Targets including this under `deps` (for static linking) or under `data` (for
+# external library) should also include data deps on the Ogre-Next RenderSystem
+# libraries and Plugin libraries that need to be supported. e.g.
+# ```
+# cc_library(
+#     name = "my_gz_sim_server_with_ogre2_rendering",
+#     srcs = my_sources_list,
+#     data = [
+#         "@ogre-next//:RenderSystem_GL3Plus.so",
+#     ],
+#     deps = [
+#         "@gz-sim",
+#         "@gz-sim//:gz-sim-sensors-system-static",
+#         "@gz-rendering//ogre2:gz-rendering-ogre2-engine-static",
+#     ]
+# )
+# ```
+#
+# Also, the `OGRE2_RESOURCE_PATH` env variable must be set from the runfiles
+# path.
+gz_rendering_engine_libraries(
+    srcs = glob([
+        "include/gz/rendering/ogre2/*.hh",
+        "src/*.cc",
+        "src/*.hh",
+    ]) + [
+        "include/gz/rendering/ogre2/Export.hh",
+    ],
+    copts = [
+        "-Wno-ctad-maybe-unsupported",
+        "-Wno-unused-value",
+        "-Wno-non-virtual-dtor",
+        "-fexceptions",
+    ],
+    data = [":ogre_media"],
+    includes = ["include"],
+    local_defines = [
+        "HAVE_EGL=1",
+        "OGRE2_RESOURCE_PATH='\"unused\"'",
+        "OGRE2_VERSION='\"unused\"'",
+    ],
+    so_lib_name = "libgz-rendering-ogre2.so",
+    static_lib_name = "gz-rendering-ogre2-engine-static",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":terra",
+        "//:gz-rendering",
+        "@egl-registry//:EGL_headers",
+        "@gz-common",
+        "@gz-math//eigen3",
+        "@gz-plugin//:register",
+        "@ogre-next//:hlms_pbs",
+        "@ogre-next//:hlms_unlit",
+        "@ogre-next//:ogre-main",
+        "@ogre-next//:overlay",
+    ],
+)


### PR DESCRIPTION
# 🎉 New feature

## Summary
Add bazel build for ogre2 render engine. Two targets are added, one for static linking and another for runtime loading from .so. Both targets are generated by a new `gz_rendering_engine_libraries` rule (similar to [gz-sim system plugins](https://github.com/gazebosim/gz-sim/blob/gz-sim9/bazel/gz_sim_system_libraries.bzl)).

## Test it
```
$ bazel build ogre2:all
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
