### PR TITLE
Mark RenderSystem_GL3Plus as optional on macOS

### DIFF
--- a/ogre2/src/Ogre2RenderEngine.cc
+++ b/ogre2/src/Ogre2RenderEngine.cc
@@ -658,7 +658,13 @@ void Ogre2RenderEngine::LoadPlugins()
     std::string extension = ".so";
 #endif
     std::string p = common::joinPaths(path, "RenderSystem_GL3Plus");
+#ifdef __APPLE__
+    // On macOS, Metal is the primary render system.  GL3Plus may not be
+    // available (e.g. ogre-next built without it), so mark it optional.
+    plugins.push_back({ p, true });
+#else
     plugins.push_back({ p, false });
+#endif
     p = common::joinPaths(path, "Plugin_ParticleFX");
     plugins.push_back({ p, false });
 


### PR DESCRIPTION
# 🦟 Bug fix

Related: #1107

## Summary

On macOS, Metal is the primary render system for ogre-next 2.x. GL3Plus may not be available (e.g. when ogre-next is built without the GL3Plus render system). Without this change, gz-rendering unconditionally requires the GL3Plus plugin, producing a confusing runtime error when the plugin is absent:

```
[error] Unable to find Ogre Plugin[.../lib/RenderSystem_GL3Plus].
        Rendering will not be possible.
```

### Changes

Mark the GL3Plus plugin load as optional (`bOptional = true`) on macOS so that rendering falls through to Metal when GL3Plus is not available. On other platforms, GL3Plus remains required.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Code

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.