### PR TITLE
Disable test from #1109 for Windows

### DIFF
--- a/test/integration/depth_camera.cc
+++ b/test/integration/depth_camera.cc
@@ -20,6 +20,7 @@
 #include <gz/common/Console.hh>
 #include <gz/common/Filesystem.hh>
 #include <gz/common/Event.hh>
+#include <gz/utils/ExtraTestMacros.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
 
@@ -778,7 +779,8 @@ void DepthCameraTest::DepthCameraParticles(
   ignition::rendering::unloadEngine(engine->Name());
 }
 
-TEST_P(DepthCameraTest, DepthCameraBoxes)
+TEST_P(DepthCameraTest,
+  IGN_UTILS_TEST_DISABLED_ON_WIN32(DepthCameraBoxes))
 {
   DepthCameraBoxes(GetParam());
 }

--- a/test/integration/thermal_camera.cc
+++ b/test/integration/thermal_camera.cc
@@ -631,17 +631,19 @@ void ThermalCameraTest::ThermalCameraParticles(
 
 // See: https://github.com/gazebosim/gz-rendering/issues/654
 TEST_P(ThermalCameraTest,
-       IGN_UTILS_TEST_DISABLED_ON_MAC(ThermalCameraBoxesUniformTemp))
+       IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ThermalCameraBoxesUniformTemp))
 {
   ThermalCameraBoxes(GetParam(), false);
 }
 
-TEST_P(ThermalCameraTest, ThermalCameraBoxesHeatSignature)
+TEST_P(ThermalCameraTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ThermalCameraBoxesHeatSignature))
 {
   ThermalCameraBoxes(GetParam(), true);
 }
 
-TEST_P(ThermalCameraTest, ThermalCameraBoxesUniformTemp8Bit)
+TEST_P(ThermalCameraTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(ThermalCameraBoxesUniformTemp8Bit))
 {
   ThermalCameraBoxes8Bit(GetParam());
 }

--- a/test/performance/scene_factory.cc
+++ b/test/performance/scene_factory.cc
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <gz/common/Console.hh>
+#include <gz/utils/ExtraTestMacros.hh>
 
 #include "test_config.h"  // NOLINT(build/include)
 
@@ -179,13 +180,15 @@ void SceneFactoryTest::VisualMemoryLeak(const std::string &_renderEngine)
 }
 
 /////////////////////////////////////////////////
-TEST_P(SceneFactoryTest, MaterialMemoryLeak)
+TEST_P(SceneFactoryTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(MaterialMemoryLeak))
 {
   MaterialMemoryLeak(GetParam());
 }
 
 /////////////////////////////////////////////////
-TEST_P(SceneFactoryTest, VisualMemoryLeak)
+TEST_P(SceneFactoryTest,
+       IGN_UTILS_TEST_DISABLED_ON_WIN32(VisualMemoryLeak))
 {
   VisualMemoryLeak(GetParam());
 }


### PR DESCRIPTION
# 🦟 Bug fix

Disabled tests for #1109

## Summary
Disables test for Windows fortress

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

CC: @miguelgonrod
