### PR TITLE
Clamp Ogre2 GPU lidar cubemap sampling at face edges

### DIFF
--- a/ogre2/src/media/materials/scripts/gpu_rays.material
+++ b/ogre2/src/media/materials/scripts/gpu_rays.material
@@ -202,30 +202,37 @@ material GpuRaysScan2nd
       texture_unit cubeUVTex
       {
         filtering none
+        tex_address_mode clamp
       }
       texture_unit tex0
       {
         filtering none
+        tex_address_mode clamp
       }
       texture_unit tex1
       {
         filtering none
+        tex_address_mode clamp
       }
       texture_unit tex2
       {
         filtering none
+        tex_address_mode clamp
       }
       texture_unit tex3
       {
         filtering none
+        tex_address_mode clamp
       }
       texture_unit tex4
       {
         filtering none
+        tex_address_mode clamp
       }
       texture_unit tex5
       {
         filtering none
+        tex_address_mode clamp
       }
     }
   }

--- a/test/integration/gpu_rays.cc
+++ b/test/integration/gpu_rays.cc
@@ -353,6 +353,88 @@ TEST_F(GpuRaysTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(RaysUnitBox))
 }
 
 /////////////////////////////////////////////////
+/// \brief Test cubemap sampling at horizontal scan endpoints
+TEST_F(GpuRaysTest,
+    GZ_UTILS_TEST_DISABLED_ON_WIN32(CubemapEndpointSampling))
+{
+  CHECK_SUPPORTED_ENGINE("ogre2");
+  #ifdef __APPLE__
+    GTEST_SKIP() << "Unsupported on apple, see issue #35.";
+  #endif
+
+  // A 90 degree horizontal field of view puts both endpoint directions on
+  // cubemap face boundaries. Distinct ranges at those boundaries expose
+  // accidental wrap addressing in the second-pass texture lookup.
+  const double hMinAngle = -GZ_PI / 4.0;
+  const double hMaxAngle = GZ_PI / 4.0;
+  const double minRange = 0.1;
+  const double maxRange = 10.0;
+  const unsigned int hRayCount = 900u;
+  const unsigned int vRayCount = 1u;
+  const double nearBoxDistance = 4.0;
+  const double farBoxDistance = 7.0;
+  const double sqrtHalf = 0.7071067811865476;
+  const double endpointTolerance = 1e-2;
+
+  ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+
+  VisualPtr root = scene->RootVisual();
+
+  GpuRaysPtr gpuRays = scene->CreateGpuRays("endpoint_gpu_rays");
+  ASSERT_NE(nullptr, gpuRays);
+  gpuRays->SetWorldPosition(0, 0, 0.5);
+  gpuRays->SetNearClipPlane(minRange);
+  gpuRays->SetFarClipPlane(maxRange);
+  gpuRays->SetAngleMin(hMinAngle);
+  gpuRays->SetAngleMax(hMaxAngle);
+  gpuRays->SetRayCount(hRayCount);
+  gpuRays->SetVerticalRayCount(vRayCount);
+  root->AddChild(gpuRays);
+
+  VisualPtr nearBox = scene->CreateVisual("EndpointNearBox");
+  nearBox->AddGeometry(scene->CreateBox());
+  nearBox->SetWorldPosition(
+      nearBoxDistance * sqrtHalf, -nearBoxDistance * sqrtHalf, 0.5);
+  root->AddChild(nearBox);
+
+  VisualPtr farBox = scene->CreateVisual("EndpointFarBox");
+  farBox->AddGeometry(scene->CreateBox());
+  farBox->SetWorldPosition(
+      farBoxDistance * sqrtHalf, farBoxDistance * sqrtHalf, 0.5);
+  root->AddChild(farBox);
+
+  const unsigned int channels = gpuRays->Channels();
+  float *scan = new float[hRayCount * vRayCount * channels];
+  common::ConnectionPtr connection =
+    gpuRays->ConnectNewGpuRaysFrame(
+        std::bind(&::OnNewGpuRaysFrame, scan,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+
+  gpuRays->Update();
+  scene->SetTime(scene->Time() + std::chrono::milliseconds(16));
+
+  // A unit axis-aligned box intersects a 45 degree ray half a diagonal
+  // before its center.
+  const double halfBoxDiagonal = sqrtHalf;
+  const double expectedNearRange = nearBoxDistance - halfBoxDiagonal;
+  const double expectedFarRange = farBoxDistance - halfBoxDiagonal;
+  const unsigned int last = (hRayCount - 1u) * channels;
+  const unsigned int mid = (hRayCount / 2u) * channels;
+
+  EXPECT_NEAR(scan[0], expectedNearRange, endpointTolerance);
+  EXPECT_FLOAT_EQ(scan[mid], math::INF_F);
+  EXPECT_NEAR(scan[last], expectedFarRange, endpointTolerance);
+
+  connection.reset();
+  delete [] scan;
+  scan = nullptr;
+
+  engine->DestroyScene(scene);
+}
+
+/////////////////////////////////////////////////
 /// \brief Test GPU rays vertical component
 TEST_F(GpuRaysTest, GZ_UTILS_TEST_DISABLED_ON_WIN32(LaserVertical))
 {


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebosim/gz-sim/issues/3475

## Summary

GPU lidar scan directions on cubemap face boundaries can produce a normalized texture coordinate of `1.0`. The Ogre2 GPU-rays second pass uses point filtering, but its sample-table and cubemap textures previously retained Ogre's default wrap addressing. An endpoint lookup could therefore sample the opposite texture edge.

This is observable with a partial-FOV scan using 900 horizontal rays from -45 to +45 degrees. Before this change, endpoint samples can select the wrong cubemap edge and produce an incorrect range or point. After applying clamp addressing, endpoint coordinates remain on the intended cubemap edge.

This PR:

- sets `tex_address_mode clamp` on the sample table and all six cubemap-face textures used by `GpuRaysScan2nd`;
- adds an Ogre2 integration test using a 900-ray partial-FOV scan;
- places deliberately asymmetric targets at the two endpoint directions so wrap addressing cannot pass through scene symmetry.

The change affects sampler state only. It does not change the GPU-rays API, point-cloud layout, scan angles, or interior texture coordinates.

Validation:

- The deterministic endpoint calculation produces a normalized cubemap coordinate of `1.0f` for both endpoint directions.
- Removing the clamp declarations causes the endpoint regression test to fail.
- Restoring the declarations makes the test pass.
- [Linux Resolute CI passed](https://build.osrfoundation.org/job/gz_rendering-ci-pr_any-resolute-amd64/3/).
- Homebrew ARM64 and Windows CI passed.
- DCO passed.

## Backport Policy

- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

The original report's exact Gazebo release is still unconfirmed. Maintainer guidance is requested on which supported versions contain the affected Ogre2 material path.

## Checklist

- [x] Signed all commits for DCO
- [x] Screen capture or video is not needed; the regression is numerical and covered by an Ogre2 integration test
- [x] Added tests
- [x] Documentation update is not needed; no public behavior or API is added
- [x] Migration guide update is not needed
- [x] Python bindings are not affected
- [x] `codecheck` passed
- [x] All tests passed
- [x] Bazel updates are not needed; no new source files were added
- [ ] While waiting for review, help review another open Gazebo pull request
- [x] Was GenAI used to generate this PR? The required disclosure is included below.

Assisted-by: OpenAI Codex

