### PR TITLE
Prepare for 10.0.0 pre2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(gz-cmake REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,15 @@
 
 1. **Baseline:** this includes all changes from 9.3.0 and earlier.
 
+1. Prevent material destruction if setting the same material to a submesh
+    * [Pull request #1168](https://github.com/gazebosim/gz-rendering/pull/1168)
+
+1. Add a note about glut dependency in installation tutorial
+    * [Pull request #1163](https://github.com/gazebosim/gz-rendering/pull/1163)
+
+1. [Bazel] Update bazel module to use jetty release branches
+    * [Pull request #1161](https://github.com/gazebosim/gz-rendering/pull/1161)
+
 1. Enable doxygen CI check on noble
     * [Pull request #1129](https://github.com/gazebosim/gz-rendering/pull/1129)
 


### PR DESCRIPTION

# 🎈 Release

Preparation for 10.0.0~pre2 release.

Comparison to 10.0.0-pre1: https://github.com/gazebosim/gz-rendering/compare/gz-rendering10_10.0.0-pre1...prep_10.0.0pre2

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
