### PR TITLE
Remove unused gz/common/Profiler.hh include in Ogre2Scene.cc

### DIFF
--- a/ogre2/src/Ogre2Scene.cc
+++ b/ogre2/src/Ogre2Scene.cc
@@ -30,7 +30,6 @@
 #endif
 
 #include <gz/common/Console.hh>
-#include <gz/common/Profiler.hh>
 #include <gz/common/Util.hh>
 
 #include "gz/rendering/base/SceneExt.hh"


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

`ogre2/src/Ogre2Scene.cc` includes `<gz/common/Profiler.hh>` but never
uses it. This header was not part of the original #1302 and breaks the
Bazel build, since gz-common's Bazel target does not expose it:

```
ogre2/src/Ogre2Scene.cc:33:10: fatal error: gz/common/Profiler.hh: No such file or directory
```

Reported by @luca-della-vedova on the gz-rendering10 backport (#1305):
https://github.com/gazebosim/gz-rendering/pull/1305/changes#r3519694401

The same dead include is also present in the two other open backports
of #1302 (#1306, #1307); fixes have been pushed to those PR branches
directly.

## Checklist
- [x] Signed all commits for DCO
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits.

Generated-by: Claude Sonnet 5