### PR TITLE
Add a note about glut dependency in installation tutorial

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,5 +1,4 @@
 freeglut3-dev
-libfreeimage-dev
 libglew-dev
 libgz-cmake5-dev
 libgz-common7-dev

--- a/tutorials/02_install.md
+++ b/tutorials/02_install.md
@@ -40,7 +40,7 @@ Be sure to replace `<#>` with a number value, such as `7` or `8`, depending on w
 
 ### Prerequisites
 
-Ubuntu Focal 20.04 or above:
+Ubuntu Noble 24.04 or above:
 
 Install dependencies:
 ```
@@ -53,7 +53,6 @@ sudo apt install -y \
     pkg-config \
     git \
     libglew-dev  \
-    libfreeimage-dev \
     freeglut3-dev \
     libxmu-dev \
     libxi-dev \
@@ -62,6 +61,8 @@ sudo apt install -y \
     libgz-common7-dev \
     libgz-plugin4-dev
 ```
+
+Note that `freeglut3-dev` is necessary for running demos in the examples directory.
 
 ### Supported Rendering Engines
 

--- a/tutorials/10_actor_animation_tutorial.md
+++ b/tutorials/10_actor_animation_tutorial.md
@@ -2,6 +2,11 @@
 
 This tutorial will show you how to use the Gazebo Rendering library to create an actor animation.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, Create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/10_actor_animation_tutorial.md
+++ b/tutorials/10_actor_animation_tutorial.md
@@ -5,7 +5,7 @@ This tutorial will show you how to use the Gazebo Rendering library to create an
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/12_mesh_viewer_tutorial.md
+++ b/tutorials/12_mesh_viewer_tutorial.md
@@ -3,7 +3,7 @@
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/12_mesh_viewer_tutorial.md
+++ b/tutorials/12_mesh_viewer_tutorial.md
@@ -1,5 +1,10 @@
 \page mesh_viewer Mesh Viewer
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/13_custom_scene_viewer.md
+++ b/tutorials/13_custom_scene_viewer.md
@@ -17,6 +17,11 @@ Some of the scenes available include:
 
 There are some scenes demonstrating reflective materials and multiple point light shadows but they appear the same in ogre because they are not supported.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/13_custom_scene_viewer.md
+++ b/tutorials/13_custom_scene_viewer.md
@@ -20,7 +20,7 @@ There are some scenes demonstrating reflective materials and multiple point ligh
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/14_camera_tracking_tutorial.md
+++ b/tutorials/14_camera_tracking_tutorial.md
@@ -2,6 +2,11 @@
 
 This example shows a camera tracking a moving target. You can use the keyboard to move the target being tracked, toggle between different tracking modes, and adjust the tracking offsets.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/14_camera_tracking_tutorial.md
+++ b/tutorials/14_camera_tracking_tutorial.md
@@ -5,7 +5,7 @@ This example shows a camera tracking a moving target. You can use the keyboard t
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/15_custom_shaders_tutorial.md
+++ b/tutorials/15_custom_shaders_tutorial.md
@@ -2,6 +2,11 @@
 
 This example shows how use custom shaders in gz-rendering to change the appearance of objects in the scene. It demonstrates two uses of shaders: The first is setting shaders for a camera and the other is setting shaders for an object in the scene.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/15_custom_shaders_tutorial.md
+++ b/tutorials/15_custom_shaders_tutorial.md
@@ -5,7 +5,7 @@ This example shows how use custom shaders in gz-rendering to change the appearan
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/17_render_pass_tutorial.md
+++ b/tutorials/17_render_pass_tutorial.md
@@ -2,6 +2,11 @@
 
 This example demonstrates the use of the render pass system for adding Gaussian noise post-processing effect to a camera.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/17_render_pass_tutorial.md
+++ b/tutorials/17_render_pass_tutorial.md
@@ -5,7 +5,7 @@ This example demonstrates the use of the render pass system for adding Gaussian 
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/18_simple_demo_tutorial.md
+++ b/tutorials/18_simple_demo_tutorial.md
@@ -2,6 +2,11 @@
 
 This example shows how move the camera automatically.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/18_simple_demo_tutorial.md
+++ b/tutorials/18_simple_demo_tutorial.md
@@ -5,7 +5,7 @@ This example shows how move the camera automatically.
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/19_text_geom_tutorial.md
+++ b/tutorials/19_text_geom_tutorial.md
@@ -2,6 +2,11 @@
 
 This example shows how to include text in the scene.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/19_text_geom_tutorial.md
+++ b/tutorials/19_text_geom_tutorial.md
@@ -5,7 +5,7 @@ This example shows how to include text in the scene.
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/20_particles_tutorial.md
+++ b/tutorials/20_particles_tutorial.md
@@ -5,7 +5,7 @@ This example shows how to include a particle emitter in the scene.
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/20_particles_tutorial.md
+++ b/tutorials/20_particles_tutorial.md
@@ -2,6 +2,11 @@
 
 This example shows how to include a particle emitter in the scene.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/21_heightmap.md
+++ b/tutorials/21_heightmap.md
@@ -4,6 +4,11 @@ This example shows how to add a heightmap to the scene.
 
 It loads 2 different heightmaps (image and Digital Elevation Model (DEM)) with different parameters.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` to compile the code:

--- a/tutorials/21_heightmap.md
+++ b/tutorials/21_heightmap.md
@@ -7,7 +7,7 @@ It loads 2 different heightmaps (image and Digital Elevation Model (DEM)) with d
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 

--- a/tutorials/22_environment_map.md
+++ b/tutorials/22_environment_map.md
@@ -9,7 +9,7 @@ map texture used by gz rendering needs to be the form of a cube map.
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Example mesh with Environment map
 

--- a/tutorials/22_environment_map.md
+++ b/tutorials/22_environment_map.md
@@ -6,6 +6,11 @@ An environment map, also known as a reflection map, is an efficient way to
 create reflective surfaces using a precomputed texture. The environment
 map texture used by gz rendering needs to be the form of a cube map.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Example mesh with Environment map
 
 An example of a mesh with an environment map can be found in the `ogre2_demo`,

--- a/tutorials/24_boundingbox_camera_tutorial.md
+++ b/tutorials/24_boundingbox_camera_tutorial.md
@@ -2,6 +2,11 @@
 
 This example shows how to use the bounding box camera.
 
+## Install prerequisites
+
+In order to compile the example in this tutorial, make sure to install the
+dependencies listed in \subpage installation tutorial.
+
 ## Compile and run the example
 
 Clone the source code, create a build directory and use `cmake` and `make` to compile the code:

--- a/tutorials/24_boundingbox_camera_tutorial.md
+++ b/tutorials/24_boundingbox_camera_tutorial.md
@@ -5,7 +5,7 @@ This example shows how to use the bounding box camera.
 ## Install prerequisites
 
 In order to compile the example in this tutorial, make sure to install the
-dependencies listed in \subpage installation tutorial.
+dependencies listed in the \subpage installation tutorial.
 
 ## Compile and run the example
 


### PR DESCRIPTION
Related: https://github.com/gazebosim/gazebo_test_cases/issues/2052

Add a note to mention that freeglut3-dev is for examples and removed freeimage from installation requirement as we no longer need it in gz-rendering
