### PR TITLE
[FIX]: Updated CMakeLists.txt with GLUT library bugs

### DIFF
--- a/examples/camera_tracking/CMakeLists.txt
+++ b/examples/camera_tracking/CMakeLists.txt
@@ -3,8 +3,7 @@ project(gz-rendering-camera-tracking)
 find_package(gz-rendering REQUIRED)
 
 find_package(GLUT REQUIRED)
-include_directories(SYSTEM ${GLUT_INCLUDE_DIRS})
-link_directories(${GLUT_LIBRARY_DIRS})
+include_directories(SYSTEM ${GLUT_INCLUDE_DIR})
 
 find_package(OpenGL REQUIRED)
 include_directories(SYSTEM ${OpenGL_INCLUDE_DIRS})
@@ -21,7 +20,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 add_executable(camera_tracking Main.cc GlutWindow.cc)
 
 target_link_libraries(camera_tracking
-  ${GLUT_LIBRARIES}
+  ${GLUT_glut_LIBRARY}
   ${OPENGL_LIBRARIES}
   ${GLEW_LIBRARIES}
   ${GZ-RENDERING_LIBRARIES}


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/2052

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
`CMakeList.txt` file has some issues with the GLUT library which causes the build to fail

Steps to reproduce:
```
git clone https://github.com/gazebosim/gz-rendering
cd gz-rendering/examples/custom_scene_viewer
mkdir build
cd build
cmake ..
```

This throws the following error
```
cmake ..
-- Looking for gz-rendering -- found version 10.0.0~pre1
-- Searching for dependencies of gz-rendering
-- Looking for gz-math -- found version 9.0.0~pre1
-- Searching for dependencies of gz-math
-- Looking for gz-utils -- found version 4.0.0~pre1
-- Searching for dependencies of gz-utils
-- Searching for <gz-math> component [eigen3]
-- Looking for gz-math-eigen3 -- found version 9.0.0~pre1
-- Searching for dependencies of gz-math-eigen3
-- Looking for gz-common -- found version 7.0.0~pre1
-- Searching for dependencies of gz-common
-- Looking for gz-utils -- found version 4.0.0~pre1
-- Searching for dependencies of gz-utils
-- Searching for <gz-utils> component [log]
-- Looking for gz-utils-log -- found version 4.0.0~pre1
-- Searching for dependencies of gz-utils-log
-- Checking for module 'uuid'
--   Found uuid, version 2.39.3
-- Searching for <gz-common> component [graphics]
-- Looking for gz-common-graphics -- found version 7.0.0~pre1
-- Searching for dependencies of gz-common-graphics
-- Looking for gz-math -- found version 9.0.0~pre1
-- Searching for <gz-common> component [events]
-- Looking for gz-common-events -- found version 7.0.0~pre1
-- Searching for dependencies of gz-common-events
-- Looking for gz-math -- found version 9.0.0~pre1
-- Searching for <gz-common> component [geospatial]
-- Looking for gz-common-geospatial -- found version 7.0.0~pre1
-- Searching for dependencies of gz-common-geospatial
-- Looking for gz-math -- found version 9.0.0~pre1
-- Looking for gz-common -- found version 7.0.0~pre1
-- Looking for gz-plugin -- found version 4.0.0~pre1
-- Searching for dependencies of gz-plugin
-- Looking for gz-utils -- found version 4.0.0~pre1
-- Searching for dependencies of gz-utils
-- Searching for <gz-utils> component [cli]
-- Looking for gz-utils-cli -- found version 4.0.0~pre1
-- Searching for dependencies of gz-utils-cli
-- Searching for <gz-plugin> component [all]
-- Looking for all libraries of gz-plugin -- found version 4.0.0~pre1
-- Looking for gz-plugin -- found version 4.0.0~pre1
-- Looking for gz-plugin-loader -- found version 4.0.0~pre1
-- Searching for dependencies of gz-plugin-loader
-- Looking for gz-plugin-register -- found version 4.0.0~pre1
-- Searching for dependencies of gz-plugin-register
-- Looking for gz-utils -- found version 4.0.0~pre1
CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find GLUT (missing: GLUT_glut_LIBRARY GLUT_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.28/Modules/FindGLUT.cmake:168 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:5 (find_package)
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.
