### PR TITLE
Hide dummy OGRE render window on macOS

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -1222,6 +1222,7 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
 
   // Hide window if dimensions are less than or equal to one.
   params["border"] = "none";
+  params["hidden"] = "true";
 
   std::ostringstream stream;
   stream << "OgreWindow(0)" << "_" << _handle;
@@ -1299,10 +1300,15 @@ std::string Ogre2RenderEngine::CreateRenderWindow(const std::string &_handle,
 
   if (this->window)
   {
-    this->window->_setVisible(true);
+    // Only show and reposition the window if it was not created as a
+    // hidden dummy window (e.g. for render-to-texture initialization).
+    if (_width > 1u && _height > 1u)
+    {
+      this->window->_setVisible(true);
 
-    // Windows needs to reposition the render window to 0,0.
-    this->window->reposition(0, 0);
+      // Windows needs to reposition the render window to 0,0.
+      this->window->reposition(0, 0);
+    }
   }
   return stream.str();
 }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

On macOS, `Ogre2RenderEngine::CreateRenderWindow()` creates a 1x1 dummy window for GPU resource initialization (HLMS, compositor setup). This window appears as a visible blank "OgreWindow(0)_0" window alongside the actual Gazebo GUI. Users can close it without affecting rendering, but it shouldn't be visible in the first place.

**Before:** Blank "OgreWindow(0)_0" window appears on every Gazebo launch on macOS

**After:** Dummy window is created hidden and stays hidden

**How to reproduce (before fix):**
1. Install Gazebo Harmonic on macOS (Apple Silicon) via conda-forge/RoboStack
2. Run `gz sim -s -r shapes.sdf &` then `gz sim -g`
3. Observe blank "OgreWindow(0)_0" window alongside the Gazebo Sim GUI
4. Close the blank window — Gazebo continues rendering normally, confirming the window is unused

**Root cause:**

Two issues in `ogre2/src/Ogre2RenderEngine.cc`:

1. **Line ~1224:** The comment says "Hide window if dimensions are less than or equal to one" but only sets `params["border"] = "none"` — it never passes `params["hidden"] = "true"` to OGRE-Next. Both the Metal (`OgreMetalWindow`) and GL3Plus (`OgreOSXCocoaWindow`) backends already support this parameter.

2. **Line ~1303:** After window creation, `this->window->_setVisible(true)` unconditionally shows the window, which would override the hidden flag even if it were set.

**Changes:**

- Pass `params["hidden"] = "true"` when creating the dummy render window
- Guard `_setVisible(true)` to only apply to real render windows (`_width > 1 && _height > 1`), preventing the dummy window from being re-shown after creation

**Testing:**

- Gazebo Harmonic 8.10.0 on macOS 26 (Tahoe), Apple M4
- RoboStack/conda-forge packages via pixi
- Verified: Gazebo GUI renders 3D scene correctly, dummy window no longer appears
- Verified: Closing the dummy window (when visible) does not affect Gazebo — confirming it is unused after initialization

**Related:** Similar issue reported for RViz on Windows: https://github.com/ms-iot/ROSOnWindows/issues/336 (same OGRE dummy window pattern)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude (Anthropic)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.