### PR TITLE
Enable WireBox_TEST for ogre2

### DIFF
--- a/test/common_test/WireBox_TEST.cc
+++ b/test/common_test/WireBox_TEST.cc
@@ -32,7 +32,7 @@ class WireBoxTest : public CommonRenderingTest
 /////////////////////////////////////////////////
 TEST_F(WireBoxTest, WireBox)
 {
-  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
+  CHECK_UNSUPPORTED_ENGINE("ogre");
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);

--- a/test/common_test/WireBox_TEST.cc
+++ b/test/common_test/WireBox_TEST.cc
@@ -32,7 +32,7 @@ class WireBoxTest : public CommonRenderingTest
 /////////////////////////////////////////////////
 TEST_F(WireBoxTest, WireBox)
 {
-  CHECK_UNSUPPORTED_ENGINE("ogre", "ogre2");
+  CHECK_SUPPORTED_ENGINE("ogre", "ogre2");
 
   ScenePtr scene = engine->CreateScene("scene");
   ASSERT_NE(nullptr, scene);


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #1263 

## Summary

I just noticed that the `WireBox_TEST` is not being run for any versions of ogre. I tried enabling it both both versions of ogre in https://github.com/gazebosim/gz-rendering/pull/1267/commits/36d9532671b68abf51ab4840f01d4318ce4483ab, and it passes for `ogre2` but fails for `ogre`, so I've just enabled it for `ogre2`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
