### PR TITLE
Run more tests with ogre2

### DIFF
--- a/test/common_test/RenderTarget_TEST.cc
+++ b/test/common_test/RenderTarget_TEST.cc
@@ -58,7 +58,7 @@ TEST_F(RenderTargetTest, RenderTexture)
 /////////////////////////////////////////////////
 TEST_F(RenderTargetTest, RenderWindow)
 {
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
   ScenePtr scene = engine->CreateScene("scene");
 
@@ -94,7 +94,7 @@ TEST_F(RenderTargetTest, RenderWindow)
 TEST_F(RenderTargetTest, AddRemoveRenderPass)
 {
   CHECK_RENDERPASS_SUPPORTED();
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
   ScenePtr scene = engine->CreateScene("scene");
 

--- a/test/common_test/Scene_TEST.cc
+++ b/test/common_test/Scene_TEST.cc
@@ -53,7 +53,7 @@ TEST_F(SceneTest, Scene)
 /////////////////////////////////////////////////
 TEST_F(SceneTest, SceneGradient)
 {
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);

--- a/test/common_test/Text_TEST.cc
+++ b/test/common_test/Text_TEST.cc
@@ -31,7 +31,8 @@ class TextTest : public CommonRenderingTest
 /////////////////////////////////////////////////
 TEST_F(TextTest, Text)
 {
-  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
+  // CreateText is not implemented for ogre2 (see issue #1264)
+  CHECK_SUPPORTED_ENGINE("ogre");
 
   ScenePtr scene = engine->CreateScene("scene");
 
@@ -99,7 +100,8 @@ TEST_F(TextTest, Text)
 class FontTest : public TextTest, public testing::WithParamInterface<std::string> {};
 
 TEST_P(FontTest, SupportedFont){
-  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
+  // CreateText is not implemented for ogre2 (see issue #1264)
+  CHECK_SUPPORTED_ENGINE("ogre");
 
   ScenePtr scene = engine->CreateScene("scene");
 

--- a/test/common_test/Text_TEST.cc
+++ b/test/common_test/Text_TEST.cc
@@ -31,7 +31,7 @@ class TextTest : public CommonRenderingTest
 /////////////////////////////////////////////////
 TEST_F(TextTest, Text)
 {
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
   ScenePtr scene = engine->CreateScene("scene");
 
@@ -99,7 +99,7 @@ TEST_F(TextTest, Text)
 class FontTest : public TextTest, public testing::WithParamInterface<std::string> {};
 
 TEST_P(FontTest, SupportedFont){
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
   ScenePtr scene = engine->CreateScene("scene");
 

--- a/test/regression/reload_engine.cc
+++ b/test/regression/reload_engine.cc
@@ -221,7 +221,7 @@ TEST_F(ReloadEngineTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(ThermalCamera))
 /////////////////////////////////////////////////
 TEST_F(ReloadEngineTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(WideAngleCamera))
 {
-  CHECK_SUPPORTED_ENGINE("ogre");
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
   this->Run([](auto engine){
     auto scene = engine->CreateScene("scene");


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-rendering/issues/1235

## Summary

There are several tests that use `CHECK_SUPPORTED_ENGINE("ogre")` to only run with `ogre`, and not `ogre2`, but there are no comments about why this limitation is in place. This adds `"ogre2"` to each of these calls to see if the tests will actually pass with ogre2, and if not I will add comments explaining why.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
