### PR TITLE
Delete .github/ci/packages-jammy.apt

### DIFF
--- a/.github/ci/packages-jammy.apt
+++ b/.github/ci/packages-jammy.apt
@@ -1,3 +1,0 @@
-libogre-next-dev
-libogre-next-2.3-dev
-libvulkan-dev


### PR DESCRIPTION
# 🦟 Bug fix

Removes file that is not supported on this branch

## Summary

Ubuntu 22.04 CI was removed in https://github.com/gazebosim/gz-rendering/pull/1131 for Jetty, but we forgot to remove the `package-jammy.apt` configuration file, so remove it now.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
