### PR TITLE
[bazel] Bump ogre-next dep version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,8 +7,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "egl-registry", version = "0.0.0-20250527")
 bazel_dep(name = "googletest", version = "1.15.2")
-bazel_dep(name = "libxtrans", version = "1.5.2.bcr.2")  # TODO(shameek): remove when ogre-next is next bumped. Currently needed to pull in a fix in libxtrans.
-bazel_dep(name = "ogre-next", version = "2.3.3.bcr.1")
+bazel_dep(name = "ogre-next", version = "2.3.3.bcr.2")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Update `ogre-next` dep version to 2.3.3.bcr.2, which fixes a crash when using Ogre2 render engine plugin with RGBD camera sensors.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
