### PR TITLE
Manual backport of: Bazel updates: prep for BCR release automation (1196)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
 load("@rules_license//rules:license.bzl", "license")
 
@@ -94,3 +96,19 @@ test_sources = glob([
     )
     for src in test_sources
 ]
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+    no_sandbox = True,
+    workspace = "//:MODULE.bazel",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,43 +1,19 @@
-## MODULE.bazel
 module(
     name = "gz-rendering",
-    repo_name = "org_gazebosim_gz-rendering",
+    compatibility_level = 9,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1")
 bazel_dep(name = "egl-registry", version = "0.0.0-20250527")
 bazel_dep(name = "googletest", version = "1.15.2")
 bazel_dep(name = "ogre-next", version = "2.3.3.bcr.2")
-bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_cc", version = "0.2.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
 
 # Gazebo Dependencies
-bazel_dep(name = "rules_gazebo", version = "0.0.3")
-bazel_dep(name = "gz-common")
-bazel_dep(name = "gz-math")
-bazel_dep(name = "gz-plugin")
-bazel_dep(name = "gz-utils")
-
-archive_override(
-    module_name = "gz-common",
-    strip_prefix = "gz-common-gz-common6",
-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/gz-common6.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-math",
-    strip_prefix = "gz-math-gz-math8",
-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/heads/gz-math8.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-plugin",
-    strip_prefix = "gz-plugin-gz-plugin3",
-    urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/heads/gz-plugin3.tar.gz"],
-)
-
-archive_override(
-    module_name = "gz-utils",
-    strip_prefix = "gz-utils-gz-utils3",
-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/heads/gz-utils3.tar.gz"],
-)
+bazel_dep(name = "rules_gazebo", version = "0.0.6")
+bazel_dep(name = "gz-common", version = "6.2.1")
+bazel_dep(name = "gz-math", version = "8.1.1.bcr.1")
+bazel_dep(name = "gz-plugin", version = "3.1.0")
+bazel_dep(name = "gz-utils", version = "3.1.1")

--- a/bazel/gz_rendering_engine_libraries.bzl
+++ b/bazel/gz_rendering_engine_libraries.bzl
@@ -1,3 +1,7 @@
+"""
+Rules to add gz-rendering plugin libraries.
+"""
+
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 

--- a/ogre2/BUILD.bazel
+++ b/ogre2/BUILD.bazel
@@ -1,4 +1,5 @@
 # Bazel targets for Ogre2 render engine plugin.
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 load("//bazel:gz_rendering_engine_libraries.bzl", "gz_rendering_engine_libraries")
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
 package(
     default_applicable_licenses = ["//:license"],
     features = [


### PR DESCRIPTION
Manually backported to use Ionic packages for gz deps from BCR instead of Jetty deps.

-- Original PR description:
Few small fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR.

- Remove `archive_override` for gazebo package deps and use Jetty packages from BCR instead. As a result, bazel CI will use released versions of gz deps, which is consistent with cmake CI.
- Drop `repo_name`, which removes the need to patch MODULE.bazel when pushing a release to BCR. `repo_name` is not a required field and can be added on the client side during import if needed to disambiguate packages.
- Add `compatibility_level` to match [what is set in BCR](https://github.com/bazelbuild/bazel-central-registry/blob/928128b1c60e7e32d21ea8bde9fd802674eba5f3/modules/gz-rendering/10.0.0-pre2/MODULE.bazel#L4)
- Add `buildifier` linting for consistent bazel files formatting.
- Use `cc_library` and `cc_test` from `rules_cc`, rather than native rules which are [deprecated in bazel 9](https://bazel.build/about/roadmap#migration_of_android_c_java_python_and_proto_rules). The buildifier lint target added above already enforces this.
- Add module docstring for bazel/gz_rendering_engine_libraries.bzl (enforced by buildifier linting).
- Bump `rules_cc` and `rules_gazebo` to versions indicated by bazel in the [resolved build graph](https://github.com/gazebosim/gz-rendering/actions/runs/19647238647/job/56265351330?pr=1196#step:8:19).

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
