### PR TITLE
Image: take a shared pointer for the caller owned pixel buffer

### DIFF
--- a/include/gz/rendering/Image.hh
+++ b/include/gz/rendering/Image.hh
@@ -35,6 +35,10 @@ namespace gz
     /// \brief Encapsulates a raw image buffer and relevant properties
     class GZ_RENDERING_VISIBLE Image
     {
+      /// \brief Shared pointer to a pixel buffer. Used to hand the image a
+      /// buffer the caller owns, see the matching constructor.
+      public: using DataPtr = std::shared_ptr<unsigned char>;
+
       /// \brief Default constructor
       public: Image();
 
@@ -45,18 +49,20 @@ namespace gz
       public: Image(unsigned int _width, unsigned int _height,
                   PixelFormat _format);
 
-      /// \brief Constructor. Creates an image that stores its pixels in a
-      /// caller owned buffer instead of allocating its own. The buffer must
-      /// hold at least MemorySize() bytes and outlive the image and any copy
-      /// of it, since copies share the same buffer. Copying a camera into
-      /// such an image writes straight into the caller's memory, for example
-      /// a message payload, and saves one copy per frame.
+      /// \brief Constructor. Creates an image whose pixels live in a buffer
+      /// the caller provides instead of one the image allocates. The buffer
+      /// must hold at least MemorySize() bytes. Ownership follows the shared
+      /// pointer: alias it to the buffer's owner to keep that owner alive for
+      /// as long as the image or any copy of it exists, or give it a no op
+      /// deleter for memory known to outlive the image. Pointer stability is
+      /// still the caller's job: if the owner reallocates the buffer (for
+      /// example a std::string that is resized), create a new image.
       /// \param[in] _width Image width in pixels
       /// \param[in] _height Image height in pixels
       /// \param[in] _format Image pixel format
-      /// \param[in] _data Caller owned pixel buffer
+      /// \param[in] _data Shared pointer to the caller's pixel buffer
       public: Image(unsigned int _width, unsigned int _height,
-                  PixelFormat _format, void *_data);
+                  PixelFormat _format, DataPtr _data);
 
       /// \brief Destructor
       public: virtual ~Image();

--- a/src/Image.cc
+++ b/src/Image.cc
@@ -17,10 +17,11 @@
 
 #include <memory>
 
+#include <utility>
+
 #include "gz/rendering/Image.hh"
 
 /// \brief Shared pointer to raw image buffer
-typedef std::shared_ptr<unsigned char> DataPtr;
 
 /// \brief Private fields of Image
 class gz::rendering::Image::Implementation
@@ -35,7 +36,7 @@ class gz::rendering::Image::Implementation
   public: PixelFormat format = PF_UNKNOWN;
 
   /// \brief Pointer to the image data
-  public: DataPtr data = nullptr;
+  public: Image::DataPtr data = nullptr;
 };
 
 using namespace gz;
@@ -67,20 +68,18 @@ Image::Image(unsigned int _width, unsigned int _height,
   this->dataPtr->format = PixelUtil::Sanitize(_format);
   unsigned int size = this->MemorySize();
   this->dataPtr->data =
-      DataPtr(new unsigned char[size], ArrayDeleter<unsigned char>());
+      Image::DataPtr(new unsigned char[size], ArrayDeleter<unsigned char>());
 }
 
 //////////////////////////////////////////////////
 Image::Image(unsigned int _width, unsigned int _height,
-  PixelFormat _format, void *_data)
+  PixelFormat _format, DataPtr _data)
   : dataPtr(utils::MakeImpl<Implementation>())
 {
   this->dataPtr->width = _width;
   this->dataPtr->height = _height;
   this->dataPtr->format = PixelUtil::Sanitize(_format);
-  // The caller owns the buffer: the deleter does nothing.
-  this->dataPtr->data = DataPtr(
-      static_cast<unsigned char *>(_data), [](unsigned char *) {});
+  this->dataPtr->data = std::move(_data);
 }
 
 //////////////////////////////////////////////////

--- a/src/Image_TEST.cc
+++ b/src/Image_TEST.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 #include "gz/rendering/Image.hh"
@@ -46,7 +47,9 @@ TEST(ImageTest, ExternalBuffer)
   std::vector<unsigned char> buffer(36, 0);
 
   {
-    Image image(4, 3, PF_R8G8B8, buffer.data());
+    // The caller keeps ownership: the deleter does nothing.
+    Image image(4, 3, PF_R8G8B8,
+        Image::DataPtr(buffer.data(), [](unsigned char *) {}));
     EXPECT_EQ(4u, image.Width());
     EXPECT_EQ(3u, image.Height());
     EXPECT_EQ(PF_R8G8B8, image.Format());
@@ -70,4 +73,31 @@ TEST(ImageTest, ExternalBuffer)
   // contents are intact.
   EXPECT_EQ(42, buffer[5]);
   EXPECT_EQ(43, buffer[6]);
+}
+
+/////////////////////////////////////////////////
+TEST(ImageTest, SharedOwner)
+{
+  // The buffer belongs to an owner object; the image keeps that owner alive
+  // through an aliased shared pointer.
+  auto owner = std::make_shared<std::vector<unsigned char>>(36, 7);
+  std::weak_ptr<std::vector<unsigned char>> watch = owner;
+
+  Image image(4, 3, PF_R8G8B8, Image::DataPtr(owner, owner->data()));
+  EXPECT_EQ(owner->data(), image.Data<unsigned char>());
+  EXPECT_EQ(2, owner.use_count());
+
+  // Dropping the caller's reference does not free the buffer.
+  owner.reset();
+  EXPECT_FALSE(watch.expired());
+  EXPECT_EQ(7, image.Data<unsigned char>()[0]);
+
+  // A copy shares the owner too; the buffer lives until the last image goes.
+  {
+    Image copy = image;
+    EXPECT_EQ(image.Data<unsigned char>(), copy.Data<unsigned char>());
+  }
+  EXPECT_FALSE(watch.expired());
+  image = Image(1, 1, PF_R8G8B8);
+  EXPECT_TRUE(watch.expired());
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Follow up to #1331, as suggested by @azeey in https://github.com/gazebosim/gz-rendering/pull/1331#issuecomment-5585974062: the constructor that wraps a caller owned pixel buffer now takes a shared pointer (`Image::DataPtr`) instead of a raw pointer. 

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Fable 5.1

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
