### PR TITLE
Depend on opengl in package.xml, packages.apt

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,5 +1,7 @@
 freeglut3-dev
+libgl1-mesa-dev
 libglew-dev
+libglu1-mesa-dev
 libgz-rotary-cmake-dev
 libgz-rotary-common-dev
 libgz-rotary-math-dev

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <depend>libvulkan-dev</depend>
   <depend>libxi-dev</depend>
   <depend>libxmu-dev</depend>
+  <depend>opengl</depend>
   <depend>uuid</depend>
 
   <test_depend>xvfb</test_depend>


### PR DESCRIPTION
# 🦟 Bug fix

Split out from https://github.com/gazebosim/gz-rendering/pull/1290

## Summary

OpenGL is a required dependency on Linux and Windows (see [gz_find_package(OpenGL REQUIRED ...)](https://github.com/gazebosim/gz-rendering/blob/a17e1ae4377aba0424322f19c9db468d493e649d/CMakeLists.txt#L63)) so list it as a dependency in the `package.xml` and add to `packages.apt` the corresponding Ubuntu packages from the [opengl rosdep key](https://github.com/ros/rosdistro/blob/3d5d28ca8f72e21d6735a2c538db2870b56a7ba2/rosdep/base.yaml#L8577-L8592).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
