### PR TITLE
Prevent material destruction if setting the same material to a submesh

### DIFF
--- a/include/gz/rendering/base/BaseMesh.hh
+++ b/include/gz/rendering/base/BaseMesh.hh
@@ -441,6 +441,11 @@ namespace gz
 
       this->SetMaterialImpl(_material);
 
+      // If the same material is being set, return early and don't try
+      // to destroy the material
+      if (!_unique && _material == origMaterial)
+        return;
+
       if (origMaterial && origUnique)
         this->Scene()->DestroyMaterial(origMaterial);
 

--- a/include/gz/rendering/base/BaseMesh.hh
+++ b/include/gz/rendering/base/BaseMesh.hh
@@ -308,6 +308,13 @@ namespace gz
         subMesh->SetMaterial(_material, false);
       }
 
+      // If the same material is being set, return early and don't try
+      // to destroy the material. We still need call SetMaterial on the
+      // submeshes in case the user changed some material properties
+      // before setting it back.
+      if (!_unique && _material == this->material)
+        return;
+
       if (this->material && this->ownsMaterial)
         this->Scene()->DestroyMaterial(this->material);
 
@@ -442,7 +449,9 @@ namespace gz
       this->SetMaterialImpl(_material);
 
       // If the same material is being set, return early and don't try
-      // to destroy the material
+      // to destroy the material. We still need to call SetMaterialImpl
+      // above in case the user changed some material properties
+      // before setting it back.
       if (!_unique && _material == origMaterial)
         return;
 

--- a/test/common_test/Mesh_TEST.cc
+++ b/test/common_test/Mesh_TEST.cc
@@ -81,6 +81,11 @@ TEST_F(MeshTest, MeshSubMesh)
   submesh->SetMaterial(matClone, true);
   EXPECT_NE(matClone, submesh->Material());
 
+  // Setting the same material but do not clone
+  MaterialPtr newMatClone = submesh->Material();
+  submesh->SetMaterial(newMatClone, false);
+  EXPECT_EQ(newMatClone, submesh->Material());
+
   // Clean up
   engine->DestroyScene(scene);
 }

--- a/test/common_test/Mesh_TEST.cc
+++ b/test/common_test/Mesh_TEST.cc
@@ -314,6 +314,11 @@ TEST_F(MeshTest, MeshClone)
         false);
   }
 
+  // Setting the same material but do not clone
+  MaterialPtr newMatClone = clonedMesh->Material();
+  clonedMesh->SetMaterial(newMatClone, false);
+  EXPECT_EQ(newMatClone, clonedMesh->Material());
+
   // Clean up
   engine->DestroyScene(scene);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Needed by https://github.com/gazebosim/gz-sim/pull/3085

## Summary

When `SubMesh::SetMaterial` is called with `_unique = false` (i.e. don't clone the input material),  check if the input material is the same as the original one. If so, return early and don't destroy the original material.

## To Test

```
GZ_ENGINE_TO_TEST=ogre2 ./build/gz-rendering/bin/UNIT_Mesh_TEST
```

Before the changes, the test will segfault. Now the test should pass without crashing.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
