### PR TITLE
ci.yml: test on Ubuntu 26.04 Resolute

### DIFF
--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,2 +1,0 @@
-libogre-next-2.3-dev
-libvulkan-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -7,6 +7,8 @@ libgz-rotary-math-eigen3-dev
 libgz-rotary-plugin-dev
 libgz-rotary-utils-dev
 libogre-1.9-dev
+libogre-next-2.3-dev
+libvulkan-dev
 libxi-dev
 libxmu-dev
 uuid-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,5 +1,7 @@
 freeglut3-dev
+libgl1-mesa-dev
 libglew-dev
+libglu1-mesa-dev
 libgz-rotary-cmake-dev
 libgz-rotary-common-dev
 libgz-rotary-math-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,27 @@ jobs:
     name: Ubuntu Noble CI
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
           gzdev-project-name: rotary
           # codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true
+  resolute-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Resolute CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@resolute
+        with:
+          gzdev-project-name: rotary
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <depend>libvulkan-dev</depend>
   <depend>libxi-dev</depend>
   <depend>libxmu-dev</depend>
+  <depend>opengl</depend>
   <depend>uuid</depend>
 
   <test_depend>xvfb</test_depend>


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1485

## Summary

Enable Ubuntu CI on 26.04 with the `resolute` branch of action-gz-ci. Also update actions/checkout to v6

## Test it

Verify that CI passes

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
