### PR TITLE
Persistent GPU->CPU readback to avoid duplicate copies

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -7,6 +7,15 @@ release will remove the deprecated code.
 
 ## Gazebo Rendering 10.x to 11.x
 
+
+### Optimizations
+
+* A Persistent GPU->CPU readback to avoid duplicate copies was introduced
+in [Pull request #1303](https://github.com/gazebosim/gz-rendering/pull/1303),
+although the end result is expected to be the same, it can be reverted
+in the presence of errors setting their environment variable
+`GZ_RENDERING_OGRE2_LEGACY_READBACK`.
+
 ### Removals
 
 The optix plugin has been removed due to years of inactivity. The plugin was

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -1204,7 +1204,7 @@ void Ogre2DepthCamera::PostRender()
   if (!this->dataPtr->depthBuffer)
     this->dataPtr->depthBuffer = new float[len * channelCount];
   if (!this->dataPtr->depthImage)
-    this->dataPtr->depthImage = new float[len];
+    this->dataPtr->depthImage = new float[len * channelCount];
 
   if (Ogre2UseLegacyReadback())
   {

--- a/ogre2/src/Ogre2DepthCamera.cc
+++ b/ogre2/src/Ogre2DepthCamera.cc
@@ -41,6 +41,7 @@
 #include "gz/rendering/ogre2/Ogre2Scene.hh"
 #include "gz/rendering/ogre2/Ogre2Sensor.hh"
 
+#include "Ogre2GpuReadbackTicket.hh"
 #include "Ogre2ParticleNoiseListener.hh"
 
 #ifdef _MSC_VER
@@ -100,6 +101,10 @@ class gz::rendering::Ogre2DepthCameraPrivate
 
   /// \brief Outgoing depth data, used by newDepthFrame event.
   public: float *depthImage = nullptr;
+
+  /// \brief Persistent GPU->CPU readback ticket used by the non-legacy
+  /// PostRender path.
+  public: Ogre2GpuReadbackTicket depthReadback;
 
   /// \brief maximum value used for data outside sensor range
   public: float dataMaxVal = gz::math::INF_D;
@@ -304,6 +309,7 @@ void Ogre2DepthCamera::Init()
 void Ogre2DepthCamera::Destroy()
 {
   this->RemoveAllRenderPasses();
+  this->dataPtr->depthReadback.Destroy();
 
   if (this->dataPtr->depthBuffer)
   {
@@ -1158,6 +1164,30 @@ void Ogre2DepthCamera::PreRender()
   this->dataPtr->renderPassDirty = false;
 }
 
+namespace
+{
+  /// \brief Copy one mapped RGBA32 readback box into the persistent depth
+  /// buffers in a single stride-aware pass: the full RGBA row into
+  /// _depthBuffer (point cloud + DepthData()) and channel 0 into _depthImage
+  /// (depth frame). Honors _box.bytesPerRow as the source stride.
+  void FillDepthBuffers(const Ogre::TextureBox &_box,
+      float *_depthBuffer, float *_depthImage,
+      unsigned int _width, unsigned int _height,
+      unsigned int _channelCount, unsigned int _bytesPerChannel)
+  {
+    const float *src = static_cast<const float *>(_box.data);
+    for (unsigned int i = 0; i < _height; ++i)
+    {
+      const unsigned int rawRowIdx = i * _box.bytesPerRow / _bytesPerChannel;
+      const unsigned int rowIdx = i * _width * _channelCount;
+      memcpy(&_depthBuffer[rowIdx], &src[rawRowIdx],
+          _width * _channelCount * _bytesPerChannel);
+      for (unsigned int j = 0; j < _width; ++j)
+        _depthImage[i * _width + j] = src[rawRowIdx + j * _channelCount];
+    }
+  }
+}  // namespace
+
 //////////////////////////////////////////////////
 void Ogre2DepthCamera::PostRender()
 {
@@ -1171,40 +1201,59 @@ void Ogre2DepthCamera::PostRender()
   unsigned int channelCount = PixelUtil::ChannelCount(format);
   unsigned int bytesPerChannel = PixelUtil::BytesPerChannel(format);
 
-  Ogre::Image2 image;
-  image.convertFromTexture(this->dataPtr->ogreDepthTexture[1], 0u, 0u);
-  Ogre::TextureBox box = image.getData(0);
-  float *depthBufferTmp = static_cast<float *>(box.data);
   if (!this->dataPtr->depthBuffer)
-  {
     this->dataPtr->depthBuffer = new float[len * channelCount];
-  }
-
-  // copy data row by row. The texture box may not be a contiguous region of
-  // a texture
-  for (unsigned int i = 0; i < height; ++i)
-  {
-    unsigned int rawDataRowIdx = i * box.bytesPerRow / bytesPerChannel;
-    unsigned int rowIdx = i * width * channelCount;
-    memcpy(&this->dataPtr->depthBuffer[rowIdx], &depthBufferTmp[rawDataRowIdx],
-        width * channelCount * bytesPerChannel);
-  }
-
   if (!this->dataPtr->depthImage)
-  {
     this->dataPtr->depthImage = new float[len];
-  }
 
-  // fill depth data
-  for (unsigned int i = 0; i < height; ++i)
+  if (Ogre2UseLegacyReadback())
   {
-    unsigned int step = i*width*channelCount;
-    for (unsigned int j = 0; j < width; ++j)
+    // Legacy A/B control: original Ogre::Image2 path, kept verbatim.
+    Ogre::Image2 image;
+    image.convertFromTexture(this->dataPtr->ogreDepthTexture[1], 0u, 0u);
+    Ogre::TextureBox box = image.getData(0);
+    float *depthBufferTmp = static_cast<float *>(box.data);
+
+    // copy data row by row. The texture box may not be a contiguous region of
+    // a texture
+    for (unsigned int i = 0; i < height; ++i)
     {
-      float x = this->dataPtr->depthBuffer[step + j*channelCount];
-      this->dataPtr->depthImage[i*width + j] = x;
+      unsigned int rawDataRowIdx = i * box.bytesPerRow / bytesPerChannel;
+      unsigned int rowIdx = i * width * channelCount;
+      memcpy(&this->dataPtr->depthBuffer[rowIdx],
+          &depthBufferTmp[rawDataRowIdx],
+          width * channelCount * bytesPerChannel);
+    }
+
+    // fill depth data
+    for (unsigned int i = 0; i < height; ++i)
+    {
+      unsigned int step = i*width*channelCount;
+      for (unsigned int j = 0; j < width; ++j)
+      {
+        float x = this->dataPtr->depthBuffer[step + j*channelCount];
+        this->dataPtr->depthImage[i*width + j] = x;
+      }
     }
   }
+  else
+  {
+    // Persistent-ticket path: map the staging buffer once and copy straight
+    // into the persistent buffers in a single fused pass.
+    Ogre::TextureBox box = this->dataPtr->depthReadback.DownloadAndMap(
+        this->dataPtr->ogreDepthTexture[1]);
+    if (!box.data)
+    {
+      gzerr << "Ogre2DepthCamera: GPU readback failed; dropping frame"
+            << std::endl;
+      return;
+    }
+    FillDepthBuffers(box, this->dataPtr->depthBuffer,
+        this->dataPtr->depthImage, width, height, channelCount,
+        bytesPerChannel);
+    this->dataPtr->depthReadback.Unmap();
+  }
+
   this->dataPtr->newDepthFrame(
         this->dataPtr->depthImage, width, height, 1, "FLOAT32");
 
@@ -1214,49 +1263,7 @@ void Ogre2DepthCamera::PostRender()
     this->dataPtr->newRgbPointCloud(
         this->dataPtr->depthBuffer, width, height, channelCount,
         "PF_FLOAT32_RGBA");
-
-    // Uncomment to debug color output
-    // for (unsigned int i = 0; i < height; ++i)
-    // {
-    //   unsigned int step = i*width*channelCount;
-    //   for (unsigned int j = 0; j < width; ++j)
-    //   {
-    //     float color =
-    //         this->dataPtr->depthBuffer[step + j*channelCount + 3];
-    //     // unpack rgb data
-    //     uint32_t *rgba = reinterpret_cast<uint32_t *>(&color);
-    //     unsigned int r = *rgba >> 24 & 0xFF;
-    //     unsigned int g = *rgba >> 16 & 0xFF;
-    //     unsigned int b = *rgba >> 8 & 0xFF;
-    //     gzdbg << "[" << r << "]" << "[" << g << "]" << "[" << b << "],";
-    //   }
-    //   gzdbg << std::endl;
-    // }
-
-    // Uncomment to debug xyz output
-    // gzdbg << "wxh: " << width << " x " << height << std::endl;
-    // for (unsigned int i = 0; i < height; ++i)
-    // {
-    //   for (unsigned int j = 0; j < width; ++j)
-    //   {
-    //     gzdbg << "[" << this->dataPtr->depthBuffer[i*width*4+j*4] << "]"
-    //       << "[" << this->dataPtr->depthBuffer[i*width*4+j*4+1] << "]"
-    //       << "[" << this->dataPtr->depthBuffer[i*width*4+j*4+2] << "],";
-    //   }
-    //   gzdbg << std::endl;
-    // }
   }
-
-  // Uncomment to debug depth output
-  // gzdbg << "wxh: " << width << " x " << height << std::endl;
-  // for (unsigned int i = 0; i < height; ++i)
-  // {
-  //   for (unsigned int j = 0; j < width; ++j)
-  //   {
-  //     gzdbg << "[" << this->dataPtr->depthImage[i*width + j] << "]";
-  //   }
-  //   gzdbg << std::endl;
-  // }
 }
 
 //////////////////////////////////////////////////

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -587,6 +587,8 @@ void Ogre2GpuRays::Init()
 //////////////////////////////////////////////////
 void Ogre2GpuRays::Destroy()
 {
+  this->dataPtr->gpuRaysReadback.Destroy();
+
   if (!this->dataPtr->ogreCamera)
     return;
 
@@ -595,7 +597,6 @@ void Ogre2GpuRays::Destroy()
     delete [] this->dataPtr->gpuRaysScan;
     this->dataPtr->gpuRaysScan = nullptr;
   }
-  this->dataPtr->gpuRaysReadback.Destroy();
 
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();

--- a/ogre2/src/Ogre2GpuRays.cc
+++ b/ogre2/src/Ogre2GpuRays.cc
@@ -60,6 +60,8 @@
   #pragma warning(pop)
 #endif
 
+#include "Ogre2GpuReadbackTicket.hh"
+
 namespace gz
 {
 namespace rendering
@@ -132,6 +134,10 @@ class GZ_RENDERING_OGRE2_HIDDEN gz::rendering::Ogre2GpuRaysPrivate
 
   /// \brief Outgoing gpu rays data, used by newGpuRaysFrame event.
   public: float *gpuRaysScan = nullptr;
+
+  /// \brief Persistent GPU->CPU readback ticket used by the non-legacy
+  /// PostRender path.
+  public: Ogre2GpuReadbackTicket gpuRaysReadback;
 
   /// \brief Cubemap camera
   public: Ogre::Camera *cubeCam{nullptr};
@@ -589,6 +595,7 @@ void Ogre2GpuRays::Destroy()
     delete [] this->dataPtr->gpuRaysScan;
     this->dataPtr->gpuRaysScan = nullptr;
   }
+  this->dataPtr->gpuRaysReadback.Destroy();
 
   auto engine = Ogre2RenderEngine::Instance();
   auto ogreRoot = engine->OgreRoot();
@@ -1300,6 +1307,33 @@ void Ogre2GpuRays::PreRender()
   }
 }
 
+namespace
+{
+  /// \brief Copy one mapped RGBA32 readback box into the RGB scan buffer
+  /// (drops alpha) in a single stride-aware pass. Honors _box.bytesPerRow.
+  void FillGpuRaysScan(const Ogre::TextureBox &_box, float *_scan,
+      unsigned int _width, unsigned int _height,
+      unsigned int _channels, unsigned int _rawChannelCount,
+      unsigned int _bytesPerChannel)
+  {
+    const float *src = static_cast<const float *>(_box.data);
+    for (unsigned int row = 0; row < _height; ++row)
+    {
+      const unsigned int rawDataRowIdx =
+          row * _box.bytesPerRow / _bytesPerChannel;
+      const unsigned int rowIdx = row * _width * _channels;
+      for (unsigned int column = 0; column < _width; ++column)
+      {
+        const unsigned int idx = rowIdx + column * _channels;
+        const unsigned int rawIdx = rawDataRowIdx + column * _rawChannelCount;
+        _scan[idx] = src[rawIdx];
+        _scan[idx + 1] = src[rawIdx + 1];
+        _scan[idx + 2] = src[rawIdx + 2];
+      }
+    }
+  }
+}  // namespace
+
 //////////////////////////////////////////////////
 void Ogre2GpuRays::PostRender()
 {
@@ -1311,12 +1345,6 @@ void Ogre2GpuRays::PostRender()
   unsigned int rawChannelCount = PixelUtil::ChannelCount(format);
   unsigned int bytesPerChannel = PixelUtil::BytesPerChannel(format);
 
-  // blit data from gpu to cpu
-  Ogre::Image2 image;
-  image.convertFromTexture(this->dataPtr->secondPassTexture, 0u, 0u);
-  Ogre::TextureBox box = image.getData(0u);
-  float *bufferTmp = static_cast<float *>(box.data);
-
   // Metal does not support RGB32_FLOAT so the internal texture format is
   // RGBA32_FLOAT. For backward compatibility, output data is kept in RGB
   // format instead of RGBA
@@ -1326,23 +1354,43 @@ void Ogre2GpuRays::PostRender()
     this->dataPtr->gpuRaysScan = new float[outputLen];
   }
 
-  // copy data from RGBA buffer to RGB buffer
-  for (unsigned int row = 0; row < height; ++row)
+  if (Ogre2UseLegacyReadback())
   {
-    unsigned int rawDataRowIdx = row * box.bytesPerRow / bytesPerChannel;
-    unsigned int rowIdx = row * width * this->Channels();
+    // Legacy A/B control: original Ogre::Image2 path, kept verbatim.
+    Ogre::Image2 image;
+    image.convertFromTexture(this->dataPtr->secondPassTexture, 0u, 0u);
+    Ogre::TextureBox box = image.getData(0u);
+    float *bufferTmp = static_cast<float *>(box.data);
 
-    // the texture box step size could be larger than our image buffer step
-    // size
-    for (unsigned int column = 0; column < width; ++column)
+    // copy data from RGBA buffer to RGB buffer
+    for (unsigned int row = 0; row < height; ++row)
     {
-      unsigned int idx = rowIdx + column * this->Channels();
-      unsigned int rawIdx = rawDataRowIdx + column * rawChannelCount;
-
-      this->dataPtr->gpuRaysScan[idx] = bufferTmp[rawIdx];
-      this->dataPtr->gpuRaysScan[idx + 1] = bufferTmp[rawIdx + 1];
-      this->dataPtr->gpuRaysScan[idx + 2] = bufferTmp[rawIdx + 2];
+      unsigned int rawDataRowIdx = row * box.bytesPerRow / bytesPerChannel;
+      unsigned int rowIdx = row * width * this->Channels();
+      for (unsigned int column = 0; column < width; ++column)
+      {
+        unsigned int idx = rowIdx + column * this->Channels();
+        unsigned int rawIdx = rawDataRowIdx + column * rawChannelCount;
+        this->dataPtr->gpuRaysScan[idx] = bufferTmp[rawIdx];
+        this->dataPtr->gpuRaysScan[idx + 1] = bufferTmp[rawIdx + 1];
+        this->dataPtr->gpuRaysScan[idx + 2] = bufferTmp[rawIdx + 2];
+      }
     }
+  }
+  else
+  {
+    // Persistent-ticket path: map the staging buffer once and repack RGBA->RGB
+    // in a single fused pass.
+    Ogre::TextureBox box = this->dataPtr->gpuRaysReadback.DownloadAndMap(
+        this->dataPtr->secondPassTexture);
+    if (!box.data)
+    {
+      gzerr << "Ogre2GpuRays: GPU readback failed; dropping frame" << std::endl;
+      return;
+    }
+    FillGpuRaysScan(box, this->dataPtr->gpuRaysScan, width, height,
+        this->Channels(), rawChannelCount, bytesPerChannel);
+    this->dataPtr->gpuRaysReadback.Unmap();
   }
 
   this->dataPtr->newGpuRaysFrame(this->dataPtr->gpuRaysScan,

--- a/ogre2/src/Ogre2GpuReadbackTicket.cc
+++ b/ogre2/src/Ogre2GpuReadbackTicket.cc
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "Ogre2GpuReadbackTicket.hh"
+
+#include <cstdlib>
+
+#include "gz/rendering/ogre2/Ogre2RenderEngine.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgreRoot.h>
+#include <OgreRenderSystem.h>
+#include <OgreTextureGpu.h>
+#include <OgreTextureGpuManager.h>
+#include <OgreAsyncTextureTicket.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
+using namespace gz;
+using namespace rendering;
+
+//////////////////////////////////////////////////
+/// \brief Fetch the active OGRE texture manager, or nullptr if unavailable.
+static Ogre::TextureGpuManager *ReadbackTextureManager()
+{
+  auto engine = Ogre2RenderEngine::Instance();
+  if (!engine)
+    return nullptr;
+  auto ogreRoot = engine->OgreRoot();
+  if (!ogreRoot || !ogreRoot->getRenderSystem())
+    return nullptr;
+  return ogreRoot->getRenderSystem()->getTextureGpuManager();
+}
+
+//////////////////////////////////////////////////
+Ogre2GpuReadbackTicket::~Ogre2GpuReadbackTicket()
+{
+  this->Destroy();
+}
+
+//////////////////////////////////////////////////
+void Ogre2GpuReadbackTicket::Destroy()
+{
+  if (!this->ticket)
+    return;
+
+  if (this->mapped)
+  {
+    this->ticket->unmap();
+    this->mapped = false;
+  }
+
+  auto textureMgr = ReadbackTextureManager();
+  if (textureMgr)
+    textureMgr->destroyAsyncTextureTicket(this->ticket);
+
+  this->ticket = nullptr;
+  this->width = 0u;
+  this->height = 0u;
+  this->format = Ogre::PFG_UNKNOWN;
+}
+
+//////////////////////////////////////////////////
+Ogre::TextureBox Ogre2GpuReadbackTicket::DownloadAndMap(
+    Ogre::TextureGpu *_texture)
+{
+  Ogre::TextureBox box;  // default-constructed: data == nullptr
+  if (!_texture)
+    return box;
+
+  auto textureMgr = ReadbackTextureManager();
+  if (!textureMgr)
+    return box;
+
+  const unsigned int w = _texture->getWidth();
+  const unsigned int h = _texture->getHeight();
+  const Ogre::PixelFormatGpu fmt = _texture->getPixelFormat();
+
+  // (Re)create the ticket on first use or when the geometry/format changed.
+  if (!this->ticket || this->width != w || this->height != h ||
+      this->format != fmt)
+  {
+    if (this->ticket)
+    {
+      if (this->mapped)
+      {
+        this->ticket->unmap();
+        this->mapped = false;
+      }
+      textureMgr->destroyAsyncTextureTicket(this->ticket);
+      this->ticket = nullptr;
+    }
+    this->ticket = textureMgr->createAsyncTextureTicket(
+        w, h, 1u, Ogre::TextureTypes::Type2D, fmt);
+    this->width = w;
+    this->height = h;
+    this->format = fmt;
+  }
+
+  if (!this->ticket)
+    return box;
+
+  // Blocking download (accurateTracking=true): map() waits on the fence.
+  this->ticket->download(_texture, 0u, true);
+  box = this->ticket->map(0u);
+  this->mapped = true;
+  return box;
+}
+
+//////////////////////////////////////////////////
+void Ogre2GpuReadbackTicket::Unmap()
+{
+  if (this->ticket && this->mapped)
+  {
+    this->ticket->unmap();
+    this->mapped = false;
+  }
+}
+
+//////////////////////////////////////////////////
+bool gz::rendering::Ogre2UseLegacyReadback()
+{
+  static const bool legacy =
+      (std::getenv("GZ_RENDERING_OGRE2_LEGACY_READBACK") != nullptr);
+  return legacy;
+}

--- a/ogre2/src/Ogre2GpuReadbackTicket.cc
+++ b/ogre2/src/Ogre2GpuReadbackTicket.cc
@@ -18,6 +18,8 @@
 
 #include <cstdlib>
 
+#include <gz/common/Console.hh>
+
 #include "gz/rendering/ogre2/Ogre2RenderEngine.hh"
 
 #ifdef _MSC_VER
@@ -69,6 +71,9 @@ void Ogre2GpuReadbackTicket::Destroy()
   auto textureMgr = ReadbackTextureManager();
   if (textureMgr)
     textureMgr->destroyAsyncTextureTicket(this->ticket);
+  else
+    gzwarn << "Ogre2GpuReadbackTicket::Destroy() called after engine "
+              "teardown; ticket staging buffer leaked." << std::endl;
 
   this->ticket = nullptr;
   this->width = 0u;
@@ -115,6 +120,14 @@ Ogre::TextureBox Ogre2GpuReadbackTicket::DownloadAndMap(
 
   if (!this->ticket)
     return box;
+
+  if (this->mapped)
+  {
+    gzwarn << "Ogre2GpuReadbackTicket::DownloadAndMap() called while still "
+              "mapped; unmapping previous frame first." << std::endl;
+    this->ticket->unmap();
+    this->mapped = false;
+  }
 
   // Blocking download (accurateTracking=true): map() waits on the fence.
   this->ticket->download(_texture, 0u, true);

--- a/ogre2/src/Ogre2GpuReadbackTicket.hh
+++ b/ogre2/src/Ogre2GpuReadbackTicket.hh
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#ifndef GZ_RENDERING_OGRE2_OGRE2GPUREADBACKTICKET_HH_
+#define GZ_RENDERING_OGRE2_OGRE2GPUREADBACKTICKET_HH_
+
+#include "gz/rendering/config.hh"
+
+#ifdef _MSC_VER
+  #pragma warning(push, 0)
+#endif
+#include <OgrePixelFormatGpu.h>
+#include <OgreTextureBox.h>
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
+
+namespace Ogre
+{
+  class AsyncTextureTicket;
+  class TextureGpu;
+}
+
+namespace gz
+{
+  namespace rendering
+  {
+    inline namespace GZ_RENDERING_VERSION_NAMESPACE {
+    //
+    /// \brief Reusable GPU->CPU texture readback backed by a single, persistent
+    /// Ogre::AsyncTextureTicket. Unlike Ogre::Image2::convertFromTexture (which
+    /// allocates a fresh staging buffer + ticket and an extra copy every call),
+    /// this keeps one ticket and maps its staging memory directly, so callers
+    /// copy once straight into their own persistent buffer.
+    /// Render-thread use only; NOT thread-safe.
+    class Ogre2GpuReadbackTicket
+    {
+      /// \brief Destructor; destroys the persistent ticket if still alive.
+      public: ~Ogre2GpuReadbackTicket();
+
+      /// \brief Issue a blocking GPU->CPU download of \p _texture (mip 0,
+      /// slice 0) into the persistent ticket and map it for reading. The
+      /// ticket is lazily created and recreated whenever the texture's
+      /// width/height/pixel-format changes. The caller MUST read the data out
+      /// honoring TextureBox::bytesPerRow and then call Unmap() before the next
+      /// frame's DownloadAndMap().
+      /// \param[in] _texture Source GPU texture.
+      /// \return Mapped TextureBox; box.data is nullptr on failure.
+      public: Ogre::TextureBox DownloadAndMap(Ogre::TextureGpu *_texture);
+
+      /// \brief Unmap the ticket previously mapped by DownloadAndMap().
+      /// Safe to call when nothing is mapped.
+      public: void Unmap();
+
+      /// \brief Destroy the persistent ticket now. Call from the owner's
+      /// Destroy() while the render engine (and its texture manager) is still
+      /// alive, ahead of engine teardown.
+      public: void Destroy();
+
+      /// \brief The persistent ticket, or nullptr before first use / after
+      /// Destroy().
+      private: Ogre::AsyncTextureTicket *ticket{nullptr};
+
+      /// \brief Cached ticket geometry; a change forces recreation.
+      private: unsigned int width{0u};
+
+      /// \brief Cached ticket height; see width.
+      private: unsigned int height{0u};
+
+      /// \brief Cached ticket pixel format; see width.
+      private: Ogre::PixelFormatGpu format{Ogre::PFG_UNKNOWN};
+
+      /// \brief True while the ticket is currently mapped.
+      private: bool mapped{false};
+    };
+
+    /// \brief Whether to use the legacy Ogre::Image2::convertFromTexture
+    /// readback path instead of the persistent-ticket path. True iff the env
+    /// var GZ_RENDERING_OGRE2_LEGACY_READBACK is set. Evaluated once.
+    /// \return true to use the legacy path.
+    bool Ogre2UseLegacyReadback();
+    }
+  }
+}
+#endif

--- a/ogre2/src/Ogre2GpuReadbackTicket.hh
+++ b/ogre2/src/Ogre2GpuReadbackTicket.hh
@@ -88,7 +88,7 @@ namespace gz
     };
 
     /// \brief Whether to use the legacy Ogre::Image2::convertFromTexture
-    /// readback path instead of the persistent-ticket path. True iff the env
+    /// readback path instead of the persistent-ticket path. True if the env
     /// var GZ_RENDERING_OGRE2_LEGACY_READBACK is set. Evaluated once.
     /// \todo Deprecate this temporary fallback env var in Gazebo N /
     /// gz-rendering12, then remove it in Gazebo O / gz-rendering13. If the new

--- a/ogre2/src/Ogre2GpuReadbackTicket.hh
+++ b/ogre2/src/Ogre2GpuReadbackTicket.hh
@@ -90,6 +90,9 @@ namespace gz
     /// \brief Whether to use the legacy Ogre::Image2::convertFromTexture
     /// readback path instead of the persistent-ticket path. True iff the env
     /// var GZ_RENDERING_OGRE2_LEGACY_READBACK is set. Evaluated once.
+    /// \todo Deprecate this temporary fallback env var in Gazebo N /
+    /// gz-rendering12, then remove it in Gazebo O / gz-rendering13. If the new
+    /// readback path works well, remove it in Gazebo N / gz-rendering12.
     /// \return true to use the legacy path.
     bool Ogre2UseLegacyReadback();
     }


### PR DESCRIPTION
# 🎉 New feature

## Summary

`Ogre2DepthCamera::PostRender()` and `Ogre2GpuRays::PostRender()` read the GPU render target back to CPU memory every frame through `Ogre::Image2::convertFromTexture`. That convenience call hides a wasteful per-frame pattern: it allocates a fresh ~4.9 MB CPU buffer, spins up a throwaway `AsyncTextureTicket`, does the blocking GPU→CPU download, `memcpy`s the staging buffer into the `Image2`, then frees the ticket — after which gz **re-copies** the whole buffer into its persistent member buffer, and the depth camera makes a **third** per-pixel pass to extract channel 0.

This PR introduces a small reusable helper, **`Ogre2GpuReadbackTicket`**, that keeps **one persistent `AsyncTextureTicket`** alive across frames, maps its staging memory, and lets the caller copy **once** in a single stride-aware pass (fusing the depth camera's channel-0 extraction into that same copy). Per camera per frame this goes from *(1 malloc/free + 2 full memcpys + 1 extraction pass)* to *(0 allocations + 1 fused pass)*.

### Interactive rich explanation

I've asked the AI agents to create an easy-to-understand explanation of the changes, I think worth it to give it a look https://j-rivero.github.io/gz-rendering-pipeline/gz_readback_dedup.html

## Rollout / opt-out

The new path is **on by default**. Setting `GZ_RENDERING_OGRE2_LEGACY_READBACK=1` restores the original `convertFromTexture` path verbatim — kept in-tree as a faithful A/B control and a safety hatch. (It can be removed in a later cleanup once the new path has soaked.)

## Performance

Measured on an RTX 4060 Ti / 16-core box, 640×480 RGBD cameras, `new` (default) vs `legacy` (`GZ_RENDERING_OGRE2_LEGACY_READBACK=1`). Single A/B run each — direction is consistent; treat the exact percentages as indicative.

**Default backend (OpenGL / GL3Plus — the gz-rendering ogre2 default):**

| Scenario | Legacy | New | Δ |
|---|---|---|---|
| 16 cams, saturated, headless | 11.55 Hz/cam | **12.73 Hz/cam** | **+10.2% throughput** |
| 8 cams, 15 Hz cap, GUI | 15.15 Hz/cam @ 148% core | 15.15 Hz/cam @ **140% core** | same FPS, **~5% less server CPU** |

**Both backends (8 cams, uncapped, GUI; active `RenderSystem` confirmed in the log):**

| Backend | Legacy | New | Δ (the fix) |
|---|---|---|---|
| OpenGL (GL3Plus) | 23.59 Hz/cam | **26.94 Hz/cam** | **+14.2%** |
| Vulkan | 26.02 Hz/cam | **27.26 Hz/cam** | **+4.8%** |

The optimization helps on **both** backends — it operates through OGRE-Next's `AsyncTextureTicket`/`convertFromTexture` abstraction over the active render system. Vulkan's *legacy* staging path is already ~10% faster than OpenGL's, so the redundant-copy removal has less headroom to recover there (smaller Δ); after the fix both backends converge to ~27 Hz/cam. Across all runs serverCPU stays ~190–200% and GPU ~33%, confirming the bottleneck removed is CPU-side memory bandwidth, not the GPU. When frame rate is capped the same saving appears as lower CPU for identical output instead of higher throughput.

## Follow-ups (out of scope)

Extend the helper to the other readback sites that still use `convertFromTexture`  (thermal, segmentation, bounding-box, wide-angle, selection buffer) and the regular camera's `copyContentsToMemory`.

## Test it

By manual look into gz-sim:

https://github.com/user-attachments/assets/6d3dc406-e572-49e8-806c-937af80e2d04

By an agent instructed to do the checks:

- **Byte-identical output** verified via header-stripped data-md5 oracles on a static
  scene, for **both** the new and legacy paths:
  - depth: image / depth / point-cloud md5s match the unmodified baseline;
  - gpu rays: scan md5 matches the unmodified baseline.
  - Oracle sensitivity confirmed (a deliberately perturbed copy → MISMATCH).
  - **Verified on both backends.** OpenGL: new/legacy match the baseline. Vulkan:  new and legacy match each other on depth/points/image (internal A/B). The Vulkan capture's depth/points differ from the OpenGL render — proving the Vulkan backend  was genuinely active, not a silent GL fallback — while new==legacy still holds within the backend.
- `INTEGRATION_depth_camera` (ogre2): 4/4 pass.
- `INTEGRATION_gpu_rays_ogre2`: 2/2 pass.
- **No leak:** RSS over a 25 s soak shows 0 kB growth (ticket is reused, not reallocated).

## Backport Policy

Changes seems to be API/ABI compatible to me so I don't see any reason not to backport the improvement to other releases. If we consider it risky, the feature could be shipped OFF by default.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.8

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.