### PR TITLE
[bazel/infra] Add manual BCR release workflow

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,22 @@
+{
+    "homepage": "https://github.com/gazebosim/gz-rendering",
+    "maintainers": [
+        {
+            "email": "iche@intrinsic.ai",
+            "github": "iche033",
+            "github_user_id": 4000684,
+            "name": "Ian Chen"
+        },
+        {
+            "email": "shameek@intrinsic.ai",
+            "github": "shameekganguly",
+            "github_user_id": 2412842,
+            "name": "Shameek Ganguly"
+        }
+    ],
+    "repository": [
+        "github:gazebosim/gz-rendering"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,18 @@
+matrix:
+  platform:
+  - ubuntu2004
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_flags:
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
+    build_targets:
+    - '@gz-rendering'

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{TAG}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,44 @@
+# Publish new releases to Bazel Central Registry.
+name: Publish to BCR
+on:
+  # For now, the workflow must be manually triggered.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: git tag being released
+        required: true
+        type: string
+jobs:
+  # The publish-to-bcr reusable workflow expects the version name to be in
+  # semver-(optional build metadata postfix) format, but the repo tags are in
+  # branch_semver-postfix format. This job extracts the branch name as a prefix
+  # to pass to publish-to-bcr.
+  extract_tag_prefix:
+    runs-on: ubuntu-latest
+    outputs:
+      prefix: ${{ steps.extract.outputs.prefix }}
+    steps:
+      - name: Extract the tag prefix from the tag name.
+        id: extract
+        run: |
+          branch=$(echo "${{ inputs.tag_name }}" | cut -d'_' -f1)
+          prefix="${branch}_"
+          echo "prefix=${prefix}" | tee -a "$GITHUB_OUTPUT"
+
+  publish:
+    needs: extract_tag_prefix
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.0.0
+    with:
+      tag_name: ${{ inputs.tag_name }}
+      # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
+      registry_fork: gazebo-forks/bazel-central-registry
+      attest: false
+      tag_prefix: ${{ needs.extract_tag_prefix.outputs.prefix }}
+
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+    secrets:
+      # Necessary to push to the BCR fork, and to open a pull request against a registry
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
# Internal tooling

## Summary
Adds the `publish.yaml` workflow to release a tag to the Bazel Central Registry (BCR). This workflow uses the official [reusable `publish-to-bcr` workflow](https://github.com/bazel-contrib/publish-to-bcr/blob/main/.github/workflows/publish.yaml) from the bazel team.

For now, the workflow must be triggered manually. Once we have iron'ed out any unforeseen issues over a few releases, we can tie it to our release automation.

The following template files are added to mirror the existing files in the [latest manual bcr release for gz-rendering](https://github.com/bazelbuild/bazel-central-registry/tree/main/modules/gz-rendering/10.0.0).
- `.bcr/metadata.template.json`
- `.bcr/presubmit.yml`
- `.bcr/source.template.json`

Some of the fields are auto-populated by `publish-to-bcr` based on the repo details when creating a PR in BCR.

Note that MODULE.bazel will be auto-patched by `publish-to-bcr` to insert the new version based on the tag e.g. tag `gz-rendering10_10.0.0` --> version `10.0.0`. This version will also be added to `metadata.json` alongside existing versions.

## Testing
This PR mirrors the BCR setup for gz-utils: https://github.com/gazebosim/gz-utils/pull/192. See testing instructions there.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.