### PR TITLE
Fix/optix warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if(NOT MSVC)
   #--------------------------------------
   # Find FreeImage
   gz_find_package(FreeImage VERSION 3.9
-    OPTIONAL_BY optix
+    QUIET
     PRIVATE_FOR optix)
 
   #--------------------------------------


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #1198 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
Jobs related to https://build.osrfoundation.org/job/gz_rendering-ci-gz-rendering10-noble-amd64/ and https://build.osrfoundation.org/job/gz_rendering-ci-main-noble-amd64 were building with a cmake warning because they need `libfreeimage` dependency.
I added to `.github/ci/packages.apt`
```diff
freeglut3-dev
+ libfreeimage-dev
libglew-dev
```

Another approach would be to silence warning, as some time ago was tried in `https://github.com/gazebosim/gz-rendering/pull/1032`, but I don't know if is better to silence instead of adding the dependency

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.