### PR TITLE
Use rotary alias packages for CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,11 +1,11 @@
 freeglut3-dev
 libglew-dev
-libgz-cmake5-dev
-libgz-common7-dev
-libgz-math9-dev
-libgz-math9-eigen3-dev
-libgz-plugin4-dev
-libgz-utils4-dev
+libgz-rotary-cmake-dev
+libgz-rotary-common-dev
+libgz-rotary-math-dev
+libgz-rotary-math-eigen3-dev
+libgz-rotary-plugin-dev
+libgz-rotary-utils-dev
 libogre-1.9-dev
 libxi-dev
 libxmu-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
+          gzdev-project-name: rotary
           # codecov-enabled: true
           cppcheck-enabled: true
           cpplint-enabled: true


### PR DESCRIPTION
Use rotary alias packages for CI

Related to https://github.com/gazebo-tooling/release-tools/issues/1446