### PR TITLE
Prefer finding boost cmake config over find module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,10 @@ endif()
 
 if (OGRE_FOUND)
   # find boost - mainly needed on macOS and also by the terrain component
+  if(POLICY CMP0167)
+    # Prefer boost config supplied by package over find module
+    cmake_policy(SET CMP0167 NEW)
+  endif()
   find_package(Boost)
   if (Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/1485

## Summary

Use new behavior of [CMP0167](https://cmake.org/cmake/help/latest/policy/CMP0167.html) if available to fix a cmake warning.

### Recent build of `main`

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_rendering-ci-main-resolute-amd64&build=5)](https://build.osrfoundation.org/job/gz_rendering-ci-main-resolute-amd64/5/) https://build.osrfoundation.org/job/gz_rendering-ci-main-resolute-amd64/5/cmake/

~~~
Policy CMP0167 is not set: The FindBoost module is removed.
~~~

### Ubuntu Resolute CI of this branch

* https://github.com/gazebosim/gz-rendering/actions/runs/26304705937/job/77438385102?pr=1295#step:4:4954

no cmake warnings

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)


**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
