### PR TITLE
Add check for existing renderable in Ogre2FrustumVisual and clear branch functionality

### DIFF
--- a/ogre2/src/Ogre2FrustumVisual.cc
+++ b/ogre2/src/Ogre2FrustumVisual.cc
@@ -133,27 +133,37 @@ void Ogre2FrustumVisual::ClearVisualData()
 void Ogre2FrustumVisual::Update()
 {
   GZ_PROFILE("Ogre2FrustumVisual::Update");
-  std::shared_ptr<Ogre2DynamicRenderable> renderable =
-                  std::shared_ptr<Ogre2DynamicRenderable>(
+  std::shared_ptr<Ogre2DynamicRenderable> renderable;
+  
+  // check if the renderable exists
+  if (this->dataPtr->rayLines.empty())
+  {
+    renderable = std::shared_ptr<Ogre2DynamicRenderable>(
                               new Ogre2DynamicRenderable(this->Scene()));
-  this->ogreNode->attachObject(renderable->OgreObject());
+    this->ogreNode->attachObject(renderable->OgreObject());
 
-  #if (!(OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7)))
-  // the Materials are assigned here to avoid repetitive search for materials
-  Ogre::MaterialPtr rayLineMat =
-                  Ogre::MaterialManager::getSingleton().getByName(
-                                                    "Frustum/BlueRay");
-  #endif
+    #if (!(OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7)))
+    Ogre::MaterialPtr rayLineMat =
+                    Ogre::MaterialManager::getSingleton().getByName(
+                                                      "Frustum/BlueRay");
+    #endif
 
-  #if (OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7))
-    MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
-  #else
-    MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
-  #endif
+    #if (OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7))
+      MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
+    #else
+      MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
+    #endif
 
-  renderable->SetMaterial(mat, false);
-  renderable->SetOperationType(MT_LINE_LIST);
-  this->dataPtr->rayLines.push_back(renderable);
+    renderable->SetMaterial(mat, false);
+    renderable->SetOperationType(MT_LINE_LIST);
+    this->dataPtr->rayLines.push_back(renderable);
+  }
+  else
+  {
+    // clear the existing renderable
+    renderable = this->dataPtr->rayLines.front();
+    renderable->Clear();
+  }
 
   // Tangent of half the field of view.
   double tanFOV2 = std::tan(this->hfov() * 0.5);

--- a/ogre2/src/Ogre2FrustumVisual.cc
+++ b/ogre2/src/Ogre2FrustumVisual.cc
@@ -143,6 +143,7 @@ void Ogre2FrustumVisual::Update()
     this->ogreNode->attachObject(renderable->OgreObject());
 
     #if (!(OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7)))
+    // the Materials are assigned here to avoid repetitive search for materials
     Ogre::MaterialPtr rayLineMat =
                     Ogre::MaterialManager::getSingleton().getByName(
                                                       "Frustum/BlueRay");

--- a/ogre2/src/Ogre2FrustumVisual.cc
+++ b/ogre2/src/Ogre2FrustumVisual.cc
@@ -134,7 +134,7 @@ void Ogre2FrustumVisual::Update()
 {
   GZ_PROFILE("Ogre2FrustumVisual::Update");
   std::shared_ptr<Ogre2DynamicRenderable> renderable;
-  
+
   // check if the renderable exists
   if (this->dataPtr->rayLines.empty())
   {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #1242 

## Summary
I check the rendering thread and found a Update() issue in [ogre2/src/Ogre2FrustumVisual.cc](https://github.com/gazebosim/gz-rendering/blob/a395a9527c83dffcdedb376575d80bc00c0c4661/ogre2/src/Ogre2FrustumVisual.cc#L134-L137) 
When we change the topic , this lead visualDirty flag to set true and then call `Update()`.
But in `Update()` function in [ogre2/src/Ogre2FrustumVisual.cc](https://github.com/gazebosim/gz-rendering/blob/a395a9527c83dffcdedb376575d80bc00c0c4661/ogre2/src/Ogre2FrustumVisual.cc#L134-L137) , there is no clear for existing raylines. It always new a object and push back to raylines.

In the same world
[visualize_frustum_rgb_camera.txt](https://github.com/user-attachments/files/25959551/visualize_frustum_rgb_camera.txt)
before fix : 
<img  class="aligncenter" width="348" height="314" alt="image" src="https://github.com/user-attachments/assets/4af0e5c7-f859-431c-9056-3f48600c73f6" />
after fix : 
<img width="1201" height="864" alt="image" src="https://github.com/user-attachments/assets/7776cf58-7862-462e-9f80-bf31141e0617" />
<img width="1201" height="864" alt="image" src="https://github.com/user-attachments/assets/70c9b4cc-6b18-4565-aa3c-1bf4f59efd49" />




## Checklist
- [x] Signed all commits for DCO
- [x] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
