### PR TITLE
Add an image constructor that wraps a caller owned pixel buffer

### DIFF
--- a/include/gz/rendering/Image.hh
+++ b/include/gz/rendering/Image.hh
@@ -45,6 +45,19 @@ namespace gz
       public: Image(unsigned int _width, unsigned int _height,
                   PixelFormat _format);
 
+      /// \brief Constructor. Creates an image that stores its pixels in a
+      /// caller owned buffer instead of allocating its own. The buffer must
+      /// hold at least MemorySize() bytes and outlive the image and any copy
+      /// of it, since copies share the same buffer. Copying a camera into
+      /// such an image writes straight into the caller's memory, for example
+      /// a message payload, and saves one copy per frame.
+      /// \param[in] _width Image width in pixels
+      /// \param[in] _height Image height in pixels
+      /// \param[in] _format Image pixel format
+      /// \param[in] _data Caller owned pixel buffer
+      public: Image(unsigned int _width, unsigned int _height,
+                  PixelFormat _format, void *_data);
+
       /// \brief Destructor
       public: virtual ~Image();
 

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -71,6 +71,19 @@ Image::Image(unsigned int _width, unsigned int _height,
 }
 
 //////////////////////////////////////////////////
+Image::Image(unsigned int _width, unsigned int _height,
+  PixelFormat _format, void *_data)
+  : dataPtr(utils::MakeImpl<Implementation>())
+{
+  this->dataPtr->width = _width;
+  this->dataPtr->height = _height;
+  this->dataPtr->format = PixelUtil::Sanitize(_format);
+  // The caller owns the buffer: the deleter does nothing.
+  this->dataPtr->data = DataPtr(
+      static_cast<unsigned char *>(_data), [](unsigned char *) {});
+}
+
+//////////////////////////////////////////////////
 Image::~Image() = default;
 
 //////////////////////////////////////////////////

--- a/src/Image_TEST.cc
+++ b/src/Image_TEST.cc
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "gz/rendering/Image.hh"
+#include "gz/rendering/PixelFormat.hh"
+
+using namespace gz;
+using namespace rendering;
+
+/////////////////////////////////////////////////
+TEST(ImageTest, OwnedBuffer)
+{
+  Image image(4, 3, PF_R8G8B8);
+  EXPECT_EQ(4u, image.Width());
+  EXPECT_EQ(3u, image.Height());
+  EXPECT_EQ(PF_R8G8B8, image.Format());
+  EXPECT_EQ(36u, image.MemorySize());
+  ASSERT_NE(nullptr, image.Data());
+
+  // The buffer is writable and readable through the typed accessors.
+  image.Data<unsigned char>()[0] = 7;
+  EXPECT_EQ(7, image.Data<unsigned char>()[0]);
+}
+
+/////////////////////////////////////////////////
+TEST(ImageTest, ExternalBuffer)
+{
+  std::vector<unsigned char> buffer(36, 0);
+
+  {
+    Image image(4, 3, PF_R8G8B8, buffer.data());
+    EXPECT_EQ(4u, image.Width());
+    EXPECT_EQ(3u, image.Height());
+    EXPECT_EQ(PF_R8G8B8, image.Format());
+    EXPECT_EQ(36u, image.MemorySize());
+
+    // The image uses the caller's buffer instead of allocating its own.
+    EXPECT_EQ(buffer.data(), image.Data<unsigned char>());
+
+    // Writing through the image lands in the caller's buffer.
+    image.Data<unsigned char>()[5] = 42;
+    EXPECT_EQ(42, buffer[5]);
+
+    // A copy of the image shares the same external buffer.
+    Image copy = image;
+    EXPECT_EQ(buffer.data(), copy.Data<unsigned char>());
+    copy.Data<unsigned char>()[6] = 43;
+    EXPECT_EQ(43, buffer[6]);
+  }
+
+  // The image went out of scope; the caller still owns the buffer and its
+  // contents are intact.
+  EXPECT_EQ(42, buffer[5]);
+  EXPECT_EQ(43, buffer[6]);
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary

Today an `Image` always allocates and owns its own pixel buffer. This patch adds one constructor that takes a buffer the caller owns and uses it as the image's storage. The image never frees it.

Here's the example that motivated this PR: a camera sensor in gz-sensors publishes every frame as a `msgs::Image`. The frame is read back from the GPU into the `Image` buffer, and then copied a second time into the gz-msg payload, because the message needs the bytes in memory it owns. With this constructor the sensor can wrap the message payload in an `Image`, so the GPU readback lands directly in the message and the second copy disappears. On a profile of the server with two 1920x1080 cameras that second copy costs about 425 microseconds per frame (6 MB per frame), and removing it made the server use 18% less CPU per step on that world. For small cameras (320x240) the saving is about 10 microseconds per frame, which does not show at world level. The full numbers are in the profiling report at https://caguero.github.io/gz-profiling/ (finding 9.6 of the 2026 09 01 run).

The gz-sensors side will come as a separate PR once this one is available.

Rules for callers, also documented on the constructor: the buffer must hold at least `MemorySize()` bytes and must outlive the image and any copy of it, since copies share the buffer.

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

Adding a constructor to a class that keeps its state behind a private implementation pointer does not change the class layout or any existing symbol, so it is ABI safe and can ship in a minor release. The `Image` class is identical on gz-rendering10, 9 and 8, so the patch applies as is there. On Fortress (ign-rendering6) `Image` predates the implementation pointer helper, so the backport needs a two line adaptation in the constructor body. Backporting matters for the gz-sensors follow up, which needs this constructor to remove the copy on the stable branches too.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise. (The Bazel build globs `src/*_TEST.cc`, no change needed.)
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5.1

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
