### PR TITLE
Fix ogre2 heightmap test on metal

### DIFF
--- a/test/integration/heightmap.cc
+++ b/test/integration/heightmap.cc
@@ -349,7 +349,7 @@ TEST_F(HeightmapTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(Heightmap))
             abs(depthg - normalData[normalIdx + 1]) > largeError ||
             abs(depthb - normalData[normalIdx + 2]) > largeError)
         {
-          const uint8_t error = 9u;
+          const uint8_t error = 10u;
           EXPECT_NEAR(depthr, normalData[normalIdx + 0], error);
           EXPECT_NEAR(depthg, normalData[normalIdx + 1], error);
           EXPECT_NEAR(depthb, normalData[normalIdx + 2], error);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-rendering/issues/1174 and https://github.com/gazebosim/gz-rendering/issues/1159

## Summary

I verified locally that the ogre2 engine was able to successfully generate images on mac when running the `INTEGRATION_heightmap` test. The test failed because when comparing the colors between an image generated by a regular camera and the color component of the point cloud data generated by a depth camera, one particular pixel has a higher error than the current allowed tolerance. Fixed by increasing this error tol from `9` -> `10`.

These are the images generated:

Regular RGB image:

<img width="100" height="100" alt="Original" src="https://github.com/user-attachments/assets/51a25f0f-b204-4ff9-957f-1640542b21e3" />

Point cloud RGB data:

<img width="100" height="100" alt="DepthRgbData" src="https://github.com/user-attachments/assets/c2842998-832f-46ef-9c1e-cfc2435f3d89" />



To run the heightmap test on mac:

```sh
GZ_ENGINE_TO_TEST=ogre2 GZ_ENGINE_BACKEND=metal ./build/gz-rendering/bin/INTEGRATION_heightmap
```

The error about unable to find `metal_stdlib` in the ogre2.log (mentioned in #1159) seems to be unrelated as I see this when launching gz sim with other worlds too, e.g. shapes.sdf. It could be a different issue.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
