### PR TITLE
Manual backport of #1243 to gz-rendering10(Close #1247)

### DIFF
--- a/ogre2/src/Ogre2FrustumVisual.cc
+++ b/ogre2/src/Ogre2FrustumVisual.cc
@@ -131,27 +131,39 @@ void Ogre2FrustumVisual::ClearVisualData()
 //////////////////////////////////////////////////
 void Ogre2FrustumVisual::Update()
 {
-  std::shared_ptr<Ogre2DynamicRenderable> renderable =
-                  std::shared_ptr<Ogre2DynamicRenderable>(
+
+  std::shared_ptr<Ogre2DynamicRenderable> renderable;
+  
+  // check if the renderable exists
+  if (this->dataPtr->rayLines.empty())
+  {
+    renderable = std::shared_ptr<Ogre2DynamicRenderable>(
                               new Ogre2DynamicRenderable(this->Scene()));
-  this->ogreNode->attachObject(renderable->OgreObject());
+    this->ogreNode->attachObject(renderable->OgreObject());
 
-  #if (!(OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7)))
-  // the Materials are assigned here to avoid repetitive search for materials
-  Ogre::MaterialPtr rayLineMat =
-                  Ogre::MaterialManager::getSingleton().getByName(
-                                                    "Frustum/BlueRay");
-  #endif
+    #if (!(OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7)))
+    // the Materials are assigned here to avoid repetitive search for materials
+    Ogre::MaterialPtr rayLineMat =
+                    Ogre::MaterialManager::getSingleton().getByName(
+                                                      "Frustum/BlueRay");
+    #endif
 
-  #if (OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7))
-    MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
-  #else
-    MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
-  #endif
+    #if (OGRE_VERSION <= ((1 << 16) | (10 << 8) | 7))
+      MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
+    #else
+      MaterialPtr mat = this->Scene()->Material("Frustum/BlueRay");
+    #endif
 
-  renderable->SetMaterial(mat, false);
-  renderable->SetOperationType(MT_LINE_LIST);
-  this->dataPtr->rayLines.push_back(renderable);
+    renderable->SetMaterial(mat, false);
+    renderable->SetOperationType(MT_LINE_LIST);
+    this->dataPtr->rayLines.push_back(renderable);
+  }
+  else
+  {
+    // clear the existing renderable
+    renderable = this->dataPtr->rayLines.front();
+    renderable->Clear();
+  }
 
   // Tangent of half the field of view.
   double tanFOV2 = std::tan(this->hfov() * 0.5);

--- a/ogre2/src/Ogre2FrustumVisual.cc
+++ b/ogre2/src/Ogre2FrustumVisual.cc
@@ -131,9 +131,7 @@ void Ogre2FrustumVisual::ClearVisualData()
 //////////////////////////////////////////////////
 void Ogre2FrustumVisual::Update()
 {
-
   std::shared_ptr<Ogre2DynamicRenderable> renderable;
-  
   // check if the renderable exists
   if (this->dataPtr->rayLines.empty())
   {


### PR DESCRIPTION
Closes #1247 

## Summary
This is a manual backport of #1243 to the `gz-rendering10` branch. 
The conflict occurred because the `main` branch includes `GZ_PROFILE` performance profiling macros which do not exist in the `gz-rendering10` branch. 

delete macro

## Test it
Same as the original PR #1243. You can compile the branch and verify that `Update()` handles the existing renderable properly without  duplicate lines.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
**Backports:** If this is a backport, please use **Rebase and Merge** instead.