### PR TITLE
Fix Ogre2 CPU ray queries from inside AABBs

### DIFF
--- a/ogre2/src/Ogre2RayQuery.cc
+++ b/ogre2/src/Ogre2RayQuery.cc
@@ -350,7 +350,8 @@ void ThreadedTriRay::execute(size_t _threadId, size_t _numThreads)
   for (auto iter = this->ogreResult.begin(); iter != this->ogreResult.end();
        ++iter)
   {
-    if (iter->distance <= 0.0)
+    // A distance of zero is valid when the ray origin is inside the AABB.
+    if (iter->distance < 0.0)
       continue;
 
     if (!iter->movable || !iter->movable->getVisible())

--- a/test/common_test/RayQuery_TEST.cc
+++ b/test/common_test/RayQuery_TEST.cc
@@ -17,11 +17,14 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include "CommonRenderingTest.hh"
 
 #include "gz/rendering/Camera.hh"
 #include "gz/rendering/RayQuery.hh"
 #include "gz/rendering/Scene.hh"
+#include "gz/rendering/Visual.hh"
 
 using namespace gz;
 using namespace rendering;
@@ -107,5 +110,38 @@ TEST_F(RayQueryTest, RayQuery)
   EXPECT_FALSE(result2);
 
   // Clean up
+  engine->DestroyScene(scene);
+}
+
+/////////////////////////////////////////////////
+TEST_F(RayQueryTest, RayOriginInsideObjectBounds)
+{
+  CHECK_SUPPORTED_ENGINE("ogre2");
+
+  ScenePtr scene = engine->CreateScene("scene");
+  ASSERT_NE(nullptr, scene);
+
+  VisualPtr box = scene->CreateVisual();
+  ASSERT_NE(nullptr, box);
+  box->AddGeometry(scene->CreateBox());
+  // The rotated box's AABB contains the ray origin, but the box itself does
+  // not. The ray should still enter the box through its front face.
+  box->SetLocalRotation(0.0, 0.0, GZ_PI / 4.0);
+  scene->RootVisual()->AddChild(box);
+
+  RayQueryPtr rayQuery = scene->CreateRayQuery();
+  ASSERT_NE(nullptr, rayQuery);
+  rayQuery->SetPreferGpu(false);
+  rayQuery->SetOrigin(math::Vector3d(0.6, 0.6, 0.0));
+  rayQuery->SetDirection(-math::Vector3d::UnitY);
+
+  RayQueryResult result = rayQuery->ClosestPoint(true);
+  ASSERT_TRUE(result);
+  EXPECT_EQ(box->Id(), result.objectId);
+  EXPECT_NEAR(1.2 - std::sqrt(0.5), result.distance, 1e-6);
+  EXPECT_NEAR(0.6, result.point.X(), 1e-6);
+  EXPECT_NEAR(std::sqrt(0.5) - 0.6, result.point.Y(), 1e-6);
+  EXPECT_NEAR(0.0, result.point.Z(), 1e-6);
+
   engine->DestroyScene(scene);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #1226.

## Summary

Ogre returns a broadphase distance of zero when a ray starts inside an object's axis-aligned bounding box. The Ogre2 CPU ray-query path discarded all candidates with a distance less than or equal to zero, so it never ran the triangle-level intersection pass for those objects.

This change keeps zero-distance candidates while continuing to reject negative distances. The narrowphase still determines whether the ray actually intersects the geometry.

The regression test uses a rotated box whose AABB contains the ray origin while the box geometry does not. Before the fix, the CPU ray query reports no result. After the fix, it returns the expected front-face intersection, object ID, distance, and point.

## Backport Policy

- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [x] I am not sure
- [ ] Other (fill in yourself)

## Validation

- Final regression on Ogre and Ogre2 GL3Plus: 4/4 CTest entries passed.
- Full serial CTest suite under Xvfb: 257/257 passed.
- `codecheck`: cpplint and cppcheck targets passed.
- Negative control: changing the production condition back to `<= 0.0` makes `RayQueryTest.RayOriginInsideObjectBounds` fail because the result is empty.

## Checklist

- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (not needed for this CPU query regression)
- [x] Added tests
- [x] Updated documentation (not needed; no public API or documented behavior changed)
- [x] Updated migration guide (not needed; no migration impact)
- [x] Consider updating Python bindings (not needed; no API change)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (not needed; no files or targets were added)
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: OpenAI Codex (GPT-5; accessed 2026-08-18)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
