### PR TITLE
fix: Use R16_UNORM as internal render format if output is PF_L16

### DIFF
--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -561,6 +561,22 @@ void Ogre2RenderTarget::DestroyTargetImpl()
 }
 
 //////////////////////////////////////////////////
+Ogre::PixelFormatGpu InternalRenderFormat(PixelFormat _format)
+{
+  switch (_format)
+  {
+    // For grey scale we render natively in grey scale format
+    // This saves CPU time later as we don't need to convert
+    // the texture.
+    case PF_L8:
+    case PF_L16:
+      return Ogre2Conversions::Convert(_format);
+    default:
+      return Ogre::PFG_RGBA8_UNORM_SRGB;
+  }
+}
+
+//////////////////////////////////////////////////
 void Ogre2RenderTarget::BuildTargetImpl()
 {
   auto engine = Ogre2RenderEngine::Instance();
@@ -586,9 +602,7 @@ void Ogre2RenderTarget::BuildTargetImpl()
 
     this->dataPtr->ogreTexture[i]->setResolution(this->width, this->height);
     this->dataPtr->ogreTexture[i]->setNumMipmaps(1u);
-    Ogre::PixelFormatGpu pf = Ogre::PFG_RGBA8_UNORM_SRGB;
-    if (this->format == PF_L16)
-      pf = Ogre::PFG_R16_UNORM;
+    const Ogre::PixelFormatGpu pf = InternalRenderFormat(this->format);
     this->dataPtr->ogreTexture[i]->setPixelFormat(pf);
 
     this->dataPtr->ogreTexture[i]->scheduleTransitionTo(

--- a/ogre2/src/Ogre2RenderTarget.cc
+++ b/ogre2/src/Ogre2RenderTarget.cc
@@ -180,6 +180,7 @@ void Ogre2RenderTarget::BuildCompositor()
             nodeDef->addTextureDefinition("rt_fsaa");
 
         msaaDef->fsaa = std::to_string(fsaa);
+        msaaDef->format = this->dataPtr->ogreTexture[0]->getPixelFormat();
 
         rtvDef->colourAttachments[0].textureName = "rt_fsaa";
         rtvDef->colourAttachments[0].resolveTextureName = "rt0";
@@ -585,7 +586,10 @@ void Ogre2RenderTarget::BuildTargetImpl()
 
     this->dataPtr->ogreTexture[i]->setResolution(this->width, this->height);
     this->dataPtr->ogreTexture[i]->setNumMipmaps(1u);
-    this->dataPtr->ogreTexture[i]->setPixelFormat(Ogre::PFG_RGBA8_UNORM_SRGB);
+    Ogre::PixelFormatGpu pf = Ogre::PFG_RGBA8_UNORM_SRGB;
+    if (this->format == PF_L16)
+      pf = Ogre::PFG_R16_UNORM;
+    this->dataPtr->ogreTexture[i]->setPixelFormat(pf);
 
     this->dataPtr->ogreTexture[i]->scheduleTransitionTo(
           Ogre::GpuResidency::Resident);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This fixes a major performance regression, if a camera uses int16 as output format. The improvement comes from skipping an expensive texture conversion inside from SRGB to INT16 by rendering native to the wanted output format.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.

