### PR TITLE
Add version guards and replace deprecated OGRE API usages (prepare ogre-1.12)

### DIFF
--- a/ogre/include/gz/rendering/ogre/OgreIncludes.hh
+++ b/ogre/include/gz/rendering/ogre/OgreIncludes.hh
@@ -43,7 +43,11 @@
 #include <OgreRoot.h>
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
+#ifdef OGRE_VERSION_LT_1_12_0
 #include <OgreVector3.h>
+#else
+#include <OgreVector.h>
+#endif
 #include <OgreManualObject.h>
 #include <OgreMaterialManager.h>
 #include <OgreMatrix4.h>

--- a/ogre/src/CMakeLists.txt
+++ b/ogre/src/CMakeLists.txt
@@ -15,11 +15,17 @@ set(engine_name "ogre")
 
 gz_add_component(${engine_name} SOURCES ${sources} GET_TARGET_NAME ogre_target)
 
+if(OGRE_VERSION VERSION_LESS 1.10.0)
+  add_definitions(-DOGRE_VERSION_LT_1_10_0)
+endif()
 if(OGRE_VERSION VERSION_LESS 1.11.0)
   add_definitions(-DOGRE_VERSION_LT_1_11_0)
 endif()
 if(OGRE_VERSION VERSION_LESS 1.12.0)
   add_definitions(-DOGRE_VERSION_LT_1_12_0)
+endif()
+if(OGRE_VERSION VERSION_LESS 1.12.9)
+  add_definitions(-DOGRE_VERSION_LT_1_12_9)
 endif()
 
 find_package(OpenGL)

--- a/ogre/src/OgreCompat.hh
+++ b/ogre/src/OgreCompat.hh
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_RENDERING_OGRE_OGRECOMPAT_HH_
+#define GZ_RENDERING_OGRE_OGRECOMPAT_HH_
+
+// Internal-only header (not installed). Provides forward-compatible aliases
+// for OGRE 1.12.9+ APIs so the gz-rendering OGRE-1 backend can keep building
+// against the older 1.9.x system package without scattering #if-blocks at
+// every call site. The aliases shadow what 1.12.9+ already provides natively.
+
+#include "gz/rendering/ogre/OgreIncludes.hh"
+
+#ifdef OGRE_VERSION_LT_1_12_9
+namespace Ogre
+{
+  // Modern (1.12.9+) free-scope buffer-usage enum names map to the
+  // deprecated nested-scope HardwareBuffer::Usage values on older OGRE.
+  constexpr auto HBU_GPU_ONLY    = HardwareBuffer::HBU_STATIC_WRITE_ONLY;
+  constexpr auto HBU_CPU_TO_GPU  = HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY;
+}
+#endif
+
+#endif

--- a/ogre/src/OgreDistortionPass.cc
+++ b/ogre/src/OgreDistortionPass.cc
@@ -88,8 +88,7 @@ namespace gz
             setTexture(distortionTexture);
 
         // @todo Explore more efficent implementations as it is run every frame
-        Ogre::GpuProgramParametersSharedPtr params =
-            _mat->getTechnique(0)->getPass(_passId)
+        auto params = _mat->getTechnique(0)->getPass(_passId)
                      ->getFragmentProgramParameters();
         params->setNamedConstant("scale",
             Ogre::Vector3(

--- a/ogre/src/OgreDynamicRenderable.cc
+++ b/ogre/src/OgreDynamicRenderable.cc
@@ -19,6 +19,7 @@
 #include <gz/common/Profiler.hh>
 
 #include "gz/rendering/ogre/OgreDynamicRenderable.hh"
+#include "OgreCompat.hh"
 
 using namespace gz;
 using namespace rendering;
@@ -175,13 +176,13 @@ void OgreDynamicRenderable::PrepareHardwareBuffers(size_t vertexCount,
       Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
         this->mRenderOp.vertexData->vertexDeclaration->getVertexSize(0),
         this->vertexBufferCapacity,
-        Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY);
+        Ogre::HBU_CPU_TO_GPU);
 
     Ogre::HardwareVertexBufferSharedPtr cbuf =
       Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
         Ogre::VertexElement::getTypeSize(Ogre::VET_COLOUR),
         this->vertexBufferCapacity,
-        Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY);
+        Ogre::HBU_CPU_TO_GPU);
 
     // TODO(anyone): Custom HBU_?
 
@@ -231,7 +232,7 @@ void OgreDynamicRenderable::PrepareHardwareBuffers(size_t vertexCount,
         Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
           Ogre::HardwareIndexBuffer::IT_16BIT,
           this->indexBufferCapacity,
-          Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY);
+          Ogre::HBU_CPU_TO_GPU);
       // TODO(anyone): Custom HBU_?
     }
 

--- a/ogre/src/OgreGaussianNoisePass.cc
+++ b/ogre/src/OgreGaussianNoisePass.cc
@@ -67,8 +67,7 @@ namespace gz
         GZ_ASSERT(technique, "Null OGRE material technique");
         Ogre::Pass *pass = technique->getPass(_passId);
         GZ_ASSERT(pass, "Null OGRE material pass");
-        Ogre::GpuProgramParametersSharedPtr params =
-            pass->getFragmentProgramParameters();
+        auto params = pass->getFragmentProgramParameters();
 #if OGRE_VERSION_LT_1_11_0
         GZ_ASSERT(!params.isNull(), "Null OGRE material GPU parameters");
 #else

--- a/ogre/src/OgreHeightmap.cc
+++ b/ogre/src/OgreHeightmap.cc
@@ -1050,7 +1050,12 @@ void OgreHeightmap::SetupShadows(bool _enableShadows)
   matProfile = static_cast<GzTerrainMatGen::SM2Profile *>(
       matGen->getActiveProfile());
 #else
-  matProfile = static_cast<Ogre::TerrainMaterialGeneratorA::SM2Profile *>(
+  // Since OGRE 1.11 the custom GzTerrainMatGen path is disabled and
+  // CreateMaterial() installs our TerrainMaterial generator whose Profile is
+  // not an SM2Profile. Use dynamic_cast so the nullptr guard below skips the
+  // SM2Profile-only setters and avoids writing past the real Profile object
+  // (the static_cast path led to heap corruption during loadAllTerrains).
+  matProfile = dynamic_cast<Ogre::TerrainMaterialGeneratorA::SM2Profile *>(
       matGen->getActiveProfile());
 #endif
 

--- a/ogre/src/OgreHeightmap.cc
+++ b/ogre/src/OgreHeightmap.cc
@@ -1508,7 +1508,7 @@ GzTerrainMatGen::SM2Profile::ShaderHelperGLSL::generateFragmentProgram(
 
   this->defaultFpParams(_prof, _terrain, _tt, ret);
 
-  Ogre::GpuProgramParametersSharedPtr params = ret->getDefaultParameters();
+  auto params = ret->getDefaultParameters();
   params->setIgnoreMissingParams(false);
 
   Ogre::uint maxLayers = _prof->getMaxLayers(_terrain);
@@ -1892,7 +1892,7 @@ void GzTerrainMatGen::SM2Profile::ShaderHelperGLSL::defaultVpParams(
     const SM2Profile *_prof, const Ogre::Terrain *_terrain,
     TechniqueType _tt, const Ogre::HighLevelGpuProgramPtr &_prog)
 {
-  Ogre::GpuProgramParametersSharedPtr params = _prog->getDefaultParameters();
+  auto params = _prog->getDefaultParameters();
   params->setIgnoreMissingParams(true);
 
   params->setNamedAutoConstant("worldMatrix",
@@ -2768,9 +2768,12 @@ Ogre::MaterialPtr TerrainMaterial::Profile::generate(
       if (!pass->hasFragmentProgram())
         continue;
 
-      Ogre::GpuProgramParametersSharedPtr params =
-          pass->getFragmentProgramParameters();
+      auto params = pass->getFragmentProgramParameters();
+#if OGRE_VERSION_LT_1_11_0
       if (params.isNull())
+#else
+      if (!params)
+#endif
         continue;
 
       // set up shadow split points in a way that is consistent with the

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -379,8 +379,7 @@ void OgreLensFlareCompositorListenerPrivate::notifyMaterialRender(
   GZ_ASSERT(technique, "Null OGRE material technique");
   Ogre::Pass *pass = technique->getPass(static_cast<uint16_t>(_passId));
   GZ_ASSERT(pass, "Null OGRE material pass");
-  Ogre::GpuProgramParametersSharedPtr params =
-    pass->getFragmentProgramParameters();
+  auto params = pass->getFragmentProgramParameters();
 
   const Ogre::Camera *camera;
 
@@ -428,7 +427,7 @@ void OgreLensFlareCompositorListenerPrivate::notifyMaterialRender(
 
   ++this->owner.dataPtr->currentFaceIdx;
 
-  GpuProgramParametersSharedPtr psParams = pass->getFragmentProgramParameters();
+  auto psParams = pass->getFragmentProgramParameters();
 
   psParams->setNamedConstant("vpAspectRatio", camera->getAspectRatio());
   psParams->setNamedConstant("lightPos", lightPos);

--- a/ogre/src/OgreLensFlarePass.cc
+++ b/ogre/src/OgreLensFlarePass.cc
@@ -34,7 +34,11 @@
 #include <OgreGpuProgram.h>
 #include <OgrePass.h>
 #include <OgreTechnique.h>
+#ifdef OGRE_VERSION_LT_1_12_0
 #include <OgreVector3.h>
+#else
+#include <OgreVector.h>
+#endif
 #ifdef _MSC_VER
 #  pragma warning(pop)
 #endif

--- a/ogre/src/OgreMaterial.cc
+++ b/ogre/src/OgreMaterial.cc
@@ -390,15 +390,13 @@ void OgreMaterial::UpdateShaderParams()
   GZ_PROFILE("OgreMaterial::UpdateShaderParams");
   if (this->vertexShaderParams && this->vertexShaderParams->IsDirty())
   {
-    Ogre::GpuProgramParametersSharedPtr ogreParams;
-    ogreParams = this->ogrePass->getVertexProgramParameters();
+    auto ogreParams = this->ogrePass->getVertexProgramParameters();
     this->UpdateShaderParams(this->vertexShaderParams, ogreParams);
     this->vertexShaderParams->ClearDirty();
   }
   if (this->fragmentShaderParams && this->fragmentShaderParams->IsDirty())
   {
-    Ogre::GpuProgramParametersSharedPtr ogreParams;
-    ogreParams = this->ogrePass->getFragmentProgramParameters();
+    auto ogreParams = this->ogrePass->getFragmentProgramParameters();
     this->UpdateShaderParams(this->fragmentShaderParams, ogreParams);
     this->fragmentShaderParams->ClearDirty();
   }

--- a/ogre/src/OgreMesh.cc
+++ b/ogre/src/OgreMesh.cc
@@ -155,12 +155,19 @@ void OgreMesh::SetSkeletonAnimationEnabled(const std::string &_name,
   if (_enabled)
   {
     Ogre::SkeletonInstance *skel = this->ogreEntity->getSkeleton();
+#ifdef OGRE_VERSION_LT_1_11_0
     Ogre::Skeleton::BoneIterator iter = skel->getBoneIterator();
     while (iter.hasMoreElements())
     {
       Ogre::Bone* bone = iter.getNext();
       bone->setManuallyControlled(false);
     }
+#else
+    for (Ogre::Bone* bone : skel->getBones())
+    {
+      bone->setManuallyControlled(false);
+    }
+#endif
   }
 
   // update animation state
@@ -192,6 +199,7 @@ std::unordered_map<std::string, float> OgreMesh::SkeletonWeights() const
     if (!anim->hasBlendMask())
       anim->createBlendMask(skel->getNumBones());
 
+#ifdef OGRE_VERSION_LT_1_11_0
     Ogre::Skeleton::BoneIterator iter = skel->getBoneIterator();
     while (iter.hasMoreElements())
     {
@@ -199,6 +207,13 @@ std::unordered_map<std::string, float> OgreMesh::SkeletonWeights() const
       mapWeights[bone->getName()] =
           anim->getBlendMaskEntry(bone->getHandle());
     }
+#else
+    for (Ogre::Bone* bone : skel->getBones())
+    {
+      mapWeights[bone->getName()] =
+          anim->getBlendMaskEntry(bone->getHandle());
+    }
+#endif
   }
 
   return mapWeights;

--- a/ogre/src/OgreMeshFactory.cc
+++ b/ogre/src/OgreMeshFactory.cc
@@ -29,6 +29,7 @@
 
 #include "gz/rendering/ogre/OgreConversions.hh"
 #include "gz/rendering/ogre/OgreIncludes.hh"
+#include "OgreCompat.hh"
 #include "gz/rendering/ogre/OgreMesh.hh"
 #include "gz/rendering/ogre/OgreMeshFactory.hh"
 #include "gz/rendering/ogre/OgreRenderEngine.hh"
@@ -335,7 +336,7 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
       vBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
                  vertexDecl->getVertexSize(0),
                  vertexData->vertexCount,
-                 Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY,
+                 Ogre::HBU_GPU_ONLY,
                  false);
 
       if (subMesh.TexCoordCountBySet(0) > 0)
@@ -343,7 +344,7 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
         texBuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
             vertexDecl->getVertexSize(1),
             vertexData->vertexCount,
-            Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY,
+            Ogre::HBU_GPU_ONLY,
             false);
       }
 
@@ -396,7 +397,7 @@ bool OgreMeshFactory::LoadImpl(const MeshDescriptor &_desc)
         Ogre::HardwareBufferManager::getSingleton().createIndexBuffer(
             Ogre::HardwareIndexBuffer::IT_32BIT,
             ogreSubMesh->indexData->indexCount,
-            Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY,
+            Ogre::HBU_GPU_ONLY,
             false);
 
       iBuf = ogreSubMesh->indexData->indexBuffer;

--- a/ogre/src/OgreRTShaderSystem.cc
+++ b/ogre/src/OgreRTShaderSystem.cc
@@ -612,7 +612,8 @@ void OgreRTShaderSystem::ApplyShadows(OgreScenePtr _scene)
   sceneMgr->setShadowTextureCasterMaterial("PSSM/shadow_caster");
 #else
   Ogre::MaterialPtr mat =
-    Ogre::MaterialManager::getSingleton().getByName("PSSM/shadow_caster");
+    Ogre::MaterialManager::getSingleton().getByName(
+      "PSSM/shadow_caster", Ogre::RGN_DEFAULT);
   sceneMgr->setShadowTextureCasterMaterial(mat);
 #endif
 

--- a/ogre/src/OgreRTShaderSystem.cc
+++ b/ogre/src/OgreRTShaderSystem.cc
@@ -351,8 +351,12 @@ void OgreRTShaderSystem::RemoveShaders(OgreSubMesh *_subMesh)
         }
       }
 
-      this->dataPtr->shaderGenerator->removeShaderBasedTechnique(srcTechnique,
-          s->Name() + Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+      if (srcTechnique)
+      {
+        this->dataPtr->shaderGenerator->removeShaderBasedTechnique(
+            srcTechnique,
+            s->Name() + Ogre::RTShader::ShaderGenerator::DEFAULT_SCHEME_NAME);
+      }
 #endif
     }
     catch(const Ogre::Exception &e)

--- a/ogre/src/OgreRenderTarget.cc
+++ b/ogre/src/OgreRenderTarget.cc
@@ -15,23 +15,6 @@
  *
  */
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wunused-parameter"
-#else
-# pragma warning(push)
-# pragma warning(disable: 4005)
-# pragma warning(disable: 4275)
-#endif
-// leave this out of OgreIncludes as it conflicts with other files requiring
-// gl.h
-#include <OgreGLFBORenderTexture.h>
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#else
-# pragma warning(pop)
-#endif
-
 
 #include <gz/common/Console.hh>
 #include <gz/common/Profiler.hh>
@@ -440,10 +423,10 @@ unsigned int OgreRenderTexture::GLId() const
   if (!this->ogreTexture)
     return 0u;
 
-  GLuint texId;
+  unsigned int texId = 0u;
   this->ogreTexture->getCustomAttribute("GLID", &texId);
 
-  return static_cast<unsigned int>(texId);
+  return texId;
 }
 
 //////////////////////////////////////////////////

--- a/ogre/src/OgreScene.cc
+++ b/ogre/src/OgreScene.cc
@@ -718,7 +718,7 @@ bool OgreScene::InitObject(OgreObjectPtr _object, unsigned int _id,
 void OgreScene::CreateContext()
 {
   Ogre::Root *root = OgreRenderEngine::Instance()->OgreRoot();
-  this->ogreSceneManager = root->createSceneManager(Ogre::ST_GENERIC);
+  this->ogreSceneManager = root->createSceneManager("DefaultSceneManager");
 
 #if (OGRE_VERSION >= ((1 << 16) | (9 << 8) | 0))
   this->ogreSceneManager->addRenderQueueListener(

--- a/ogre/src/OgreScene.cc
+++ b/ogre/src/OgreScene.cc
@@ -33,6 +33,7 @@
 #include "gz/rendering/ogre/OgreGrid.hh"
 #include "gz/rendering/ogre/OgreHeightmap.hh"
 #include "gz/rendering/ogre/OgreIncludes.hh"
+#include "OgreCompat.hh"
 #include "gz/rendering/ogre/OgreInertiaVisual.hh"
 #include "gz/rendering/ogre/OgreJointVisual.hh"
 #include "gz/rendering/ogre/OgreLidarVisual.hh"
@@ -85,7 +86,7 @@ namespace gz
           Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
             decl->getVertexSize(this->kColorBinding),
             mRenderOp.vertexData->vertexCount,
-            Ogre::HardwareBuffer::HBU_STATIC_WRITE_ONLY);
+            Ogre::HBU_GPU_ONLY);
 
         // Bind buffer
         bind->setBinding(this->kColorBinding, vbuf);

--- a/ogre/src/OgreText.cc
+++ b/ogre/src/OgreText.cc
@@ -27,6 +27,7 @@
 #include "gz/rendering/ogre/OgreMaterial.hh"
 #include "gz/rendering/ogre/OgreScene.hh"
 #include "gz/rendering/ogre/OgreText.hh"
+#include "OgreCompat.hh"
 
 #define POS_TEX_BINDING    0
 #define COLOUR_BINDING     1
@@ -473,7 +474,7 @@ void OgreMovableText::SetupGeometry()
   ptbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
             decl->getVertexSize(POS_TEX_BINDING),
             this->renderOp.vertexData->vertexCount,
-            Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY);
+            Ogre::HBU_CPU_TO_GPU);
 
   bind->setBinding(POS_TEX_BINDING, ptbuf);
 
@@ -484,7 +485,7 @@ void OgreMovableText::SetupGeometry()
   cbuf = Ogre::HardwareBufferManager::getSingleton().createVertexBuffer(
            decl->getVertexSize(COLOUR_BINDING),
            this->renderOp.vertexData->vertexCount,
-           Ogre::HardwareBuffer::HBU_DYNAMIC_WRITE_ONLY);
+           Ogre::HBU_CPU_TO_GPU);
 
   bind->setBinding(COLOUR_BINDING, cbuf);
 

--- a/ogre/src/OgreWideAngleCamera.cc
+++ b/ogre/src/OgreWideAngleCamera.cc
@@ -637,8 +637,7 @@ void OgreWideAngleCamera::SetUniformVariables(Ogre::Pass *_pass,
     float _ratio, float _hfov)
 {
   GZ_PROFILE("OgreWideAngleCamera::SetUniformVariables");
-  Ogre::GpuProgramParametersSharedPtr uniforms =
-    _pass->getFragmentProgramParameters();
+  auto uniforms = _pass->getFragmentProgramParameters();
 
   uniforms->setNamedConstant("c1", static_cast<Ogre::Real>(
     this->Lens().C1()));
@@ -672,8 +671,7 @@ void OgreWideAngleCamera::SetUniformVariables(Ogre::Pass *_pass,
   uniforms->setNamedConstant("cutOffAngle",
     static_cast<Ogre::Real>(this->Lens().CutOffAngle()));
 
-  Ogre::GpuProgramParametersSharedPtr uniformsVs =
-    _pass->getVertexProgramParameters();
+  auto uniformsVs = _pass->getVertexProgramParameters();
 
   uniformsVs->setNamedConstant("ratio", static_cast<Ogre::Real>(_ratio));
 }


### PR DESCRIPTION
# 🎉 New feature

Part of #1281. Preparation for an ogre-1.12 migration.

## Summary

Commits are self-explanatory. The PR contains many fixes for preparing the code base to be migrated to ogre 1.12.

Forward-compatible API renames, wrapped in version guards so the tree still builds on OGRE 1.9 and 1.12. No packages.apt change. New OGRE_VERSION_LT_1_10_0 / _LT_1_11_0 / _LT_1_12_0 / _LT_1_12_9 macros are added in ogre/src/CMakeLists.txt; an internal OgreCompat.hh shim provides Ogre::HBU_GPU_ONLY / HBU_CPU_TO_GPU aliases when building against pre-1.12.9 OGRE.

Renames covered: <OgreVector3.h> → <OgreVector.h>, ST_GENERIC → "DefaultSceneManager", HBU_*_WRITE_ONLY → Ogre::HBU_GPU_ONLY / HBU_CPU_TO_GPU, getBoneIterator() → range-for over getBones(), RGN_DEFAULT group on MaterialManager::getByName, internal OgreGLFBORenderTexture.h removed; defensive dynamic_cast + null-guard in OgreHeightmap::SetupShadows; SetNormalMap extracted into a shared CreateOgreTextureFromImage helper.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Sonnet 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.