### PR TITLE
Disabled RenderingIfaceTest test for win32

### DIFF
--- a/src/RenderingIface_TEST.cc
+++ b/src/RenderingIface_TEST.cc
@@ -24,6 +24,7 @@
 #include "gz/rendering/config.hh"
 #include "gz/rendering/RenderEngine.hh"
 #include "gz/rendering/RenderingIface.hh"
+#include <gz/utils/ExtraTestMacros.hh>
 
 using namespace gz;
 using namespace rendering;
@@ -46,7 +47,7 @@ unsigned int defaultEnginesForTest()
 }
 
 /////////////////////////////////////////////////
-TEST(RenderingIfaceTest, GetEngine)
+TEST(RenderingIfaceTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(GetEngine))
 {
 #ifdef __APPLE__                                                                              
   std::cerr << "Skipping test for apple, see issue #847." << std::endl;                       

--- a/src/RenderingIface_TEST.cc
+++ b/src/RenderingIface_TEST.cc
@@ -110,7 +110,7 @@ TEST(RenderingIfaceTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(GetEngine))
 }
 
 /////////////////////////////////////////////////
-TEST(RenderingIfaceTest, RegisterEngine)
+TEST(RenderingIfaceTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(RegisterEngine))
 {
   common::Console::SetVerbosity(4);
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #1282 

## Summary
As told in the Gazebo PMC meeting, as this is fortress and windows regressions, the best approach is to disable the test

```diff
+ #include <gz/utils/ExtraTestMacros.hh>
...
- TEST(RenderingIfaceTest, GetEngine)
+ TEST(RenderingIfaceTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(GetEngine))
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)